### PR TITLE
feat: redesign Gather app shell as command center

### DIFF
--- a/.superpowers/sdd/task-5-report.md
+++ b/.superpowers/sdd/task-5-report.md
@@ -1,0 +1,31 @@
+# Task 5 Report: Command Feed And Group Inspector
+
+## Status
+
+Completed.
+
+## Delivered
+
+- Added `CommandFeed`, including an honest designed-preview command-center summary, module cards derived from `MODULES`, and the compact inspector for screens below `xl`.
+- Added `GroupInspector`, which derives live and planned module counts from `MODULES` and presents active modules, preview tasks, and member context.
+- Replaced the desktop shell inspector slot with `GroupInspector` at the required `xl` breakpoint.
+- Updated the existing shell test from the retired slot ID and `lg` expectation to the rendered inspector landmark and `xl` breakpoint.
+- Added command-feed and group-inspector coverage, with a lightweight router link stub required by the isolated component test.
+
+## TDD Record
+
+1. Added `CommandFeed.test.tsx` before either production component existed.
+2. Confirmed RED: Vitest failed to resolve `./GroupInspector` because the requested component had not been created.
+3. Implemented the feed, inspector, and shell wiring.
+4. Confirmed GREEN: the focused feed and shell suite passed with 8 tests.
+
+## Verification
+
+- `vitest run src/components/app/CommandFeed.test.tsx src/components/app/AppShell.test.tsx`: 2 files passed, 8 tests passed.
+- `pnpm run typecheck`: passed.
+- `biome check` for the five Task 5 source/test files: passed.
+- `git diff --check`: passed.
+
+## Note
+
+`pnpm exec vitest` could not locate the local Windows command shim in this worktree even after a lockfile install. The equivalent checked-in local shim, `node_modules/.bin/vitest.cmd`, ran the required Vitest commands successfully.

--- a/docs/superpowers/specs/2026-07-15-gather-command-center-redesign.md
+++ b/docs/superpowers/specs/2026-07-15-gather-command-center-redesign.md
@@ -1,0 +1,234 @@
+# Gather Command Center Redesign
+
+**Date:** 2026-07-15
+**Status:** Approved for implementation planning
+**Scope:** Authenticated app redesign: app shell, command-center dashboard, responsive navigation, persistent Gather entry point, module placeholders, and visual system. Real chat persistence and AI automation are out of scope.
+
+## 1. Context
+
+Gather is currently a household-management app with a grouped sidebar, dashboard cards, one live module (Recipes), and several placeholder modules. The attached design files point to a broader product direction: Gather should feel like a command center for a shared group, with coordination, module summaries, and contextual actions organized in one operational UI.
+
+The redesign treats **groups** as the durable product concept. A group may be a household, couple, family, shared home, club, trip, tasting group, or any other small coordinated unit. "Household" can remain a warm default in copy where it fits, but the interface should not hard-code the product around households only.
+
+## 2. Product Direction
+
+Gather becomes a **group command center**. The authenticated home route should open on a command-center surface for the active group. It should visually follow the attached comps: quiet system UI, compact density, crisp borders, 8px radii, neutral low-chroma surfaces, restrained accent color, and operational cards.
+
+The central command surface is not real chat yet. For this redesign it is a **feed-style coordination surface** made from designed or registry-derived blocks:
+
+- recent or sample activity,
+- upcoming items,
+- module summaries,
+- suggested actions,
+- and Gather/system-style summaries.
+
+The feed should feel like it could become conversational later, but the first implementation must not create a chat/message backend or imply that automated actions already work.
+
+## 3. Responsive Layout
+
+The app shell should support three responsive modes.
+
+### Desktop
+
+Desktop uses a three-pane layout:
+
+- **Left sidebar:** brand, active group, primary areas, module navigation, group card, and settings/groups access.
+- **Center pane:** route content. On `/dashboard`, this is the command feed. On module pages, it is the module page.
+- **Right inspector:** group overview cards such as modules/extensions, tasks today, upcoming calendar, and members.
+
+### Tablet
+
+Tablet keeps the command-center feel while reducing chrome:
+
+- sidebar compacts to icons or becomes a drawer, depending on available width,
+- right inspector collapses into a toggleable panel or moves below the main content,
+- center route content remains primary.
+
+### Mobile
+
+Mobile is a first-class layout, not a squeezed desktop:
+
+- no permanent sidebar or inspector,
+- topbar shows active group and current route,
+- bottom dock provides stable navigation targets,
+- a drawer/sheet exposes full navigation,
+- inspector content becomes stacked "Today" cards on the home screen,
+- the persistent Gather entry point opens as a sheet or full-height drawer.
+
+The mobile bottom dock should use four stable targets: Home, Tasks, Calendar, and Modules. Routes that do not yet have live modules may still point to their placeholder pages.
+
+## 4. Navigation Model
+
+The redesigned shell shifts navigation from "all modules only" to "active group plus command areas."
+
+Desktop sidebar structure:
+
+1. Brand row: Gather, active group name, and a create/add icon button.
+2. Primary areas: Command Center, Tasks, Calendar, Modules.
+3. Module groups from the existing registry: Kitchen, Money, Home & life, Tasting.
+4. Bottom group card: active group, member initials, sync/share status, and a link to groups/settings.
+
+The existing `MODULES` registry remains the source of truth for module routes, labels, icons, groups, statuses, and descriptions. Sidebar, module cards, command palette, mobile drawer, and placeholder pages should all derive from it where possible.
+
+The topbar becomes contextual:
+
+- route title,
+- route subtitle,
+- search/command trigger,
+- issue report trigger,
+- persistent Gather entry point,
+- and account menu.
+
+## 5. Persistent Gather Entry Point
+
+Gather should be callable from anywhere in the authenticated app.
+
+On the command-center home route, the central feed is the full expression of this idea. On content pages such as Recipes, Groups, Settings, and future modules, Gather appears as a compact topbar icon button.
+
+Desktop behavior:
+
+- topbar includes an icon button labeled for accessibility as "Ask Gather",
+- activation opens a right-side panel or modal,
+- the panel is scoped to the active group,
+- the panel initially shows a prompt box, examples, and contextual suggestions,
+- suggestions must be written as non-automated prompts unless the action is actually implemented.
+
+Mobile behavior:
+
+- the Gather entry point remains reachable from the topbar or dock depending on route density,
+- activation opens a bottom sheet or full-height drawer,
+- the panel must not obscure persistent save actions, destructive actions, or bottom navigation without an obvious close path.
+
+Implementation boundary:
+
+- build open/close behavior,
+- build responsive panel presentation,
+- build designed empty and suggestion states,
+- do not persist messages,
+- do not add AI execution,
+- do not add Convex message tables.
+
+Labels should stay product-neutral and future-compatible: prefer "Ask Gather", "Gather", or "Command" over labeling the feature as "AI" everywhere.
+
+## 6. Core Components
+
+The redesign should introduce focused shell components instead of styling each route independently.
+
+- `AppShell`: owns responsive layout, sidebar, topbar, inspector slot, mobile dock, navigation drawer, and route content area.
+- `Sidebar`: renders brand, active group identity, primary areas, registry module groups, settings, and groups links.
+- `Topbar`: renders contextual title/subtitle, command/search trigger, issue reporter, Gather entry point, and account menu.
+- `GroupInspector`: renders the desktop right column and provides content that can be reused as mobile "Today" cards.
+- `MobileDock`: renders Home, Tasks, Calendar, and Modules with route-aware active states.
+- `GatherPanel`: renders the persistent callable Gather panel with placeholder prompts and responsive presentation.
+- `CommandFeed`: renders the dashboard command-center feed and activity cards.
+- Shared primitives: `IconButton`, `SurfaceCard`, `Pill`, `AvatarStack`, `StatusDot`, and `SectionHeader`.
+
+These components should remain presentational unless they already have real app data to read. Keep behavior close to the shell and route components; do not introduce a broad state-management abstraction for this redesign.
+
+## 7. Data Approach
+
+Reuse existing data and registries:
+
+- `MODULES` and `modulesByGroup()` drive module navigation and module/extension cards.
+- existing auth state drives signed-in layout access and account display.
+- existing group data can be used where available.
+- presentational fallbacks are acceptable while group/member/task/calendar data is incomplete.
+
+The redesign should avoid Convex schema changes unless a tiny read helper is needed for existing data display. Do not create message, assistant, task, or calendar schemas as part of this work.
+
+## 8. Visual System
+
+The authenticated app should move away from the current decorative gradients, island cards, and Fraunces/Manrope look. The new shell should use the design files as a north star:
+
+- system-style font stack,
+- low-chroma near-white background,
+- neutral foreground and muted text colors,
+- one restrained accent color,
+- crisp 1px borders,
+- 8px border radius for app UI,
+- compact spacing,
+- stable icon buttons with lucide icons,
+- dense but readable cards and rows.
+
+Public and auth pages can remain compatible with `@appelent/auth` and do not need the full command-center shell. If theme tokens are adjusted, keep auth screens visually coherent without making them the focus of this redesign.
+
+## 9. Route Behavior And States
+
+Loading states:
+
+- the authenticated loading state should be restyled to match the new shell tone.
+- list skeletons should use neutral surfaces and borders.
+
+Dashboard:
+
+- `/dashboard` becomes the command-center home.
+- central feed uses designed activity/system cards.
+- right inspector appears on desktop and collapses into home cards on mobile.
+
+Module pages:
+
+- live modules, beginning with Recipes, render inside the redesigned shell.
+- module placeholders become operational placeholder pages, not centered "coming soon" islands.
+- empty module states should use real module layout patterns with clear actions.
+
+Gather panel:
+
+- empty state makes clear that automation is coming later.
+- examples must not overpromise working automation.
+- Escape and close controls should dismiss the panel.
+
+Mobile drawer and dock:
+
+- drawer supports open/close state and Escape/overlay dismissal.
+- dock highlights active route families.
+- bottom navigation must not overlap route actions or form submission buttons.
+
+## 10. Testing
+
+Keep existing tests passing and update expectations for the redesigned shell.
+
+Expected coverage:
+
+- registry integrity still verifies module paths resolve,
+- shell navigation renders expected desktop labels,
+- mobile dock renders Home, Tasks, Calendar, and Modules targets,
+- persistent Gather entry point renders and opens/closes the panel,
+- module placeholders render from registry data in the new layout,
+- existing recipe form and issue reporter tests continue to pass.
+
+Verification commands after implementation:
+
+```sh
+pnpm run check
+pnpm run typecheck
+pnpm test
+pnpm run build
+```
+
+Focused tests may be run during development, but final verification should include the broader commands unless a known unrelated blocker is documented.
+
+## 11. Out Of Scope
+
+This redesign does not include:
+
+- real chat persistence,
+- AI action execution,
+- Convex message tables,
+- full implementations of Tasks, Calendar, Groceries, Pantry, Finances, Bills, Notes, Cheeses, or Wines,
+- complete multi-group switching UI,
+- notification workflows,
+- calendar integrations,
+- rebuilding public/auth pages beyond token compatibility,
+- or replacing the existing group/sharing model.
+
+## 12. Success Criteria
+
+The redesign is successful when:
+
+- Gather feels like a group command center rather than a module launcher,
+- the attached design files are clearly reflected in the authenticated app,
+- desktop, tablet, and mobile each have intentional navigation,
+- the persistent Gather entry point is available from content pages,
+- current live functionality, especially Recipes, remains usable,
+- placeholder modules feel integrated and operational,
+- and the implementation leaves a clear path to real chat or AI later without building those systems now.

--- a/src/components/app/AppShell.test.tsx
+++ b/src/components/app/AppShell.test.tsx
@@ -24,12 +24,21 @@ vi.mock('@tanstack/react-router', async () => {
       children,
       to,
       className,
+      onClick,
     }: {
       children: React.ReactNode
       to: string
       className?: string
+      onClick?: React.MouseEventHandler<HTMLAnchorElement>
     }) => (
-      <a href={to} className={className}>
+      <a
+        href={to}
+        className={className}
+        onClick={(event) => {
+          event.preventDefault()
+          onClick?.(event)
+        }}
+      >
         {children}
       </a>
     ),
@@ -67,6 +76,17 @@ test('renders mobile dock targets', () => {
   expect(within(dock).getByRole('link', { name: /Modules/i })).toBeDefined()
 })
 
+test('shows the group inspector by the desktop breakpoint', () => {
+  render(
+    <AppShell>
+      <main>Content</main>
+    </AppShell>,
+  )
+
+  const inspector = document.getElementById('group-inspector-slot')
+  expect(inspector?.parentElement?.className).toContain('lg:block')
+})
+
 test('opens navigation drawer and Gather panel from topbar actions', () => {
   render(
     <AppShell>
@@ -79,4 +99,49 @@ test('opens navigation drawer and Gather panel from topbar actions', () => {
 
   fireEvent.click(screen.getByRole('button', { name: 'Ask Gather' }))
   expect(screen.getByRole('dialog', { name: 'Ask Gather' })).toBeDefined()
+})
+
+test('manages drawer focus and closes from controls, Escape, and navigation', () => {
+  render(
+    <AppShell>
+      <main>Content</main>
+    </AppShell>,
+  )
+
+  const opener = screen.getByRole('button', { name: 'Open navigation' })
+  opener.focus()
+  fireEvent.click(opener)
+
+  const drawer = screen.getByRole('dialog', { name: 'Navigation' })
+  const closeButton = within(drawer).getByRole('button', {
+    name: 'Close navigation',
+  })
+  const lastLink = within(drawer).getByRole('link', { name: 'Settings' })
+
+  expect(document.activeElement).toBe(closeButton)
+
+  fireEvent.keyDown(closeButton, { key: 'Tab', shiftKey: true })
+  expect(document.activeElement).toBe(lastLink)
+
+  fireEvent.keyDown(lastLink, { key: 'Tab' })
+  expect(document.activeElement).toBe(closeButton)
+
+  fireEvent.click(closeButton)
+  expect(screen.queryByRole('dialog', { name: 'Navigation' })).toBeNull()
+  expect(document.activeElement).toBe(opener)
+
+  fireEvent.click(opener)
+  fireEvent.click(
+    within(screen.getByRole('dialog', { name: 'Navigation' })).getByRole(
+      'link',
+      { name: 'Command Center' },
+    ),
+  )
+  expect(screen.queryByRole('dialog', { name: 'Navigation' })).toBeNull()
+
+  fireEvent.click(opener)
+  fireEvent.keyDown(screen.getByRole('dialog', { name: 'Navigation' }), {
+    key: 'Escape',
+  })
+  expect(screen.queryByRole('dialog', { name: 'Navigation' })).toBeNull()
 })

--- a/src/components/app/AppShell.test.tsx
+++ b/src/components/app/AppShell.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { AppShell } from './AppShell'
+
+vi.mock('@appelent/auth', () => ({
+  HeaderUser: () => <div>Account menu</div>,
+}))
+
+vi.mock('@clerk/clerk-react', () => ({
+  useUser: () => ({ user: null }),
+}))
+
+vi.mock('./CommandPalette', () => ({
+  CommandPalette: () => null,
+}))
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-router')>(
+    '@tanstack/react-router',
+  )
+  return {
+    ...actual,
+    Link: ({
+      children,
+      to,
+      className,
+    }: {
+      children: React.ReactNode
+      to: string
+      className?: string
+    }) => (
+      <a href={to} className={className}>
+        {children}
+      </a>
+    ),
+    useLocation: () => ({ pathname: '/recipes' }),
+  }
+})
+
+test('renders redesigned shell navigation and route content', () => {
+  render(
+    <AppShell>
+      <main>Recipe route content</main>
+    </AppShell>,
+  )
+
+  expect(screen.getByText('Gather')).toBeDefined()
+  expect(screen.getByText('Oak House')).toBeDefined()
+  expect(screen.getByRole('link', { name: /Command Center/i })).toBeDefined()
+  expect(screen.getByRole('link', { name: /Recipes/i })).toBeDefined()
+  expect(screen.getByRole('heading', { name: 'Recipes' })).toBeDefined()
+  expect(screen.getByText('Recipe route content')).toBeDefined()
+})
+
+test('renders mobile dock targets', () => {
+  render(
+    <AppShell>
+      <main>Content</main>
+    </AppShell>,
+  )
+
+  const dock = screen.getByRole('navigation', { name: 'Mobile navigation' })
+  expect(dock).toBeDefined()
+  expect(within(dock).getByRole('link', { name: /Home/i })).toBeDefined()
+  expect(within(dock).getByRole('link', { name: /Tasks/i })).toBeDefined()
+  expect(within(dock).getByRole('link', { name: /Calendar/i })).toBeDefined()
+  expect(within(dock).getByRole('link', { name: /Modules/i })).toBeDefined()
+})
+
+test('opens navigation drawer and Gather panel from topbar actions', () => {
+  render(
+    <AppShell>
+      <main>Content</main>
+    </AppShell>,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'Open navigation' }))
+  expect(screen.getByRole('dialog', { name: 'Navigation' })).toBeDefined()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Ask Gather' }))
+  expect(screen.getByRole('dialog', { name: 'Ask Gather' })).toBeDefined()
+})

--- a/src/components/app/AppShell.test.tsx
+++ b/src/components/app/AppShell.test.tsx
@@ -2,6 +2,10 @@ import { fireEvent, render, screen, within } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
 import { AppShell } from './AppShell'
 
+const routerState = vi.hoisted(() => ({
+  location: { pathname: '/recipes', hash: '' },
+}))
+
 vi.mock('@appelent/auth', () => ({
   HeaderUser: () => <div>Account menu</div>,
 }))
@@ -42,23 +46,24 @@ vi.mock('@tanstack/react-router', async () => {
         {children}
       </a>
     ),
-    useLocation: () => ({ pathname: '/recipes' }),
+    useLocation: () => routerState.location,
   }
 })
 
 test('renders redesigned shell navigation and route content', () => {
   render(
     <AppShell>
-      <main>Recipe route content</main>
+      <div>Recipe route content</div>
     </AppShell>,
   )
 
   expect(screen.getByText('Gather')).toBeDefined()
-  expect(screen.getByText('Oak House')).toBeDefined()
+  expect(screen.getAllByText('Preview group').length).toBeGreaterThan(0)
   expect(screen.getByRole('link', { name: /Command Center/i })).toBeDefined()
   expect(screen.getByRole('link', { name: /Recipes/i })).toBeDefined()
   expect(screen.getByRole('heading', { name: 'Recipes' })).toBeDefined()
   expect(screen.getByText('Recipe route content')).toBeDefined()
+  expect(screen.getByRole('main').textContent).toContain('Recipe route content')
 })
 
 test('renders mobile dock targets', () => {
@@ -87,6 +92,33 @@ test('shows the group inspector by the desktop breakpoint', () => {
     name: 'Group overview',
   })
   expect(inspector.parentElement?.className).toContain('xl:block')
+  expect(inspector.parentElement?.parentElement?.className).toContain(
+    'xl:grid-cols-[264px_minmax(0,1fr)_336px]',
+  )
+})
+
+test('keeps dashboard primary navigation active state exclusive by hash', () => {
+  routerState.location = { pathname: '/dashboard', hash: 'modules' }
+  render(
+    <AppShell>
+      <div>Content</div>
+    </AppShell>,
+  )
+
+  const primary = screen.getByRole('navigation', { name: 'Primary' })
+  expect(
+    within(primary).getByRole('link', { name: 'Command Center' }).className,
+  ).not.toContain('border-[var(--app-fg)]')
+  expect(
+    within(primary).getByRole('link', { name: 'Modules' }).className,
+  ).toContain('border-[var(--app-fg)]')
+
+  const mobileGroupLabel = screen
+    .getAllByText('Preview group')
+    .find((element) => element.className.includes('md:hidden'))
+  expect(mobileGroupLabel?.className).toContain('md:hidden')
+
+  routerState.location = { pathname: '/recipes', hash: '' }
 })
 
 test('opens navigation drawer and Gather panel from topbar actions', () => {
@@ -139,6 +171,12 @@ test('manages drawer focus and closes from controls, Escape, and navigation', ()
       { name: 'Command Center' },
     ),
   )
+  expect(screen.queryByRole('dialog', { name: 'Navigation' })).toBeNull()
+
+  fireEvent.click(opener)
+  const backdrop = screen.getByTestId('navigation-backdrop')
+  expect(backdrop.className).toContain('overflow-y-auto')
+  fireEvent.click(backdrop)
   expect(screen.queryByRole('dialog', { name: 'Navigation' })).toBeNull()
 
   fireEvent.click(opener)

--- a/src/components/app/AppShell.test.tsx
+++ b/src/components/app/AppShell.test.tsx
@@ -83,8 +83,10 @@ test('shows the group inspector by the desktop breakpoint', () => {
     </AppShell>,
   )
 
-  const inspector = document.getElementById('group-inspector-slot')
-  expect(inspector?.parentElement?.className).toContain('lg:block')
+  const inspector = screen.getByRole('complementary', {
+    name: 'Group overview',
+  })
+  expect(inspector.parentElement?.className).toContain('xl:block')
 })
 
 test('opens navigation drawer and Gather panel from topbar actions', () => {

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -87,7 +87,7 @@ export function AppShell({ children }: { children: ReactNode }) {
 
   return (
     <div className="app-shell">
-      <div className="grid min-h-svh md:grid-cols-[264px_minmax(0,1fr)] lg:grid-cols-[264px_minmax(0,1fr)_336px]">
+      <div className="grid min-h-svh md:grid-cols-[264px_minmax(0,1fr)] xl:grid-cols-[264px_minmax(0,1fr)_336px]">
         <Sidebar />
         <div className="flex min-w-0 flex-col pb-20 md:pb-0">
           <Topbar
@@ -95,9 +95,9 @@ export function AppShell({ children }: { children: ReactNode }) {
             onOpenNavigation={() => setNavigationOpen(true)}
             onOpenGather={() => setGatherOpen(true)}
           />
-          <div className="min-w-0 flex-1 px-3 py-4 md:px-5 md:py-5">
+          <main className="min-w-0 flex-1 px-3 py-4 md:px-5 md:py-5">
             {children}
-          </div>
+          </main>
         </div>
         <div className="hidden border-l border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_86%,transparent)] p-4 xl:block">
           <GroupInspector />
@@ -105,14 +105,19 @@ export function AppShell({ children }: { children: ReactNode }) {
       </div>
 
       {navigationOpen ? (
-        <div className="fixed inset-0 z-50 bg-black/20 md:hidden">
+        <div
+          data-testid="navigation-backdrop"
+          className="fixed inset-0 z-50 overflow-y-auto bg-black/20 md:hidden"
+          onClick={() => setNavigationOpen(false)}
+        >
           <aside
             ref={navigationDrawerRef}
             role="dialog"
             aria-modal="true"
             aria-label="Navigation"
             onKeyDown={handleDrawerKeyDown}
-            className="h-full w-[min(22rem,92vw)] border-r border-[var(--app-border)] bg-[var(--app-surface)]"
+            onClick={(event) => event.stopPropagation()}
+            className="min-h-full w-[min(22rem,92vw)] overflow-y-auto border-r border-[var(--app-border)] bg-[var(--app-surface)]"
           >
             <div className="flex justify-end p-3">
               <IconButton
@@ -130,10 +135,10 @@ export function AppShell({ children }: { children: ReactNode }) {
         </div>
       ) : null}
 
-      <MobileDock pathname={location.pathname} />
+      <MobileDock location={location} />
       <GatherPanel
         open={gatherOpen}
-        activeGroupName="Oak House"
+        activeGroupName="Preview group"
         routeTitle={context.title}
         onClose={() => setGatherOpen(false)}
       />

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -10,6 +10,7 @@ import {
 import { getRouteContext } from '../../lib/appNavigation'
 import { CommandPalette } from './CommandPalette'
 import { GatherPanel } from './GatherPanel'
+import { GroupInspector } from './GroupInspector'
 import { IssueReporterModal } from './IssueReporterModal'
 import { MobileDock } from './MobileDock'
 import { IconButton } from './ShellPrimitives'
@@ -98,8 +99,8 @@ export function AppShell({ children }: { children: ReactNode }) {
             {children}
           </div>
         </div>
-        <div className="hidden border-l border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_86%,transparent)] p-4 lg:block">
-          <div id="group-inspector-slot" />
+        <div className="hidden border-l border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_86%,transparent)] p-4 xl:block">
+          <GroupInspector />
         </div>
       </div>
 

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1,7 +1,12 @@
 import { useLocation } from '@tanstack/react-router'
 import { X } from 'lucide-react'
-import type { ReactNode } from 'react'
-import { useState } from 'react'
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { getRouteContext } from '../../lib/appNavigation'
 import { CommandPalette } from './CommandPalette'
 import { GatherPanel } from './GatherPanel'
@@ -11,15 +16,77 @@ import { IconButton } from './ShellPrimitives'
 import { Sidebar } from './Sidebar'
 import { Topbar } from './Topbar'
 
+const FOCUSABLE_SELECTOR =
+  'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+
+function getFocusableElements(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+}
+
 export function AppShell({ children }: { children: ReactNode }) {
   const location = useLocation()
   const context = getRouteContext(location.pathname)
   const [navigationOpen, setNavigationOpen] = useState(false)
   const [gatherOpen, setGatherOpen] = useState(false)
+  const navigationDrawerRef = useRef<HTMLElement>(null)
+  const navigationOpenerRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (!navigationOpen) {
+      const opener = navigationOpenerRef.current
+      if (opener?.isConnected) opener.focus()
+      navigationOpenerRef.current = null
+      return
+    }
+
+    navigationOpenerRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
+
+    const drawer = navigationDrawerRef.current
+    if (drawer) getFocusableElements(drawer)[0]?.focus()
+  }, [navigationOpen])
+
+  useEffect(() => {
+    if (!navigationOpen) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setNavigationOpen(false)
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [navigationOpen])
+
+  useEffect(() => {
+    return () => {
+      const opener = navigationOpenerRef.current
+      if (opener?.isConnected) opener.focus()
+    }
+  }, [])
+
+  const handleDrawerKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (event.key !== 'Tab') return
+
+    const focusableElements = getFocusableElements(event.currentTarget)
+    const firstFocusable = focusableElements[0]
+    const lastFocusable = focusableElements.at(-1)
+
+    if (!firstFocusable || !lastFocusable) return
+
+    if (event.shiftKey && document.activeElement === firstFocusable) {
+      event.preventDefault()
+      lastFocusable.focus()
+    } else if (!event.shiftKey && document.activeElement === lastFocusable) {
+      event.preventDefault()
+      firstFocusable.focus()
+    }
+  }
 
   return (
     <div className="app-shell">
-      <div className="grid min-h-svh md:grid-cols-[264px_minmax(0,1fr)] xl:grid-cols-[264px_minmax(0,1fr)_336px]">
+      <div className="grid min-h-svh md:grid-cols-[264px_minmax(0,1fr)] lg:grid-cols-[264px_minmax(0,1fr)_336px]">
         <Sidebar />
         <div className="flex min-w-0 flex-col pb-20 md:pb-0">
           <Topbar
@@ -31,7 +98,7 @@ export function AppShell({ children }: { children: ReactNode }) {
             {children}
           </div>
         </div>
-        <div className="hidden border-l border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_86%,transparent)] p-4 xl:block">
+        <div className="hidden border-l border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_86%,transparent)] p-4 lg:block">
           <div id="group-inspector-slot" />
         </div>
       </div>
@@ -39,9 +106,11 @@ export function AppShell({ children }: { children: ReactNode }) {
       {navigationOpen ? (
         <div className="fixed inset-0 z-50 bg-black/20 md:hidden">
           <aside
+            ref={navigationDrawerRef}
             role="dialog"
             aria-modal="true"
             aria-label="Navigation"
+            onKeyDown={handleDrawerKeyDown}
             className="h-full w-[min(22rem,92vw)] border-r border-[var(--app-border)] bg-[var(--app-surface)]"
           >
             <div className="flex justify-end p-3">

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1,0 +1,74 @@
+import { useLocation } from '@tanstack/react-router'
+import { X } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+import { getRouteContext } from '../../lib/appNavigation'
+import { CommandPalette } from './CommandPalette'
+import { GatherPanel } from './GatherPanel'
+import { IssueReporterModal } from './IssueReporterModal'
+import { MobileDock } from './MobileDock'
+import { IconButton } from './ShellPrimitives'
+import { Sidebar } from './Sidebar'
+import { Topbar } from './Topbar'
+
+export function AppShell({ children }: { children: ReactNode }) {
+  const location = useLocation()
+  const context = getRouteContext(location.pathname)
+  const [navigationOpen, setNavigationOpen] = useState(false)
+  const [gatherOpen, setGatherOpen] = useState(false)
+
+  return (
+    <div className="app-shell">
+      <div className="grid min-h-svh md:grid-cols-[264px_minmax(0,1fr)] xl:grid-cols-[264px_minmax(0,1fr)_336px]">
+        <Sidebar />
+        <div className="flex min-w-0 flex-col pb-20 md:pb-0">
+          <Topbar
+            context={context}
+            onOpenNavigation={() => setNavigationOpen(true)}
+            onOpenGather={() => setGatherOpen(true)}
+          />
+          <div className="min-w-0 flex-1 px-3 py-4 md:px-5 md:py-5">
+            {children}
+          </div>
+        </div>
+        <div className="hidden border-l border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_86%,transparent)] p-4 xl:block">
+          <div id="group-inspector-slot" />
+        </div>
+      </div>
+
+      {navigationOpen ? (
+        <div className="fixed inset-0 z-50 bg-black/20 md:hidden">
+          <aside
+            role="dialog"
+            aria-modal="true"
+            aria-label="Navigation"
+            className="h-full w-[min(22rem,92vw)] border-r border-[var(--app-border)] bg-[var(--app-surface)]"
+          >
+            <div className="flex justify-end p-3">
+              <IconButton
+                label="Close navigation"
+                onClick={() => setNavigationOpen(false)}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+              </IconButton>
+            </div>
+            <Sidebar
+              variant="drawer"
+              onNavigate={() => setNavigationOpen(false)}
+            />
+          </aside>
+        </div>
+      ) : null}
+
+      <MobileDock pathname={location.pathname} />
+      <GatherPanel
+        open={gatherOpen}
+        activeGroupName="Oak House"
+        routeTitle={context.title}
+        onClose={() => setGatherOpen(false)}
+      />
+      <CommandPalette />
+      <IssueReporterModal />
+    </div>
+  )
+}

--- a/src/components/app/CommandFeed.test.tsx
+++ b/src/components/app/CommandFeed.test.tsx
@@ -33,6 +33,11 @@ test('CommandFeed renders command center activity without promising real automat
   ).toBeDefined()
   expect(screen.getByText(/designed preview/i)).toBeDefined()
   expect(screen.queryByText(/automatically completed/i)).toBeNull()
+  expect(screen.getByRole('heading', { name: 'Activity' })).toBeDefined()
+  expect(screen.getByRole('heading', { name: 'Upcoming' })).toBeDefined()
+  expect(
+    screen.getByRole('heading', { name: 'Suggested actions' }),
+  ).toBeDefined()
 })
 
 test('CommandFeed renders module-derived cards', () => {
@@ -41,6 +46,10 @@ test('CommandFeed renders module-derived cards', () => {
   expect(screen.getByRole('heading', { name: 'Modules' })).toBeDefined()
   expect(screen.getByText('Recipes')).toBeDefined()
   expect(screen.getByText('Meal planner')).toBeDefined()
+  expect(
+    screen.getByRole('heading', { name: 'Modules' }).closest('section')
+      ?.className,
+  ).toContain('scroll-mt-20')
 })
 
 test('GroupInspector renders group overview cards', () => {
@@ -49,4 +58,7 @@ test('GroupInspector renders group overview cards', () => {
   expect(screen.getByText('Active modules')).toBeDefined()
   expect(screen.getByText('Today')).toBeDefined()
   expect(screen.getByText('Members')).toBeDefined()
+  expect(screen.getByText('Preview data')).toBeDefined()
+  expect(screen.queryByText('Alex')).toBeNull()
+  expect(screen.queryByText('Maya')).toBeNull()
 })

--- a/src/components/app/CommandFeed.test.tsx
+++ b/src/components/app/CommandFeed.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { CommandFeed } from './CommandFeed'
+import { GroupInspector } from './GroupInspector'
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-router')>(
+    '@tanstack/react-router',
+  )
+  return {
+    ...actual,
+    Link: ({
+      children,
+      to,
+      className,
+    }: {
+      children: React.ReactNode
+      to: string
+      className?: string
+    }) => (
+      <a href={to} className={className}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+test('CommandFeed renders command center activity without promising real automation', () => {
+  render(<CommandFeed />)
+
+  expect(
+    screen.getByRole('heading', { name: 'Group command center' }),
+  ).toBeDefined()
+  expect(screen.getByText(/designed preview/i)).toBeDefined()
+  expect(screen.queryByText(/automatically completed/i)).toBeNull()
+})
+
+test('CommandFeed renders module-derived cards', () => {
+  render(<CommandFeed />)
+
+  expect(screen.getByRole('heading', { name: 'Modules' })).toBeDefined()
+  expect(screen.getByText('Recipes')).toBeDefined()
+  expect(screen.getByText('Meal planner')).toBeDefined()
+})
+
+test('GroupInspector renders group overview cards', () => {
+  render(<GroupInspector />)
+
+  expect(screen.getByText('Active modules')).toBeDefined()
+  expect(screen.getByText('Today')).toBeDefined()
+  expect(screen.getByText('Members')).toBeDefined()
+})

--- a/src/components/app/CommandFeed.tsx
+++ b/src/components/app/CommandFeed.tsx
@@ -7,6 +7,27 @@ import { MODULES } from '../../lib/modules'
 import { GroupInspector } from './GroupInspector'
 import { Pill, SectionHeader, SurfaceCard } from './ShellPrimitives'
 
+const PREVIEW_ACTIVITY = [
+  {
+    label: 'Recipe changes',
+    detail: 'Connected recipe edits and notes will appear here.',
+  },
+  {
+    label: 'Shared updates',
+    detail: 'Group-wide changes will stack into a readable timeline.',
+  },
+] as const
+
+const PREVIEW_UPCOMING = [
+  'Meals and grocery checkpoints',
+  'Calendar holds and reminders',
+] as const
+
+const PREVIEW_ACTIONS = [
+  'Suggested follow-ups from module activity',
+  'Prompted check-ins for shared planning',
+] as const
+
 function Icon({ name }: { name: string }) {
   const Component =
     (Icons as unknown as Record<string, LucideIcon>)[name] ?? Icons.Square
@@ -49,7 +70,66 @@ export function CommandFeed() {
         </SurfaceCard>
       </section>
 
-      <section id="modules" className="grid gap-3">
+      <section className="grid gap-3">
+        <SectionHeader
+          title="Activity"
+          action={<Pill tone="warning">Preview</Pill>}
+        />
+        <SurfaceCard>
+          <div className="grid gap-3">
+            {PREVIEW_ACTIVITY.map((item) => (
+              <div
+                key={item.label}
+                className="flex items-start justify-between gap-3 border-t border-[var(--app-border)] pt-3 first:border-t-0 first:pt-0"
+              >
+                <div className="min-w-0">
+                  <h3 className="m-0 text-sm font-semibold">{item.label}</h3>
+                  <p className="mt-1 text-sm leading-6 text-[var(--app-muted)]">
+                    {item.detail}
+                  </p>
+                </div>
+                <Pill>Slot</Pill>
+              </div>
+            ))}
+          </div>
+        </SurfaceCard>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-2">
+        <SurfaceCard>
+          <SectionHeader title="Upcoming" action={<Pill>Preview</Pill>} />
+          <div className="grid gap-2 text-sm">
+            {PREVIEW_UPCOMING.map((item) => (
+              <div
+                key={item}
+                className="flex items-center justify-between gap-3 border-t border-[var(--app-border)] pt-2 first:border-t-0 first:pt-0"
+              >
+                <span>{item}</span>
+                <Pill>Slot</Pill>
+              </div>
+            ))}
+          </div>
+        </SurfaceCard>
+        <SurfaceCard>
+          <SectionHeader
+            title="Suggested actions"
+            action={<Pill>Preview</Pill>}
+          />
+          <div className="grid gap-2 text-sm">
+            {PREVIEW_ACTIONS.map((item) => (
+              <div
+                key={item}
+                className="flex items-center justify-between gap-3 border-t border-[var(--app-border)] pt-2 first:border-t-0 first:pt-0"
+              >
+                <span>{item}</span>
+                <Pill>Soon</Pill>
+              </div>
+            ))}
+          </div>
+        </SurfaceCard>
+      </section>
+
+      <section id="modules" className="grid scroll-mt-20 gap-3">
         <SectionHeader title="Modules" />
         <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
           {MODULES.map((module) => (

--- a/src/components/app/CommandFeed.tsx
+++ b/src/components/app/CommandFeed.tsx
@@ -1,0 +1,85 @@
+import type { LinkProps } from '@tanstack/react-router'
+import { Link } from '@tanstack/react-router'
+import type { LucideIcon } from 'lucide-react'
+import * as Icons from 'lucide-react'
+import { getModulesByStatus } from '../../lib/appNavigation'
+import { MODULES } from '../../lib/modules'
+import { GroupInspector } from './GroupInspector'
+import { Pill, SectionHeader, SurfaceCard } from './ShellPrimitives'
+
+function Icon({ name }: { name: string }) {
+  const Component =
+    (Icons as unknown as Record<string, LucideIcon>)[name] ?? Icons.Square
+  return <Component className="h-4 w-4" aria-hidden="true" />
+}
+
+export function CommandFeed() {
+  const byStatus = getModulesByStatus()
+
+  return (
+    <div className="mx-auto grid max-w-5xl gap-4">
+      <section className="grid gap-3">
+        <div>
+          <p className="mb-2 text-xs font-semibold uppercase text-[var(--app-muted)]">
+            Designed preview
+          </p>
+          <h2 className="m-0 text-2xl font-semibold">Group command center</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-[var(--app-muted)]">
+            A shared view of plans, module updates, and suggested next actions.
+            This feed is a designed coordination surface; real automation comes
+            later.
+          </p>
+        </div>
+
+        <SurfaceCard>
+          <SectionHeader
+            title="Gather summary"
+            action={<Pill tone="warning">Preview</Pill>}
+          />
+          <p className="m-0 text-sm leading-6 text-[var(--app-muted)]">
+            Recipes is live. {byStatus.placeholder.length} other modules are
+            staged as placeholders, so the group can see what is planned without
+            losing the current working flows.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Pill tone="dark">Recipes live</Pill>
+            <Pill>{MODULES.length} modules</Pill>
+            <Pill>Group scoped</Pill>
+          </div>
+        </SurfaceCard>
+      </section>
+
+      <section id="modules" className="grid gap-3">
+        <SectionHeader title="Modules" />
+        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+          {MODULES.map((module) => (
+            <Link
+              key={module.id}
+              to={module.path as LinkProps['to']}
+              className="grid min-h-28 gap-3 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-3 text-[var(--app-fg)] no-underline"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="grid h-9 w-9 place-items-center rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface-muted)] text-[var(--app-muted)]">
+                  <Icon name={module.icon} />
+                </span>
+                <Pill tone={module.status === 'live' ? 'success' : 'default'}>
+                  {module.status === 'live' ? 'Live' : 'Soon'}
+                </Pill>
+              </div>
+              <div>
+                <h3 className="m-0 text-sm font-semibold">{module.label}</h3>
+                <p className="mt-1 text-xs leading-5 text-[var(--app-muted)]">
+                  {module.description}
+                </p>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <div className="xl:hidden">
+        <GroupInspector compact />
+      </div>
+    </div>
+  )
+}

--- a/src/components/app/GatherPanel.test.tsx
+++ b/src/components/app/GatherPanel.test.tsx
@@ -48,3 +48,26 @@ test('calls onClose from close button and Escape', () => {
 
   expect(onClose).toHaveBeenCalledTimes(2)
 })
+
+test('moves focus into the panel and traps Tab navigation', () => {
+  render(
+    <GatherPanel
+      open={true}
+      activeGroupName="Oak House"
+      routeTitle="Recipes"
+      onClose={() => {}}
+    />,
+  )
+
+  const closeButton = screen.getByRole('button', { name: 'Close Ask Gather' })
+  const textarea = screen.getByPlaceholderText(/ask gather/i)
+
+  expect(document.activeElement).toBe(closeButton)
+
+  textarea.focus()
+  fireEvent.keyDown(textarea, { key: 'Tab' })
+  expect(document.activeElement).toBe(closeButton)
+
+  fireEvent.keyDown(closeButton, { key: 'Tab', shiftKey: true })
+  expect(document.activeElement).toBe(textarea)
+})

--- a/src/components/app/GatherPanel.test.tsx
+++ b/src/components/app/GatherPanel.test.tsx
@@ -71,3 +71,25 @@ test('moves focus into the panel and traps Tab navigation', () => {
   fireEvent.keyDown(closeButton, { key: 'Tab', shiftKey: true })
   expect(document.activeElement).toBe(textarea)
 })
+
+test('restores focus to the opener when it closes', () => {
+  const renderPanel = (open: boolean) => (
+    <>
+      <button type="button">Open Gather</button>
+      <GatherPanel
+        open={open}
+        activeGroupName="Oak House"
+        routeTitle="Recipes"
+        onClose={() => {}}
+      />
+    </>
+  )
+  const { rerender } = render(renderPanel(false))
+  const opener = screen.getByRole('button', { name: 'Open Gather' })
+
+  opener.focus()
+  rerender(renderPanel(true))
+  rerender(renderPanel(false))
+
+  expect(document.activeElement).toBe(opener)
+})

--- a/src/components/app/GatherPanel.test.tsx
+++ b/src/components/app/GatherPanel.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { GatherPanel } from './GatherPanel'
+
+test('does not render when closed', () => {
+  render(
+    <GatherPanel
+      open={false}
+      activeGroupName="Oak House"
+      routeTitle="Recipes"
+      onClose={() => {}}
+    />,
+  )
+
+  expect(screen.queryByRole('dialog', { name: 'Ask Gather' })).toBeNull()
+})
+
+test('renders non-automated placeholder prompts when open', () => {
+  render(
+    <GatherPanel
+      open={true}
+      activeGroupName="Oak House"
+      routeTitle="Recipes"
+      onClose={() => {}}
+    />,
+  )
+
+  expect(screen.getByRole('dialog', { name: 'Ask Gather' })).toBeDefined()
+  expect(screen.getByText('Oak House')).toBeDefined()
+  expect(screen.getByText('Context: Recipes')).toBeDefined()
+  expect(screen.getByText(/automation is not connected yet/i)).toBeDefined()
+  expect(screen.getByPlaceholderText(/ask gather/i)).toBeDefined()
+})
+
+test('calls onClose from close button and Escape', () => {
+  const onClose = vi.fn()
+  render(
+    <GatherPanel
+      open={true}
+      activeGroupName="Oak House"
+      routeTitle="Recipes"
+      onClose={onClose}
+    />,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'Close Ask Gather' }))
+  fireEvent.keyDown(window, { key: 'Escape' })
+
+  expect(onClose).toHaveBeenCalledTimes(2)
+})

--- a/src/components/app/GatherPanel.test.tsx
+++ b/src/components/app/GatherPanel.test.tsx
@@ -6,7 +6,7 @@ test('does not render when closed', () => {
   render(
     <GatherPanel
       open={false}
-      activeGroupName="Oak House"
+      activeGroupName="Preview group"
       routeTitle="Recipes"
       onClose={() => {}}
     />,
@@ -19,14 +19,14 @@ test('renders non-automated placeholder prompts when open', () => {
   render(
     <GatherPanel
       open={true}
-      activeGroupName="Oak House"
+      activeGroupName="Preview group"
       routeTitle="Recipes"
       onClose={() => {}}
     />,
   )
 
   expect(screen.getByRole('dialog', { name: 'Ask Gather' })).toBeDefined()
-  expect(screen.getByText('Oak House')).toBeDefined()
+  expect(screen.getByText('Preview group')).toBeDefined()
   expect(screen.getByText('Context: Recipes')).toBeDefined()
   expect(screen.getByText(/automation is not connected yet/i)).toBeDefined()
   expect(screen.getByPlaceholderText(/ask gather/i)).toBeDefined()
@@ -37,7 +37,7 @@ test('calls onClose from close button and Escape', () => {
   render(
     <GatherPanel
       open={true}
-      activeGroupName="Oak House"
+      activeGroupName="Preview group"
       routeTitle="Recipes"
       onClose={onClose}
     />,
@@ -78,7 +78,7 @@ test('restores focus to the opener when it closes', () => {
       <button type="button">Open Gather</button>
       <GatherPanel
         open={open}
-        activeGroupName="Oak House"
+        activeGroupName="Preview group"
         routeTitle="Recipes"
         onClose={() => {}}
       />

--- a/src/components/app/GatherPanel.tsx
+++ b/src/components/app/GatherPanel.tsx
@@ -33,12 +33,27 @@ export function GatherPanel({
   onClose,
 }: GatherPanelProps) {
   const panelRef = useRef<HTMLElement>(null)
+  const openerRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
-    if (!open) return
+    if (!open) {
+      const opener = openerRef.current
+      if (opener?.isConnected) opener.focus()
+      openerRef.current = null
+      return
+    }
+
+    openerRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
 
     const panel = panelRef.current
     if (panel) getFocusableElements(panel)[0]?.focus()
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
 
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onClose()
@@ -47,6 +62,13 @@ export function GatherPanel({
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [open, onClose])
+
+  useEffect(() => {
+    return () => {
+      const opener = openerRef.current
+      if (opener?.isConnected) opener.focus()
+    }
+  }, [])
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.key !== 'Tab') return

--- a/src/components/app/GatherPanel.tsx
+++ b/src/components/app/GatherPanel.tsx
@@ -1,0 +1,97 @@
+import { Sparkles, X } from 'lucide-react'
+import { useEffect } from 'react'
+import { IconButton, Pill, SectionHeader, SurfaceCard } from './ShellPrimitives'
+
+export interface GatherPanelProps {
+  open: boolean
+  activeGroupName: string
+  routeTitle: string
+  onClose: () => void
+}
+
+const PROMPTS = [
+  'Show me what changed recently',
+  'Draft a plan for this group',
+  'Summarize this page',
+]
+
+export function GatherPanel({
+  open,
+  activeGroupName,
+  routeTitle,
+  onClose,
+}: GatherPanelProps) {
+  useEffect(() => {
+    if (!open) return
+
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/20 md:bg-transparent">
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="Ask Gather"
+        className="fixed inset-x-0 bottom-0 max-h-[88svh] overflow-auto rounded-t-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-4 shadow-2xl md:inset-y-3 md:right-3 md:left-auto md:w-[360px] md:rounded-[var(--app-radius)]"
+      >
+        <header className="mb-4 flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="mb-1 text-xs font-semibold uppercase text-[var(--app-muted)]">
+              {activeGroupName}
+            </p>
+            <h2 className="m-0 text-lg font-semibold">Ask Gather</h2>
+            <p className="mt-1 text-sm text-[var(--app-muted)]">
+              Context: {routeTitle}
+            </p>
+          </div>
+          <IconButton label="Close Ask Gather" onClick={onClose}>
+            <X className="h-4 w-4" aria-hidden="true" />
+          </IconButton>
+        </header>
+
+        <SurfaceCard className="mb-3">
+          <div className="mb-3 flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-[var(--app-accent)]" />
+            <Pill tone="warning">Preview</Pill>
+          </div>
+          <p className="m-0 text-sm leading-6 text-[var(--app-muted)]">
+            Automation is not connected yet. Use this panel as a command
+            scratchpad for the active group; real actions will arrive in a later
+            feature.
+          </p>
+        </SurfaceCard>
+
+        <SurfaceCard>
+          <SectionHeader title="Try asking" />
+          <div className="grid gap-2">
+            {PROMPTS.map((prompt) => (
+              <button
+                type="button"
+                key={prompt}
+                className="rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface-muted)] px-3 py-2 text-left text-sm"
+              >
+                {prompt}
+              </button>
+            ))}
+          </div>
+        </SurfaceCard>
+
+        <label className="mt-3 block">
+          <span className="sr-only">Ask Gather</span>
+          <textarea
+            placeholder="Ask Gather to help with this group..."
+            className="min-h-28 w-full resize-none rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)]"
+          />
+        </label>
+      </aside>
+    </div>
+  )
+}

--- a/src/components/app/GatherPanel.tsx
+++ b/src/components/app/GatherPanel.tsx
@@ -1,5 +1,9 @@
 import { Sparkles, X } from 'lucide-react'
-import { useEffect } from 'react'
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useRef,
+} from 'react'
 import { IconButton, Pill, SectionHeader, SurfaceCard } from './ShellPrimitives'
 
 export interface GatherPanelProps {
@@ -15,14 +19,26 @@ const PROMPTS = [
   'Summarize this page',
 ]
 
+const FOCUSABLE_SELECTOR =
+  'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
+
+function getFocusableElements(panel: HTMLElement) {
+  return Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+}
+
 export function GatherPanel({
   open,
   activeGroupName,
   routeTitle,
   onClose,
 }: GatherPanelProps) {
+  const panelRef = useRef<HTMLElement>(null)
+
   useEffect(() => {
     if (!open) return
+
+    const panel = panelRef.current
+    if (panel) getFocusableElements(panel)[0]?.focus()
 
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onClose()
@@ -32,14 +48,34 @@ export function GatherPanel({
     return () => window.removeEventListener('keydown', onKey)
   }, [open, onClose])
 
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (event.key !== 'Tab') return
+
+    const focusableElements = getFocusableElements(event.currentTarget)
+    const firstFocusable = focusableElements[0]
+    const lastFocusable = focusableElements.at(-1)
+
+    if (!firstFocusable || !lastFocusable) return
+
+    if (event.shiftKey && document.activeElement === firstFocusable) {
+      event.preventDefault()
+      lastFocusable.focus()
+    } else if (!event.shiftKey && document.activeElement === lastFocusable) {
+      event.preventDefault()
+      firstFocusable.focus()
+    }
+  }
+
   if (!open) return null
 
   return (
     <div className="fixed inset-0 z-50 bg-black/20 md:bg-transparent">
       <aside
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         aria-label="Ask Gather"
+        onKeyDown={handleKeyDown}
         className="fixed inset-x-0 bottom-0 max-h-[88svh] overflow-auto rounded-t-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-4 shadow-2xl md:inset-y-3 md:right-3 md:left-auto md:w-[360px] md:rounded-[var(--app-radius)]"
       >
         <header className="mb-4 flex items-start justify-between gap-3">

--- a/src/components/app/GroupInspector.tsx
+++ b/src/components/app/GroupInspector.tsx
@@ -1,11 +1,5 @@
 import { MODULES } from '../../lib/modules'
-import {
-  AvatarStack,
-  Pill,
-  SectionHeader,
-  StatusDot,
-  SurfaceCard,
-} from './ShellPrimitives'
+import { Pill, SectionHeader, StatusDot, SurfaceCard } from './ShellPrimitives'
 
 export function GroupInspector({ compact = false }: { compact?: boolean }) {
   const liveCount = MODULES.filter((module) => module.status === 'live').length
@@ -36,12 +30,12 @@ export function GroupInspector({ compact = false }: { compact?: boolean }) {
         />
         <div className="grid gap-2 text-sm">
           <div className="flex items-center justify-between gap-3 border-t border-[var(--app-border)] pt-2 first:border-t-0 first:pt-0">
-            <span>Review this week's meals</span>
-            <Pill>Kitchen</Pill>
+            <span>Meal planning snapshot</span>
+            <Pill>Slot</Pill>
           </div>
           <div className="flex items-center justify-between gap-3 border-t border-[var(--app-border)] pt-2">
-            <span>Check shared list updates</span>
-            <Pill>Group</Pill>
+            <span>Shared updates snapshot</span>
+            <Pill>Slot</Pill>
           </div>
         </div>
       </SurfaceCard>
@@ -49,9 +43,11 @@ export function GroupInspector({ compact = false }: { compact?: boolean }) {
       <SurfaceCard>
         <SectionHeader
           title="Members"
-          action={<Pill tone="success">synced</Pill>}
+          action={<Pill tone="warning">Preview data</Pill>}
         />
-        <AvatarStack members={['Alex', 'Maya']} />
+        <p className="m-0 text-sm leading-6 text-[var(--app-muted)]">
+          Member details will appear here when group data is connected.
+        </p>
       </SurfaceCard>
     </aside>
   )

--- a/src/components/app/GroupInspector.tsx
+++ b/src/components/app/GroupInspector.tsx
@@ -1,0 +1,58 @@
+import { MODULES } from '../../lib/modules'
+import {
+  AvatarStack,
+  Pill,
+  SectionHeader,
+  StatusDot,
+  SurfaceCard,
+} from './ShellPrimitives'
+
+export function GroupInspector({ compact = false }: { compact?: boolean }) {
+  const liveCount = MODULES.filter((module) => module.status === 'live').length
+  const plannedCount = MODULES.length - liveCount
+
+  return (
+    <aside
+      aria-label="Group overview"
+      className={compact ? 'grid gap-3' : 'grid gap-4'}
+    >
+      <SurfaceCard>
+        <SectionHeader
+          title="Active modules"
+          action={<Pill>{liveCount} live</Pill>}
+        />
+        <div className="grid gap-2 text-sm">
+          <StatusDot label="Recipes connected" />
+          <p className="m-0 text-[var(--app-muted)]">
+            {plannedCount} planned modules are ready as placeholders.
+          </p>
+        </div>
+      </SurfaceCard>
+
+      <SurfaceCard>
+        <SectionHeader
+          title="Today"
+          action={<Pill tone="warning">Preview</Pill>}
+        />
+        <div className="grid gap-2 text-sm">
+          <div className="flex items-center justify-between gap-3 border-t border-[var(--app-border)] pt-2 first:border-t-0 first:pt-0">
+            <span>Review this week's meals</span>
+            <Pill>Kitchen</Pill>
+          </div>
+          <div className="flex items-center justify-between gap-3 border-t border-[var(--app-border)] pt-2">
+            <span>Check shared list updates</span>
+            <Pill>Group</Pill>
+          </div>
+        </div>
+      </SurfaceCard>
+
+      <SurfaceCard>
+        <SectionHeader
+          title="Members"
+          action={<Pill tone="success">synced</Pill>}
+        />
+        <AvatarStack members={['Alex', 'Maya']} />
+      </SurfaceCard>
+    </aside>
+  )
+}

--- a/src/components/app/MobileDock.tsx
+++ b/src/components/app/MobileDock.tsx
@@ -1,0 +1,32 @@
+import type { LinkProps } from '@tanstack/react-router'
+import { Link } from '@tanstack/react-router'
+import type { LucideIcon } from 'lucide-react'
+import * as Icons from 'lucide-react'
+import { isDockItemActive, MOBILE_DOCK_ITEMS } from '../../lib/appNavigation'
+
+function Icon({ name }: { name: string }) {
+  const Component =
+    (Icons as unknown as Record<string, LucideIcon>)[name] ?? Icons.Square
+  return <Component className="h-4 w-4" aria-hidden="true" />
+}
+
+export function MobileDock({ pathname }: { pathname: string }) {
+  return (
+    <nav
+      aria-label="Mobile navigation"
+      className="fixed inset-x-2 bottom-2 z-30 grid grid-cols-4 gap-1 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-1 md:hidden"
+    >
+      {MOBILE_DOCK_ITEMS.map((item) => (
+        <Link
+          key={item.id}
+          to={item.path as LinkProps['to']}
+          aria-current={isDockItemActive(pathname, item) ? 'page' : undefined}
+          className="grid min-h-11 place-items-center rounded-[7px] text-xs text-[var(--app-muted)] no-underline aria-[current=page]:bg-[var(--app-surface-muted)] aria-[current=page]:text-[var(--app-fg)]"
+        >
+          <Icon name={item.icon} />
+          <span>{item.label}</span>
+        </Link>
+      ))}
+    </nav>
+  )
+}

--- a/src/components/app/MobileDock.tsx
+++ b/src/components/app/MobileDock.tsx
@@ -10,7 +10,11 @@ function Icon({ name }: { name: string }) {
   return <Component className="h-4 w-4" aria-hidden="true" />
 }
 
-export function MobileDock({ pathname }: { pathname: string }) {
+export function MobileDock({
+  location,
+}: {
+  location: { pathname: string; hash?: string }
+}) {
   return (
     <nav
       aria-label="Mobile navigation"
@@ -20,7 +24,7 @@ export function MobileDock({ pathname }: { pathname: string }) {
         <Link
           key={item.id}
           to={item.path as LinkProps['to']}
-          aria-current={isDockItemActive(pathname, item) ? 'page' : undefined}
+          aria-current={isDockItemActive(location, item) ? 'page' : undefined}
           className="grid min-h-11 place-items-center rounded-[7px] text-xs text-[var(--app-muted)] no-underline aria-[current=page]:bg-[var(--app-surface-muted)] aria-[current=page]:text-[var(--app-fg)]"
         >
           <Icon name={item.icon} />

--- a/src/components/app/ModulePlaceholder.test.tsx
+++ b/src/components/app/ModulePlaceholder.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { expect, test } from 'vitest'
 import { ModulePlaceholder } from './ModulePlaceholder'
 
-test('renders the module label and description with a coming-soon note', () => {
+test('renders an operational placeholder page for a module', () => {
   render(
     <ModulePlaceholder
       label="Groceries"
@@ -14,5 +14,6 @@ test('renders the module label and description with a coming-soon note', () => {
   expect(
     screen.getByText('A shared shopping list you both check off.'),
   ).toBeDefined()
-  expect(screen.getByText(/coming soon/i)).toBeDefined()
+  expect(screen.getByText('Module planned')).toBeDefined()
+  expect(screen.getByText(/this group module is staged/i)).toBeDefined()
 })

--- a/src/components/app/ModulePlaceholder.tsx
+++ b/src/components/app/ModulePlaceholder.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon } from 'lucide-react'
 import * as Icons from 'lucide-react'
+import { Pill, SurfaceCard } from './ShellPrimitives'
 
 export function ModulePlaceholder({
   label,
@@ -14,13 +15,32 @@ export function ModulePlaceholder({
     (Icons as unknown as Record<string, LucideIcon>)[icon] ?? Icons.Square
 
   return (
-    <div className="mx-auto flex max-w-md flex-col items-center gap-3 py-20 text-center">
-      <Icon className="h-10 w-10 opacity-60" aria-hidden="true" />
-      <h1 className="text-xl font-semibold">{label}</h1>
-      <p className="text-sm opacity-70">{description}</p>
-      <span className="mt-2 rounded-full border px-3 py-1 text-xs uppercase tracking-wide opacity-60">
-        Coming soon
-      </span>
+    <div className="mx-auto grid max-w-4xl gap-4">
+      <SurfaceCard>
+        <div className="flex items-start gap-3">
+          <span className="grid h-10 w-10 shrink-0 place-items-center rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface-muted)] text-[var(--app-muted)]">
+            <Icon className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <h1 className="m-0 text-2xl font-semibold">{label}</h1>
+              <Pill>Module planned</Pill>
+            </div>
+            <p className="m-0 max-w-2xl text-sm leading-6 text-[var(--app-muted)]">
+              {description}
+            </p>
+          </div>
+        </div>
+      </SurfaceCard>
+
+      <SurfaceCard>
+        <h2 className="m-0 text-sm font-semibold">What will live here</h2>
+        <p className="mt-2 text-sm leading-6 text-[var(--app-muted)]">
+          This group module is staged in the command center so navigation,
+          sharing, and mobile layout are ready before the full workflow is
+          implemented.
+        </p>
+      </SurfaceCard>
     </div>
   )
 }

--- a/src/components/app/ShellPrimitives.test.tsx
+++ b/src/components/app/ShellPrimitives.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import { Bell } from 'lucide-react'
+import { expect, test } from 'vitest'
+import {
+  AvatarStack,
+  IconButton,
+  Pill,
+  SectionHeader,
+  StatusDot,
+  SurfaceCard,
+} from './ShellPrimitives'
+
+test('IconButton renders an accessible icon-only button', () => {
+  render(
+    <IconButton label="Open alerts">
+      <Bell className="h-4 w-4" aria-hidden="true" />
+    </IconButton>,
+  )
+
+  expect(screen.getByRole('button', { name: 'Open alerts' })).toBeDefined()
+})
+
+test('SurfaceCard, SectionHeader, Pill, StatusDot, and AvatarStack render shell UI content', () => {
+  render(
+    <SurfaceCard ariaLabel="Group status">
+      <SectionHeader title="Today" action={<Pill>synced</Pill>} />
+      <StatusDot label="Connected" />
+      <AvatarStack members={['Alex', 'Maya', 'Sam']} />
+    </SurfaceCard>,
+  )
+
+  expect(screen.getByLabelText('Group status')).toBeDefined()
+  expect(screen.getByRole('heading', { name: 'Today' })).toBeDefined()
+  expect(screen.getByText('synced')).toBeDefined()
+  expect(screen.getByText('Connected')).toBeDefined()
+  expect(screen.getByText('A')).toBeDefined()
+  expect(screen.getByText('M')).toBeDefined()
+  expect(screen.getByText('S')).toBeDefined()
+})

--- a/src/components/app/ShellPrimitives.tsx
+++ b/src/components/app/ShellPrimitives.tsx
@@ -1,0 +1,131 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+
+export interface IconButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  label: string
+  children: ReactNode
+}
+
+export function IconButton({
+  label,
+  children,
+  className = '',
+  type = 'button',
+  ...props
+}: IconButtonProps) {
+  return (
+    <button
+      type={type}
+      aria-label={label}
+      title={label}
+      className={`shell-icon-button ${className}`.trim()}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}
+
+export interface SurfaceCardProps {
+  children: ReactNode
+  className?: string
+  ariaLabel?: string
+}
+
+export function SurfaceCard({
+  children,
+  className = '',
+  ariaLabel,
+}: SurfaceCardProps) {
+  return (
+    <section
+      aria-label={ariaLabel}
+      className={`shell-card ${className}`.trim()}
+    >
+      {children}
+    </section>
+  )
+}
+
+export interface PillProps {
+  children: ReactNode
+  tone?: 'default' | 'dark' | 'success' | 'warning'
+  className?: string
+}
+
+export function Pill({
+  children,
+  tone = 'default',
+  className = '',
+}: PillProps) {
+  return (
+    <span className={`shell-pill shell-pill-${tone} ${className}`.trim()}>
+      {children}
+    </span>
+  )
+}
+
+export interface SectionHeaderProps {
+  title: string
+  eyebrow?: string
+  action?: ReactNode
+}
+
+export function SectionHeader({ title, eyebrow, action }: SectionHeaderProps) {
+  return (
+    <header className="shell-section-header">
+      <div className="min-w-0">
+        {eyebrow ? <p className="shell-eyebrow">{eyebrow}</p> : null}
+        <h2>{title}</h2>
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </header>
+  )
+}
+
+export interface StatusDotProps {
+  label: string
+  tone?: 'success' | 'warning' | 'muted'
+}
+
+export function StatusDot({ label, tone = 'success' }: StatusDotProps) {
+  return (
+    <span className="shell-status">
+      <span className={`shell-status-dot shell-status-dot-${tone}`} />
+      {label}
+    </span>
+  )
+}
+
+export interface AvatarStackProps {
+  members: string[]
+  max?: number
+}
+
+function initials(name: string) {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return '?'
+  if (parts.length === 1) return parts[0].slice(0, 1).toUpperCase()
+  return `${parts[0].slice(0, 1)}${parts[1].slice(0, 1)}`.toUpperCase()
+}
+
+export function AvatarStack({ members, max = 4 }: AvatarStackProps) {
+  const visible = members.slice(0, max)
+  const remaining = members.length - visible.length
+
+  return (
+    <fieldset
+      className="shell-avatar-stack"
+      aria-label={`${members.length} members`}
+    >
+      {visible.map((member) => (
+        <span key={member} className="shell-avatar" title={member}>
+          {initials(member)}
+        </span>
+      ))}
+      {remaining > 0 ? (
+        <span className="shell-avatar shell-avatar-more">+{remaining}</span>
+      ) : null}
+    </fieldset>
+  )
+}

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -1,10 +1,10 @@
 import type { LinkProps } from '@tanstack/react-router'
-import { Link } from '@tanstack/react-router'
+import { Link, useLocation } from '@tanstack/react-router'
 import type { LucideIcon } from 'lucide-react'
 import * as Icons from 'lucide-react'
-import { PRIMARY_AREAS } from '../../lib/appNavigation'
+import { isPrimaryAreaActive, PRIMARY_AREAS } from '../../lib/appNavigation'
 import { MODULE_GROUPS, modulesByGroup } from '../../lib/modules'
-import { AvatarStack, Pill } from './ShellPrimitives'
+import { Pill } from './ShellPrimitives'
 
 function Icon({ name, className }: { name: string; className?: string }) {
   const Component =
@@ -20,13 +20,14 @@ export interface SidebarProps {
 export function Sidebar({ variant = 'desktop', onNavigate }: SidebarProps) {
   const byGroup = modulesByGroup()
   const isDrawer = variant === 'drawer'
+  const location = useLocation()
 
   return (
     <aside
       className={
         isDrawer
-          ? 'flex h-full flex-col gap-6 p-4'
-          : 'hidden h-svh w-66 shrink-0 flex-col gap-6 border-r border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_86%,transparent)] p-4 md:flex'
+          ? 'flex min-h-full flex-col gap-6 overflow-y-auto p-4'
+          : 'hidden h-svh w-66 shrink-0 flex-col gap-6 overflow-y-auto border-r border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_86%,transparent)] p-4 md:flex'
       }
       aria-label="Gather navigation"
     >
@@ -44,17 +45,19 @@ export function Sidebar({ variant = 'desktop', onNavigate }: SidebarProps) {
               Gather
             </strong>
             <span className="block truncate text-xs text-[var(--app-muted)]">
-              Oak House
+              Preview group
             </span>
           </span>
         </Link>
-        <button
-          type="button"
+        <Link
+          to="/groups"
+          onClick={onNavigate}
           className="shell-icon-button"
-          aria-label="Create group item"
+          aria-label="Manage groups"
+          title="Manage groups"
         >
           <Icon name="Plus" className="h-4 w-4" />
-        </button>
+        </Link>
       </div>
 
       <nav className="grid gap-1" aria-label="Primary">
@@ -66,11 +69,11 @@ export function Sidebar({ variant = 'desktop', onNavigate }: SidebarProps) {
             key={item.id}
             to={item.path as LinkProps['to']}
             onClick={onNavigate}
-            className="grid min-h-10 grid-cols-[28px_minmax(0,1fr)] items-center gap-2 rounded-[var(--app-radius)] border border-transparent px-2 text-sm font-semibold text-[var(--app-fg)] no-underline"
-            activeProps={{
-              className:
-                'border-[var(--app-fg)] bg-[var(--app-surface)] text-[var(--app-fg)]',
-            }}
+            className={`grid min-h-10 grid-cols-[28px_minmax(0,1fr)] items-center gap-2 rounded-[var(--app-radius)] border border-transparent px-2 text-sm font-semibold text-[var(--app-fg)] no-underline ${
+              isPrimaryAreaActive(location, item)
+                ? 'border-[var(--app-fg)] bg-[var(--app-surface)] text-[var(--app-fg)]'
+                : ''
+            }`}
           >
             <span className="grid h-7 w-7 place-items-center rounded-[7px] border border-[var(--app-border)] bg-[var(--app-surface)] text-[var(--app-muted)]">
               <Icon name={item.icon} className="h-4 w-4" />
@@ -109,10 +112,12 @@ export function Sidebar({ variant = 'desktop', onNavigate }: SidebarProps) {
 
       <section className="mt-auto rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-3">
         <div className="mb-3 flex items-center justify-between gap-2">
-          <h2 className="m-0 text-sm font-semibold">Active group</h2>
-          <Pill tone="success">synced</Pill>
+          <h2 className="m-0 text-sm font-semibold">Preview group</h2>
+          <Pill tone="warning">Preview data</Pill>
         </div>
-        <AvatarStack members={['Alex', 'Maya']} />
+        <p className="m-0 text-sm text-[var(--app-muted)]">
+          Group and member details appear here once connected.
+        </p>
         <div className="mt-3 grid grid-cols-2 gap-2">
           <Link
             to="/groups"

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -2,72 +2,134 @@ import type { LinkProps } from '@tanstack/react-router'
 import { Link } from '@tanstack/react-router'
 import type { LucideIcon } from 'lucide-react'
 import * as Icons from 'lucide-react'
+import { PRIMARY_AREAS } from '../../lib/appNavigation'
 import { MODULE_GROUPS, modulesByGroup } from '../../lib/modules'
+import { AvatarStack, Pill } from './ShellPrimitives'
 
 function Icon({ name, className }: { name: string; className?: string }) {
-  const C =
+  const Component =
     (Icons as unknown as Record<string, LucideIcon>)[name] ?? Icons.Square
-  return <C className={className} aria-hidden="true" />
+  return <Component className={className} aria-hidden="true" />
 }
 
-export function Sidebar() {
+export interface SidebarProps {
+  variant?: 'desktop' | 'drawer'
+  onNavigate?: () => void
+}
+
+export function Sidebar({ variant = 'desktop', onNavigate }: SidebarProps) {
   const byGroup = modulesByGroup()
+  const isDrawer = variant === 'drawer'
+
   return (
-    <aside className="hidden w-60 shrink-0 border-r p-4 sm:block">
-      <Link
-        to="/dashboard"
-        className="mb-4 flex items-center gap-2 px-2 font-semibold no-underline"
-      >
-        <span className="h-2.5 w-2.5 rounded-full bg-emerald-400" />
-        gather
-      </Link>
-
-      <Link
-        to="/dashboard"
-        className="mb-3 flex items-center gap-2 rounded-md px-3 py-2 text-sm no-underline"
-        activeProps={{ className: 'bg-black/5 dark:bg-white/10' }}
-      >
-        <Icon name="LayoutDashboard" className="h-4 w-4" />
-        Dashboard
-      </Link>
-
-      {MODULE_GROUPS.map((group) => (
-        <div key={group} className="mb-3">
-          <p className="px-3 pb-1 text-[11px] uppercase tracking-wide opacity-50">
-            {group}
-          </p>
-          {byGroup[group].map((m) => (
-            <Link
-              key={m.id}
-              to={m.path as LinkProps['to']}
-              className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm no-underline opacity-90"
-              activeProps={{
-                className: 'bg-black/5 dark:bg-white/10 opacity-100',
-              }}
-            >
-              <Icon name={m.icon} className="h-4 w-4" />
-              {m.label}
-            </Link>
-          ))}
-        </div>
-      ))}
-
-      <div className="mt-4 border-t pt-3">
+    <aside
+      className={
+        isDrawer
+          ? 'flex h-full flex-col gap-6 p-4'
+          : 'hidden h-svh w-66 shrink-0 flex-col gap-6 border-r border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_86%,transparent)] p-4 md:flex'
+      }
+      aria-label="Gather navigation"
+    >
+      <div className="flex min-h-11 items-center justify-between gap-3">
         <Link
-          to="/settings"
-          className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm no-underline opacity-90"
-          activeProps={{ className: 'bg-black/5 dark:bg-white/10' }}
+          to="/dashboard"
+          onClick={onNavigate}
+          className="flex min-w-0 items-center gap-2 no-underline"
         >
-          <Icon name="Settings" className="h-4 w-4" /> Settings
+          <span className="grid h-8 w-8 place-items-center rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] text-sm font-bold text-[var(--app-fg)]">
+            G
+          </span>
+          <span className="min-w-0">
+            <strong className="block truncate text-sm text-[var(--app-fg)]">
+              Gather
+            </strong>
+            <span className="block truncate text-xs text-[var(--app-muted)]">
+              Oak House
+            </span>
+          </span>
         </Link>
-        <Link
-          to="/groups"
-          className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm no-underline opacity-90"
-          activeProps={{ className: 'bg-black/5 dark:bg-white/10' }}
+        <button
+          type="button"
+          className="shell-icon-button"
+          aria-label="Create group item"
         >
-          <Icon name="Users" className="h-4 w-4" /> Groups
-        </Link>
+          <Icon name="Plus" className="h-4 w-4" />
+        </button>
       </div>
+
+      <nav className="grid gap-1" aria-label="Primary">
+        <p className="m-0 px-2 pb-1 text-[11px] font-semibold uppercase text-[var(--app-muted)]">
+          Today
+        </p>
+        {PRIMARY_AREAS.map((item) => (
+          <Link
+            key={item.id}
+            to={item.path as LinkProps['to']}
+            onClick={onNavigate}
+            className="grid min-h-10 grid-cols-[28px_minmax(0,1fr)] items-center gap-2 rounded-[var(--app-radius)] border border-transparent px-2 text-sm font-semibold text-[var(--app-fg)] no-underline"
+            activeProps={{
+              className:
+                'border-[var(--app-fg)] bg-[var(--app-surface)] text-[var(--app-fg)]',
+            }}
+          >
+            <span className="grid h-7 w-7 place-items-center rounded-[7px] border border-[var(--app-border)] bg-[var(--app-surface)] text-[var(--app-muted)]">
+              <Icon name={item.icon} className="h-4 w-4" />
+            </span>
+            <span className="truncate">{item.label}</span>
+          </Link>
+        ))}
+      </nav>
+
+      <nav className="grid gap-3" aria-label="Modules">
+        {MODULE_GROUPS.map((group) => (
+          <div key={group} className="grid gap-1">
+            <p className="m-0 px-2 pb-1 text-[11px] font-semibold uppercase text-[var(--app-muted)]">
+              {group}
+            </p>
+            {byGroup[group].map((module) => (
+              <Link
+                key={module.id}
+                to={module.path as LinkProps['to']}
+                onClick={onNavigate}
+                className="grid min-h-9 grid-cols-[28px_minmax(0,1fr)_auto] items-center gap-2 rounded-[var(--app-radius)] border border-transparent px-2 text-sm font-semibold text-[var(--app-fg)] no-underline"
+                activeProps={{
+                  className: 'border-[var(--app-fg)] bg-[var(--app-surface)]',
+                }}
+              >
+                <span className="grid h-7 w-7 place-items-center rounded-[7px] border border-[var(--app-border)] bg-[var(--app-surface)] text-[var(--app-muted)]">
+                  <Icon name={module.icon} className="h-4 w-4" />
+                </span>
+                <span className="truncate">{module.label}</span>
+                {module.status === 'placeholder' ? <Pill>Soon</Pill> : null}
+              </Link>
+            ))}
+          </div>
+        ))}
+      </nav>
+
+      <section className="mt-auto rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-3">
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <h2 className="m-0 text-sm font-semibold">Active group</h2>
+          <Pill tone="success">synced</Pill>
+        </div>
+        <AvatarStack members={['Alex', 'Maya']} />
+        <div className="mt-3 grid grid-cols-2 gap-2">
+          <Link
+            to="/groups"
+            onClick={onNavigate}
+            className="text-xs no-underline"
+          >
+            Groups
+          </Link>
+          <Link
+            to="/settings"
+            onClick={onNavigate}
+            className="text-xs no-underline"
+          >
+            Settings
+          </Link>
+        </div>
+      </section>
     </aside>
   )
 }

--- a/src/components/app/Topbar.tsx
+++ b/src/components/app/Topbar.tsx
@@ -1,45 +1,72 @@
 import { HeaderUser } from '@appelent/auth'
-import { Bug } from 'lucide-react'
-import { CommandPalette } from './CommandPalette'
-import { IssueReporterModal } from './IssueReporterModal'
+import { Bug, Menu, MessageSquare, Search } from 'lucide-react'
+import type { RouteContext } from '../../lib/appNavigation'
+import { IconButton, StatusDot } from './ShellPrimitives'
 
-export function Topbar() {
+export interface TopbarProps {
+  context: RouteContext
+  onOpenNavigation: () => void
+  onOpenGather: () => void
+}
+
+export function Topbar({
+  context,
+  onOpenNavigation,
+  onOpenGather,
+}: TopbarProps) {
   return (
-    <header className="flex items-center gap-3 border-b px-4 py-3 sm:px-8">
-      <button
-        type="button"
-        className="flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm opacity-70"
-        onClick={() => {
-          window.dispatchEvent(
-            new KeyboardEvent('keydown', { key: 'k', metaKey: true }),
-          )
-        }}
-      >
-        <span>Jump to…</span>
-        <kbd className="rounded border px-1 text-xs">⌘K</kbd>
-      </button>
-      <button
-        type="button"
-        aria-label="Report an issue"
-        title="Report an issue (Ctrl+Shift+I)"
-        className="rounded-md border p-1.5 opacity-70"
-        onClick={() => {
-          window.dispatchEvent(
-            new KeyboardEvent('keydown', {
-              key: 'i',
-              ctrlKey: true,
-              shiftKey: true,
-            }),
-          )
-        }}
-      >
-        <Bug className="h-4 w-4" />
-      </button>
-      <div className="ml-auto">
+    <header className="sticky top-0 z-20 flex min-h-16 items-center justify-between gap-3 border-b border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-bg)_86%,transparent)] px-3 backdrop-blur md:min-h-[72px] md:px-5">
+      <div className="flex min-w-0 items-center gap-3">
+        <IconButton
+          label="Open navigation"
+          onClick={onOpenNavigation}
+          className="md:hidden"
+        >
+          <Menu className="h-4 w-4" aria-hidden="true" />
+        </IconButton>
+        <div className="min-w-0">
+          <h1 className="m-0 truncate text-xl font-semibold leading-tight md:text-2xl">
+            {context.title}
+          </h1>
+          <p className="mt-1 hidden truncate text-sm text-[var(--app-muted)] sm:block">
+            {context.subtitle}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        <span className="hidden md:inline-flex">
+          <StatusDot label="Group synced" />
+        </span>
+        <IconButton
+          label="Jump to"
+          onClick={() => {
+            window.dispatchEvent(
+              new KeyboardEvent('keydown', { key: 'k', metaKey: true }),
+            )
+          }}
+        >
+          <Search className="h-4 w-4" aria-hidden="true" />
+        </IconButton>
+        <IconButton label="Ask Gather" onClick={onOpenGather}>
+          <MessageSquare className="h-4 w-4" aria-hidden="true" />
+        </IconButton>
+        <IconButton
+          label="Report an issue"
+          onClick={() => {
+            window.dispatchEvent(
+              new KeyboardEvent('keydown', {
+                key: 'i',
+                ctrlKey: true,
+                shiftKey: true,
+              }),
+            )
+          }}
+        >
+          <Bug className="h-4 w-4" aria-hidden="true" />
+        </IconButton>
         <HeaderUser />
       </div>
-      <CommandPalette />
-      <IssueReporterModal />
     </header>
   )
 }

--- a/src/components/app/Topbar.tsx
+++ b/src/components/app/Topbar.tsx
@@ -28,15 +28,18 @@ export function Topbar({
           <h1 className="m-0 truncate text-xl font-semibold leading-tight md:text-2xl">
             {context.title}
           </h1>
-          <p className="mt-1 hidden truncate text-sm text-[var(--app-muted)] sm:block">
+          <p className="mt-1 hidden truncate text-sm text-[var(--app-muted)] md:block">
             {context.subtitle}
+          </p>
+          <p className="mt-1 truncate text-sm text-[var(--app-muted)] md:hidden">
+            Preview group
           </p>
         </div>
       </div>
 
       <div className="flex shrink-0 items-center gap-2">
         <span className="hidden md:inline-flex">
-          <StatusDot label="Group synced" />
+          <StatusDot label="Preview mode" tone="muted" />
         </span>
         <IconButton
           label="Jump to"

--- a/src/components/recipes/RecipeForm.tsx
+++ b/src/components/recipes/RecipeForm.tsx
@@ -38,7 +38,7 @@ export function RecipeForm({ initial, submitting, onSubmit }: Props) {
 
   return (
     <form
-      className="mx-auto max-w-2xl space-y-4"
+      className="mx-auto grid max-w-2xl gap-4"
       onSubmit={(e) => {
         e.preventDefault()
         onSubmit({
@@ -54,7 +54,7 @@ export function RecipeForm({ initial, submitting, onSubmit }: Props) {
       <label className="block text-sm">
         <span className="mb-1 block font-medium">Title</span>
         <input
-          className="w-full rounded border px-2 py-1"
+          className="w-full rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)]"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           required
@@ -63,7 +63,7 @@ export function RecipeForm({ initial, submitting, onSubmit }: Props) {
       <label className="block text-sm">
         <span className="mb-1 block font-medium">Description</span>
         <textarea
-          className="w-full rounded border px-2 py-1"
+          className="w-full rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)]"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
@@ -71,7 +71,7 @@ export function RecipeForm({ initial, submitting, onSubmit }: Props) {
       <label className="block text-sm">
         <span className="mb-1 block font-medium">Ingredients</span>
         <textarea
-          className="h-28 w-full rounded border px-2 py-1"
+          className="h-32 w-full rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)]"
           value={ingredients}
           onChange={(e) => setIngredients(e.target.value)}
           placeholder="One per line"
@@ -80,7 +80,7 @@ export function RecipeForm({ initial, submitting, onSubmit }: Props) {
       <label className="block text-sm">
         <span className="mb-1 block font-medium">Steps</span>
         <textarea
-          className="h-28 w-full rounded border px-2 py-1"
+          className="h-32 w-full rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)]"
           value={steps}
           onChange={(e) => setSteps(e.target.value)}
           placeholder="One per line"
@@ -89,7 +89,7 @@ export function RecipeForm({ initial, submitting, onSubmit }: Props) {
       <label className="block text-sm">
         <span className="mb-1 block font-medium">Tags</span>
         <input
-          className="w-full rounded border px-2 py-1"
+          className="w-full rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)]"
           value={tags}
           onChange={(e) => setTags(e.target.value)}
           placeholder="comma, separated"
@@ -101,7 +101,7 @@ export function RecipeForm({ initial, submitting, onSubmit }: Props) {
           type="number"
           min="1"
           max="5"
-          className="w-24 rounded border px-2 py-1"
+          className="w-28 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)]"
           value={rating}
           onChange={(e) => setRating(e.target.value)}
         />
@@ -109,7 +109,7 @@ export function RecipeForm({ initial, submitting, onSubmit }: Props) {
       <button
         type="submit"
         disabled={submitting}
-        className="rounded-md border px-4 py-2 text-sm"
+        className="w-fit rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-4 py-2 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
       >
         {submitting ? 'Saving…' : 'Save recipe'}
       </button>

--- a/src/lib/appNavigation.test.ts
+++ b/src/lib/appNavigation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest'
+import {
+  getModulesByStatus,
+  getRouteContext,
+  isDockItemActive,
+  MOBILE_DOCK_ITEMS,
+  PRIMARY_AREAS,
+} from './appNavigation'
+
+describe('app navigation metadata', () => {
+  test('defines command-center primary areas without hard-coded household copy', () => {
+    expect(PRIMARY_AREAS.map((item) => item.label)).toEqual([
+      'Command Center',
+      'Tasks',
+      'Calendar',
+      'Modules',
+    ])
+    expect(PRIMARY_AREAS.map((item) => item.path)).toEqual([
+      '/dashboard',
+      '/tasks',
+      '/calendar',
+      '/dashboard#modules',
+    ])
+  })
+
+  test('defines the four stable mobile dock targets', () => {
+    expect(MOBILE_DOCK_ITEMS.map((item) => item.label)).toEqual([
+      'Home',
+      'Tasks',
+      'Calendar',
+      'Modules',
+    ])
+  })
+
+  test('derives route context for dashboard, module, and settings paths', () => {
+    expect(getRouteContext('/dashboard')).toMatchObject({
+      title: 'Command Center',
+      subtitle: 'A shared view of group plans, modules, and next actions.',
+    })
+    expect(getRouteContext('/recipes')).toMatchObject({
+      title: 'Recipes',
+      subtitle: 'Keep and rate the dishes you cook.',
+    })
+    expect(getRouteContext('/settings')).toMatchObject({
+      title: 'Settings',
+    })
+  })
+
+  test('computes mobile dock active states by route family', () => {
+    const home = MOBILE_DOCK_ITEMS[0]
+    const tasks = MOBILE_DOCK_ITEMS[1]
+    const modules = MOBILE_DOCK_ITEMS[3]
+
+    expect(isDockItemActive('/dashboard', home)).toBe(true)
+    expect(isDockItemActive('/tasks', tasks)).toBe(true)
+    expect(isDockItemActive('/recipes', modules)).toBe(true)
+    expect(isDockItemActive('/recipes/new', modules)).toBe(true)
+  })
+
+  test('splits modules by live and placeholder status', () => {
+    const byStatus = getModulesByStatus()
+    expect(byStatus.live.map((module) => module.id)).toEqual(['recipes'])
+    expect(byStatus.placeholder.length).toBeGreaterThan(0)
+  })
+})

--- a/src/lib/appNavigation.test.ts
+++ b/src/lib/appNavigation.test.ts
@@ -3,6 +3,7 @@ import {
   getModulesByStatus,
   getRouteContext,
   isDockItemActive,
+  isPrimaryAreaActive,
   MOBILE_DOCK_ITEMS,
   PRIMARY_AREAS,
 } from './appNavigation'
@@ -46,15 +47,47 @@ describe('app navigation metadata', () => {
     })
   })
 
-  test('computes mobile dock active states by route family', () => {
+  test('computes mobile dock active states by full location signal', () => {
     const home = MOBILE_DOCK_ITEMS[0]
     const tasks = MOBILE_DOCK_ITEMS[1]
     const modules = MOBILE_DOCK_ITEMS[3]
 
     expect(isDockItemActive('/dashboard', home)).toBe(true)
+    expect(isDockItemActive('/dashboard#modules', home)).toBe(false)
+    expect(isDockItemActive('/dashboard#modules', modules)).toBe(true)
+    const routerDashboardModules = { pathname: '/dashboard', hash: 'modules' }
+    expect(isDockItemActive(routerDashboardModules, home)).toBe(false)
+    expect(isDockItemActive(routerDashboardModules, modules)).toBe(true)
+    expect(
+      MOBILE_DOCK_ITEMS.filter((item) =>
+        isDockItemActive(routerDashboardModules, item),
+      ),
+    ).toEqual([modules])
     expect(isDockItemActive('/tasks', tasks)).toBe(true)
+    expect(isDockItemActive('/tasks', modules)).toBe(false)
     expect(isDockItemActive('/recipes', modules)).toBe(true)
     expect(isDockItemActive('/recipes/new', modules)).toBe(true)
+  })
+
+  test('keeps Command Center and Modules primary activation exclusive', () => {
+    const commandCenter = PRIMARY_AREAS[0]
+    const modules = PRIMARY_AREAS[3]
+
+    expect(
+      isPrimaryAreaActive({ pathname: '/dashboard', hash: '' }, commandCenter),
+    ).toBe(true)
+    expect(
+      isPrimaryAreaActive({ pathname: '/dashboard', hash: '' }, modules),
+    ).toBe(false)
+    expect(
+      isPrimaryAreaActive(
+        { pathname: '/dashboard', hash: 'modules' },
+        commandCenter,
+      ),
+    ).toBe(false)
+    expect(
+      isPrimaryAreaActive({ pathname: '/dashboard', hash: 'modules' }, modules),
+    ).toBe(true)
   })
 
   test('splits modules by live and placeholder status', () => {

--- a/src/lib/appNavigation.ts
+++ b/src/lib/appNavigation.ts
@@ -15,6 +15,8 @@ export interface MobileDockItem {
   icon: string
   path: string
   activePaths: string[]
+  activeHash?: string
+  inactiveHash?: string
 }
 
 export interface RouteContext {
@@ -60,6 +62,7 @@ export const MOBILE_DOCK_ITEMS: MobileDockItem[] = [
     icon: 'Home',
     path: '/dashboard',
     activePaths: ['/dashboard'],
+    inactiveHash: '#modules',
   },
   {
     id: 'tasks',
@@ -80,7 +83,10 @@ export const MOBILE_DOCK_ITEMS: MobileDockItem[] = [
     label: 'Modules',
     icon: 'Grid2X2',
     path: '/dashboard#modules',
-    activePaths: MODULES.map((module) => module.path),
+    activePaths: MODULES.filter(
+      (module) => !['/tasks', '/calendar'].includes(module.path),
+    ).map((module) => module.path),
+    activeHash: '#modules',
   },
 ]
 
@@ -127,13 +133,47 @@ export function getRouteContext(pathname: string): RouteContext {
 }
 
 export function isDockItemActive(
-  pathname: string,
+  location: string | { pathname: string; hash?: string },
   item: MobileDockItem,
 ): boolean {
-  const normalized = normalizePath(pathname)
+  const { pathname, hash } = normalizeLocation(location)
+
+  if (
+    item.activeHash &&
+    pathname === '/dashboard' &&
+    hash === item.activeHash
+  ) {
+    return true
+  }
+
+  if (
+    item.inactiveHash &&
+    pathname === '/dashboard' &&
+    hash === item.inactiveHash
+  ) {
+    return false
+  }
+
   return item.activePaths.some(
-    (path) => normalized === path || normalized.startsWith(`${path}/`),
+    (path) => pathname === path || pathname.startsWith(`${path}/`),
   )
+}
+
+export function isPrimaryAreaActive(
+  location: string | { pathname: string; hash?: string },
+  item: PrimaryArea,
+): boolean {
+  const { pathname, hash } = normalizeLocation(location)
+
+  if (item.id === 'modules') {
+    return pathname === '/dashboard' && hash === '#modules'
+  }
+
+  if (item.id === 'command-center') {
+    return pathname === '/dashboard' && hash !== '#modules'
+  }
+
+  return pathname === item.path || pathname.startsWith(`${item.path}/`)
 }
 
 export function getModulesByStatus(): {
@@ -152,4 +192,22 @@ function normalizePath(pathname: string) {
     return withoutHash.slice(0, -1)
   }
   return withoutHash || '/dashboard'
+}
+
+function normalizeLocation(
+  location: string | { pathname: string; hash?: string },
+) {
+  if (typeof location === 'string') {
+    const [pathname, hash = ''] = location.split('#')
+    return { pathname: normalizePath(pathname), hash: hash ? `#${hash}` : '' }
+  }
+
+  return {
+    pathname: normalizePath(location.pathname),
+    hash: normalizeHash(location.hash ?? ''),
+  }
+}
+
+function normalizeHash(hash: string) {
+  return hash ? (hash.startsWith('#') ? hash : `#${hash}`) : ''
 }

--- a/src/lib/appNavigation.ts
+++ b/src/lib/appNavigation.ts
@@ -1,0 +1,155 @@
+import type { ModuleDef } from './modules'
+import { MODULES } from './modules'
+
+export interface PrimaryArea {
+  id: 'command-center' | 'tasks' | 'calendar' | 'modules'
+  label: string
+  icon: string
+  path: string
+  description: string
+}
+
+export interface MobileDockItem {
+  id: 'home' | 'tasks' | 'calendar' | 'modules'
+  label: string
+  icon: string
+  path: string
+  activePaths: string[]
+}
+
+export interface RouteContext {
+  title: string
+  subtitle: string
+}
+
+export const PRIMARY_AREAS: PrimaryArea[] = [
+  {
+    id: 'command-center',
+    label: 'Command Center',
+    icon: 'MessagesSquare',
+    path: '/dashboard',
+    description: 'Group overview and next actions.',
+  },
+  {
+    id: 'tasks',
+    label: 'Tasks',
+    icon: 'ListChecks',
+    path: '/tasks',
+    description: 'Shared to-dos and recurring responsibilities.',
+  },
+  {
+    id: 'calendar',
+    label: 'Calendar',
+    icon: 'Calendar',
+    path: '/calendar',
+    description: 'Upcoming group events and reminders.',
+  },
+  {
+    id: 'modules',
+    label: 'Modules',
+    icon: 'Grid2X2',
+    path: '/dashboard#modules',
+    description: 'All connected group modules.',
+  },
+]
+
+export const MOBILE_DOCK_ITEMS: MobileDockItem[] = [
+  {
+    id: 'home',
+    label: 'Home',
+    icon: 'Home',
+    path: '/dashboard',
+    activePaths: ['/dashboard'],
+  },
+  {
+    id: 'tasks',
+    label: 'Tasks',
+    icon: 'ListChecks',
+    path: '/tasks',
+    activePaths: ['/tasks'],
+  },
+  {
+    id: 'calendar',
+    label: 'Calendar',
+    icon: 'Calendar',
+    path: '/calendar',
+    activePaths: ['/calendar'],
+  },
+  {
+    id: 'modules',
+    label: 'Modules',
+    icon: 'Grid2X2',
+    path: '/dashboard#modules',
+    activePaths: MODULES.map((module) => module.path),
+  },
+]
+
+const STATIC_ROUTE_CONTEXT: Record<string, RouteContext> = {
+  '/dashboard': {
+    title: 'Command Center',
+    subtitle: 'A shared view of group plans, modules, and next actions.',
+  },
+  '/groups': {
+    title: 'Groups',
+    subtitle: 'Manage sharing, membership, and active group setup.',
+  },
+  '/settings': {
+    title: 'Settings',
+    subtitle: 'Tune appearance and app preferences.',
+  },
+  '/account': {
+    title: 'Account',
+    subtitle: 'Manage your profile and sign-in details.',
+  },
+}
+
+export function getRouteContext(pathname: string): RouteContext {
+  const normalized = normalizePath(pathname)
+  const staticContext = STATIC_ROUTE_CONTEXT[normalized]
+  if (staticContext) return staticContext
+
+  const module = MODULES.find(
+    (item) =>
+      normalized === item.path || normalized.startsWith(`${item.path}/`),
+  )
+
+  if (module) {
+    return {
+      title: module.label,
+      subtitle: module.description,
+    }
+  }
+
+  return {
+    title: 'Gather',
+    subtitle: 'Group plans, modules, and shared context.',
+  }
+}
+
+export function isDockItemActive(
+  pathname: string,
+  item: MobileDockItem,
+): boolean {
+  const normalized = normalizePath(pathname)
+  return item.activePaths.some(
+    (path) => normalized === path || normalized.startsWith(`${path}/`),
+  )
+}
+
+export function getModulesByStatus(): {
+  live: ModuleDef[]
+  placeholder: ModuleDef[]
+} {
+  return {
+    live: MODULES.filter((module) => module.status === 'live'),
+    placeholder: MODULES.filter((module) => module.status === 'placeholder'),
+  }
+}
+
+function normalizePath(pathname: string) {
+  const withoutHash = pathname.split('#')[0]
+  if (withoutHash.length > 1 && withoutHash.endsWith('/')) {
+    return withoutHash.slice(0, -1)
+  }
+  return withoutHash || '/dashboard'
+}

--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -2,8 +2,7 @@ import { createFileRoute, Outlet, useNavigate } from '@tanstack/react-router'
 import { useConvexAuth, useMutation } from 'convex/react'
 import { useEffect } from 'react'
 import { api } from '../../convex/_generated/api'
-import { Sidebar } from '../components/app/Sidebar'
-import { Topbar } from '../components/app/Topbar'
+import { AppShell } from '../components/app/AppShell'
 
 export const Route = createFileRoute('/_app')({
   component: AppLayout,
@@ -34,14 +33,8 @@ function AppLayout() {
   if (!isAuthenticated) return null
 
   return (
-    <div className="flex min-h-svh">
-      <Sidebar />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <Topbar />
-        <main className="min-w-0 flex-1 px-4 py-6 sm:px-8">
-          <Outlet />
-        </main>
-      </div>
-    </div>
+    <AppShell>
+      <Outlet />
+    </AppShell>
   )
 }

--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -25,8 +25,8 @@ function AppLayout() {
 
   if (isLoading) {
     return (
-      <div className="grid min-h-svh place-items-center text-sm opacity-60">
-        Loading…
+      <div className="app-shell grid min-h-svh place-items-center text-sm text-[var(--app-muted)]">
+        Loading...
       </div>
     )
   }

--- a/src/routes/_app/dashboard.tsx
+++ b/src/routes/_app/dashboard.tsx
@@ -1,40 +1,10 @@
-import type { LinkProps } from '@tanstack/react-router'
-import { createFileRoute, Link } from '@tanstack/react-router'
-import type { LucideIcon } from 'lucide-react'
-import * as Icons from 'lucide-react'
-import { MODULES } from '../../lib/modules'
+import { createFileRoute } from '@tanstack/react-router'
+import { CommandFeed } from '../../components/app/CommandFeed'
 
 export const Route = createFileRoute('/_app/dashboard')({
   component: Dashboard,
 })
 
 function Dashboard() {
-  return (
-    <div>
-      <h1 className="mb-6 text-2xl font-semibold">Welcome to gather</h1>
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-        {MODULES.map((m) => {
-          const Icon =
-            (Icons as unknown as Record<string, LucideIcon>)[m.icon] ??
-            Icons.Square
-          return (
-            <Link
-              key={m.id}
-              to={m.path as LinkProps['to']}
-              className="flex flex-col gap-2 rounded-xl border p-4 no-underline transition hover:bg-black/5 dark:hover:bg-white/10"
-            >
-              <Icon className="h-6 w-6 opacity-80" aria-hidden="true" />
-              <span className="font-medium">{m.label}</span>
-              <span className="text-xs opacity-60">{m.description}</span>
-              {m.status === 'placeholder' && (
-                <span className="mt-1 w-fit rounded-full border px-2 text-[10px] uppercase opacity-50">
-                  Soon
-                </span>
-              )}
-            </Link>
-          )
-        })}
-      </div>
-    </div>
-  )
+  return <CommandFeed />
 }

--- a/src/routes/_app/recipes/index.tsx
+++ b/src/routes/_app/recipes/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useQuery } from 'convex/react'
+import { Plus } from 'lucide-react'
 import { api } from '../../../../convex/_generated/api'
+import { Pill, SurfaceCard } from '../../../components/app/ShellPrimitives'
 
 export const Route = createFileRoute('/_app/recipes/')({
   component: RecipeList,
@@ -10,52 +12,72 @@ function RecipeList() {
   const recipes = useQuery(api.recipes.list)
 
   return (
-    <div>
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Recipes</h1>
+    <div className="mx-auto grid max-w-5xl gap-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="m-0 text-2xl font-semibold">Recipes</h2>
+          <p className="mt-1 text-sm text-[var(--app-muted)]">
+            Keep and rate the dishes this group cooks.
+          </p>
+        </div>
         <Link
           to="/recipes/new"
-          className="rounded-md border px-3 py-1.5 text-sm no-underline"
+          className="inline-flex min-h-9 items-center gap-2 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 text-sm font-semibold text-[var(--app-fg)] no-underline"
         >
+          <Plus className="h-4 w-4" aria-hidden="true" />
           Add recipe
         </Link>
       </div>
 
       {recipes === undefined ? (
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-          {[0, 1, 2].map((i) => (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {[0, 1, 2].map((index) => (
             <div
-              key={i}
-              className="h-32 animate-pulse rounded-xl border bg-black/5"
+              key={index}
+              className="h-32 animate-pulse rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface-muted)]"
             />
           ))}
         </div>
       ) : recipes.length === 0 ? (
-        <div className="rounded-xl border p-10 text-center">
-          <p className="mb-3 text-sm opacity-70">No recipes yet.</p>
-          <Link
-            to="/recipes/new"
-            className="rounded-md border px-3 py-1.5 text-sm no-underline"
-          >
-            Add your first recipe
-          </Link>
-        </div>
-      ) : (
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-          {recipes.map((r) => (
+        <SurfaceCard>
+          <div className="grid gap-3 text-center">
+            <h3 className="m-0 text-base font-semibold">No recipes yet</h3>
+            <p className="m-0 text-sm text-[var(--app-muted)]">
+              Add the first recipe to make this module useful for the group.
+            </p>
             <Link
-              key={r._id}
-              to="/recipes/$recipeId"
-              params={{ recipeId: r._id }}
-              className="rounded-xl border p-4 no-underline transition hover:bg-black/5 dark:hover:bg-white/10"
+              to="/recipes/new"
+              className="mx-auto inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold no-underline"
             >
-              <p className="font-medium">{r.title}</p>
-              {r.rating != null && (
-                <p className="text-xs opacity-60">{'★'.repeat(r.rating)}</p>
-              )}
-              {r.tags.length > 0 && (
-                <p className="mt-1 text-xs opacity-50">{r.tags.join(', ')}</p>
-              )}
+              Add your first recipe
+            </Link>
+          </div>
+        </SurfaceCard>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {recipes.map((recipe) => (
+            <Link
+              key={recipe._id}
+              to="/recipes/$recipeId"
+              params={{ recipeId: recipe._id }}
+              className="grid min-h-32 gap-3 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-3 text-[var(--app-fg)] no-underline hover:border-[var(--app-fg)]"
+            >
+              <div>
+                <h3 className="m-0 text-sm font-semibold">{recipe.title}</h3>
+                {recipe.description ? (
+                  <p className="mt-1 line-clamp-2 text-xs leading-5 text-[var(--app-muted)]">
+                    {recipe.description}
+                  </p>
+                ) : null}
+              </div>
+              <div className="flex flex-wrap items-center gap-2 self-end">
+                {recipe.rating != null ? (
+                  <Pill>{'★'.repeat(recipe.rating)}</Pill>
+                ) : null}
+                {recipe.tags.slice(0, 3).map((tag) => (
+                  <Pill key={tag}>{tag}</Pill>
+                ))}
+              </div>
             </Link>
           ))}
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -9,6 +9,17 @@
 }
 
 :root {
+  --app-bg: oklch(99% 0.002 240);
+  --app-surface: oklch(100% 0 0);
+  --app-surface-muted: oklch(97% 0.004 250);
+  --app-fg: oklch(18% 0.012 250);
+  --app-muted: oklch(54% 0.012 250);
+  --app-border: oklch(92% 0.005 250);
+  --app-accent: oklch(58% 0.18 255);
+  --app-success: oklch(58% 0.14 150);
+  --app-warning: oklch(70% 0.14 75);
+  --app-danger: oklch(62% 0.16 25);
+  --app-radius: 8px;
   --sea-ink: #173a40;
   --sea-ink-soft: #416166;
   --lagoon: #4fb8b2;
@@ -31,6 +42,16 @@
 }
 
 :root[data-theme="dark"] {
+  --app-bg: oklch(16% 0.012 250);
+  --app-surface: oklch(20% 0.012 250);
+  --app-surface-muted: oklch(24% 0.012 250);
+  --app-fg: oklch(94% 0.006 250);
+  --app-muted: oklch(70% 0.012 250);
+  --app-border: oklch(31% 0.012 250);
+  --app-accent: oklch(70% 0.16 255);
+  --app-success: oklch(72% 0.13 150);
+  --app-warning: oklch(78% 0.12 75);
+  --app-danger: oklch(72% 0.13 25);
   --sea-ink: #d7ece8;
   --sea-ink-soft: #afcdc8;
   --lagoon: #60d7cf;
@@ -76,6 +97,7 @@
   }
 }
 
+
 /* @appelent/auth brand overrides — bridge the shared auth UI onto gather's
    sea/lagoon palette. These reference gather's own theme vars (already
    correctly re-themed via :root[data-theme="dark"] / prefers-color-scheme),
@@ -91,6 +113,146 @@
   --auth-accent: var(--lagoon-deep);
   --auth-accent-fg: var(--foam);
   --auth-error: #c14747;
+}
+
+.app-shell {
+  min-height: 100svh;
+  background: var(--app-bg);
+  color: var(--app-fg);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+}
+
+.shell-card {
+  border: 1px solid var(--app-border);
+  border-radius: var(--app-radius);
+  background: var(--app-surface);
+  padding: 0.875rem;
+}
+
+.shell-icon-button {
+  display: inline-grid;
+  place-items: center;
+  inline-size: 2.25rem;
+  block-size: 2.25rem;
+  border: 1px solid var(--app-border);
+  border-radius: var(--app-radius);
+  background: var(--app-surface);
+  color: var(--app-fg);
+}
+
+.shell-icon-button:hover {
+  border-color: var(--app-fg);
+}
+
+.shell-pill {
+  display: inline-flex;
+  min-height: 1.5rem;
+  align-items: center;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  padding: 0.25rem 0.5rem;
+  color: var(--app-muted);
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.shell-pill-dark {
+  border-color: var(--app-fg);
+  background: var(--app-fg);
+  color: var(--app-surface);
+}
+
+.shell-pill-success {
+  border-color: color-mix(in oklch, var(--app-success) 45%, var(--app-border));
+  color: var(--app-success);
+}
+
+.shell-pill-warning {
+  border-color: color-mix(in oklch, var(--app-warning) 45%, var(--app-border));
+  color: var(--app-warning);
+}
+
+.shell-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.shell-section-header h2 {
+  margin: 0;
+  color: var(--app-fg);
+  font-size: 0.8125rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.shell-eyebrow {
+  margin: 0 0 0.25rem;
+  color: var(--app-muted);
+  font-size: 0.6875rem;
+  font-weight: 650;
+  text-transform: uppercase;
+}
+
+.shell-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--app-muted);
+  font-size: 0.8125rem;
+}
+
+.shell-status-dot {
+  inline-size: 0.4375rem;
+  block-size: 0.4375rem;
+  border-radius: 999px;
+}
+
+.shell-status-dot-success {
+  background: var(--app-success);
+}
+
+.shell-status-dot-warning {
+  background: var(--app-warning);
+}
+
+.shell-status-dot-muted {
+  background: var(--app-muted);
+}
+
+.shell-avatar-stack {
+  display: flex;
+  align-items: center;
+  min-inline-size: 0;
+  margin: 0;
+  border: 0;
+  padding: 0;
+}
+
+.shell-avatar {
+  display: inline-grid;
+  place-items: center;
+  inline-size: 1.875rem;
+  block-size: 1.875rem;
+  margin-inline-start: -0.4375rem;
+  border: 2px solid var(--app-surface);
+  border-radius: 999px;
+  background: var(--app-surface-muted);
+  color: var(--app-fg);
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.shell-avatar:first-child {
+  margin-inline-start: 0;
+}
+
+.shell-avatar-more {
+  color: var(--app-muted);
 }
 
 * {
@@ -506,4 +668,3 @@ a {
     font-size: 16px !important;
   }
 }
-


### PR DESCRIPTION
## What changed
- redesign the authenticated Gather experience into a responsive command-center shell
- add a richer dashboard feed with activity, upcoming, suggested actions, and module summaries
- keep Gather chat entry points available from the dashboard and content pages
- tighten mobile and hash-based navigation behavior, including drawer dismissal, inspector breakpoints, and dock/sidebar active states
- replace fabricated household-specific shell data with explicit preview copy for groups

## Why
The redesign needed to move beyond a household-only shell and toward a scalable group command center that works on mobile and content pages, while still being honest about which surfaces are preview-only.

## Impact
- dashboard and in-app navigation now feel like a cohesive product surface instead of a module launcher
- groups are treated as the organizing concept instead of hard-coded household copy
- mobile behavior is more reliable and accessible

## Validation
- `pnpm test`
- `pnpm run check`
- `pnpm run typecheck`
- `git diff --check --cached`
- `node_modules\\.bin\\vite.cmd build` (build succeeded; Wrangler emitted the known sandbox log-write warning after completion)