### PR TITLE
Unify public pages around the Gather command-center frame

### DIFF
--- a/src/components/app/PublicPageFrame.test.tsx
+++ b/src/components/app/PublicPageFrame.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { PublicPageFrame } from './PublicPageFrame'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    className,
+  }: {
+    children: React.ReactNode
+    to: string
+    className?: string
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}))
+
+test('renders public pages in the command-center visual system', () => {
+  render(
+    <PublicPageFrame eyebrow="Public" title="Welcome back" subtitle="Sign in.">
+      <form aria-label="Auth form" />
+    </PublicPageFrame>,
+  )
+
+  expect(screen.getByText('Gather')).toBeDefined()
+  expect(screen.getByText('Command center')).toBeDefined()
+  expect(screen.getByRole('heading', { name: 'Welcome back' })).toBeDefined()
+  expect(screen.getByLabelText('Auth form')).toBeDefined()
+  expect(screen.getByRole('main').className).toContain('app-shell')
+  expect(screen.getByRole('main').className).not.toContain('island-shell')
+})

--- a/src/components/app/PublicPageFrame.tsx
+++ b/src/components/app/PublicPageFrame.tsx
@@ -1,0 +1,62 @@
+import { Link } from '@tanstack/react-router'
+import type { ReactNode } from 'react'
+
+interface PublicPageFrameProps {
+  eyebrow: string
+  title: string
+  subtitle: string
+  children: ReactNode
+  actions?: ReactNode
+}
+
+export function PublicPageFrame({
+  eyebrow,
+  title,
+  subtitle,
+  children,
+  actions,
+}: PublicPageFrameProps) {
+  return (
+    <main className="app-shell grid min-h-svh grid-rows-[auto_1fr] bg-[var(--app-bg)] text-[var(--app-fg)]">
+      <header className="border-b border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_88%,transparent)]">
+        <div className="mx-auto flex min-h-14 w-full max-w-6xl items-center justify-between gap-4 px-4 md:px-6">
+          <Link
+            to="/dashboard"
+            className="flex min-w-0 items-center gap-2 text-[var(--app-fg)] no-underline"
+          >
+            <span className="grid h-8 w-8 place-items-center rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] text-sm font-bold">
+              G
+            </span>
+            <span className="min-w-0">
+              <strong className="block truncate text-sm">Gather</strong>
+              <span className="block truncate text-xs text-[var(--app-muted)]">
+                Command center
+              </span>
+            </span>
+          </Link>
+          {actions ? (
+            <nav className="flex items-center gap-3 text-sm font-semibold">
+              {actions}
+            </nav>
+          ) : null}
+        </div>
+      </header>
+      <div className="mx-auto grid w-full max-w-6xl items-center px-4 py-8 md:px-6 md:py-12">
+        <section className="mx-auto grid w-full max-w-md gap-4">
+          <div className="shell-card grid gap-4 p-5 md:p-6">
+            <div>
+              <p className="shell-eyebrow">{eyebrow}</p>
+              <h1 className="m-0 text-2xl font-semibold tracking-normal text-[var(--app-fg)]">
+                {title}
+              </h1>
+              <p className="mt-2 mb-0 text-sm leading-6 text-[var(--app-muted)]">
+                {subtitle}
+              </p>
+            </div>
+            {children}
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/src/routes/-public-pages.test.tsx
+++ b/src/routes/-public-pages.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { NotFoundPage } from './__root'
+import { AboutPage } from './about'
+
+vi.mock('@tanstack/react-router', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-router')>(
+    '@tanstack/react-router',
+  )
+  return {
+    ...actual,
+    createFileRoute: () => (options: unknown) => ({ options }),
+    createRootRouteWithContext: () => () => (options: unknown) => ({
+      options,
+    }),
+    Link: ({
+      children,
+      to,
+      className,
+    }: {
+      children: React.ReactNode
+      to: string
+      className?: string
+    }) => (
+      <a href={to} className={className}>
+        {children}
+      </a>
+    ),
+  }
+})
+
+vi.mock('@appelent/auth', () => ({
+  AuthConfigProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  THEME_INIT_SCRIPT: '',
+  ThemeSync: () => null,
+}))
+
+vi.mock('@tanstack/react-devtools', () => ({
+  TanStackDevtools: () => null,
+}))
+
+vi.mock('@tanstack/react-router-devtools', () => ({
+  TanStackRouterDevtoolsPanel: () => null,
+}))
+
+vi.mock('../integrations/clerk/provider', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../integrations/convex/provider', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../integrations/tanstack-query/devtools', () => ({
+  default: {},
+}))
+
+test('about page uses Gather-specific copy in the public frame', () => {
+  render(<AboutPage />)
+
+  expect(screen.getByText('Gather')).toBeDefined()
+  expect(
+    screen.getByRole('heading', { name: /group command center/i }),
+  ).toBeDefined()
+  expect(screen.queryByText(/small starter/i)).toBeNull()
+  expect(screen.queryByText(/TanStack Start/i)).toBeNull()
+})
+
+test('not found page is styled and gives a recovery path', () => {
+  render(<NotFoundPage />)
+
+  expect(screen.getByText('Gather')).toBeDefined()
+  expect(screen.getByRole('heading', { name: /page not found/i })).toBeDefined()
+  expect(screen.getByRole('link', { name: /go to dashboard/i })).toBeDefined()
+  expect(screen.getByRole('main').textContent?.trim()).not.toBe('Not Found')
+})

--- a/src/routes/-sign-in.test.tsx
+++ b/src/routes/-sign-in.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { SignInPage } from './sign-in'
+
+const authState = vi.hoisted(() => ({
+  isLoaded: true,
+  isSignedIn: false,
+}))
+
+const navigateMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@clerk/clerk-react', () => ({
+  useAuth: () => authState,
+}))
+
+vi.mock('@appelent/auth', () => ({
+  SignInForm: ({ onSuccess }: { onSuccess: () => void }) => (
+    <section aria-label="Sign in form">
+      <button type="button" onClick={onSuccess}>
+        Sign in
+      </button>
+      <button type="button">▶ Dev: log in as test user</button>
+    </section>
+  ),
+  TestLoginButton: ({ onSuccess }: { onSuccess: () => void }) => (
+    <button type="button" onClick={onSuccess}>
+      ▶ Dev: log in as test user
+    </button>
+  ),
+  useAuthConfig: () => ({ paths: { afterAuth: '/dashboard' } }),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: unknown) => ({ options }),
+  Link: ({
+    children,
+    to,
+    className,
+  }: {
+    children: React.ReactNode
+    to: string
+    className?: string
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => navigateMock,
+}))
+
+test('renders one dev login button from the sign-in form', () => {
+  authState.isLoaded = true
+  authState.isSignedIn = false
+
+  render(<SignInPage />)
+
+  expect(
+    screen.getAllByRole('button', { name: '▶ Dev: log in as test user' }),
+  ).toHaveLength(1)
+})
+
+test('redirects signed-in users away from the sign-in page', () => {
+  authState.isLoaded = true
+  authState.isSignedIn = true
+  navigateMock.mockClear()
+
+  render(<SignInPage />)
+
+  expect(navigateMock).toHaveBeenCalledWith({ to: '/dashboard' })
+})
+
+test('keeps form success navigation to the post-auth route', () => {
+  authState.isLoaded = true
+  authState.isSignedIn = false
+  navigateMock.mockClear()
+
+  render(<SignInPage />)
+  fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+
+  expect(navigateMock).toHaveBeenCalledWith({ to: '/dashboard' })
+})

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -9,10 +9,12 @@ import type { QueryClient } from '@tanstack/react-query'
 import {
   createRootRouteWithContext,
   HeadContent,
+  Link,
   Scripts,
 } from '@tanstack/react-router'
 import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
 import { useEffect } from 'react'
+import { PublicPageFrame } from '../components/app/PublicPageFrame'
 import ClerkProvider from '../integrations/clerk/provider'
 import ConvexProvider from '../integrations/convex/provider'
 import TanStackQueryDevtools from '../integrations/tanstack-query/devtools'
@@ -52,7 +54,36 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
     ],
   }),
   shellComponent: RootDocument,
+  notFoundComponent: NotFoundPage,
 })
+
+export function NotFoundPage() {
+  return (
+    <PublicPageFrame
+      eyebrow="Not found"
+      title="Page not found"
+      subtitle="This route is not part of the current Gather workspace."
+      actions={
+        <Link to="/sign-in" className="text-[var(--app-muted)] no-underline">
+          Sign in
+        </Link>
+      }
+    >
+      <div className="grid gap-4">
+        <p className="m-0 text-sm leading-6 text-[var(--app-muted)]">
+          The page may have moved, or the link may point to a module that has
+          not been added yet.
+        </p>
+        <Link
+          to="/dashboard"
+          className="inline-flex min-h-10 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-3 text-sm font-semibold text-[var(--app-surface)] no-underline"
+        >
+          Go to dashboard
+        </Link>
+      </div>
+    </PublicPageFrame>
+  )
+}
 
 function RootDocument({ children }: { children: React.ReactNode }) {
   useEffect(() => {

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,23 +1,29 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { PublicPageFrame } from '../components/app/PublicPageFrame'
 
 export const Route = createFileRoute('/about')({
-  component: About,
+  component: AboutPage,
 })
 
-function About() {
+export function AboutPage() {
   return (
-    <main className="page-wrap px-4 py-12">
-      <section className="island-shell rounded-2xl p-6 sm:p-8">
-        <p className="island-kicker mb-2">About</p>
-        <h1 className="display-title mb-3 text-4xl font-bold text-[var(--sea-ink)] sm:text-5xl">
-          A small starter with room to grow.
-        </h1>
-        <p className="m-0 max-w-3xl text-base leading-8 text-[var(--sea-ink-soft)]">
-          TanStack Start gives you type-safe routing, server functions, and
-          modern SSR defaults. Use this as a clean foundation, then layer in
-          your own routes, styling, and add-ons.
+    <PublicPageFrame
+      eyebrow="About Gather"
+      title="A group command center for everyday coordination"
+      subtitle="Gather keeps shared recipes, plans, lists, tasks, notes, and tasting logs in one compact workspace for the people who coordinate together."
+    >
+      <div className="grid gap-3 text-sm leading-6 text-[var(--app-muted)]">
+        <p className="m-0">
+          Recipes are live today, and the surrounding modules are staged so a
+          group can grow into meal planning, groceries, pantry tracking,
+          finances, bills, tasks, calendar, notes, cheeses, and wines without
+          changing products.
         </p>
-      </section>
-    </main>
+        <p className="m-0">
+          The command center brings those modules together as a shared view of
+          what is active, what is planned, and what needs attention next.
+        </p>
+      </div>
+    </PublicPageFrame>
   )
 }

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -1,18 +1,23 @@
 import { ForgotPasswordForm, useAuthConfig } from '@appelent/auth'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { PublicPageFrame } from '../components/app/PublicPageFrame'
 
 export const Route = createFileRoute('/forgot-password')({
   component: ForgotPasswordPage,
 })
 
-function ForgotPasswordPage() {
+export function ForgotPasswordPage() {
   const navigate = useNavigate()
   const { paths } = useAuthConfig()
   const onSuccess = () => navigate({ to: paths.signIn })
 
   return (
-    <main className="mx-auto flex min-h-svh max-w-md flex-col justify-center px-4">
+    <PublicPageFrame
+      eyebrow="Account recovery"
+      title="Reset your password"
+      subtitle="Send a recovery code and get back to your group workspace."
+    >
       <ForgotPasswordForm onSuccess={onSuccess} />
-    </main>
+    </PublicPageFrame>
   )
 }

--- a/src/routes/sign-in.tsx
+++ b/src/routes/sign-in.tsx
@@ -1,17 +1,43 @@
-import { SignInForm, TestLoginButton, useAuthConfig } from '@appelent/auth'
+import { SignInForm, useAuthConfig } from '@appelent/auth'
+import { useAuth } from '@clerk/clerk-react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { useCallback, useEffect } from 'react'
+import { PublicPageFrame } from '../components/app/PublicPageFrame'
 
 export const Route = createFileRoute('/sign-in')({ component: SignInPage })
 
-function SignInPage() {
+export function SignInPage() {
   const navigate = useNavigate()
   const { paths } = useAuthConfig()
-  const onSuccess = () => navigate({ to: paths.afterAuth })
+  const { isLoaded, isSignedIn } = useAuth()
+  const onSuccess = useCallback(
+    () => navigate({ to: paths.afterAuth }),
+    [navigate, paths.afterAuth],
+  )
+
+  useEffect(() => {
+    if (isLoaded && isSignedIn) onSuccess()
+  }, [isLoaded, isSignedIn, onSuccess])
+
+  if (isLoaded && isSignedIn) {
+    return (
+      <PublicPageFrame
+        eyebrow="Signed in"
+        title="Opening Gather"
+        subtitle="Taking you to the command center."
+      >
+        <p className="m-0 text-sm text-[var(--app-muted)]">Redirecting...</p>
+      </PublicPageFrame>
+    )
+  }
 
   return (
-    <main className="mx-auto flex min-h-svh max-w-md flex-col justify-center px-4">
+    <PublicPageFrame
+      eyebrow="Sign in"
+      title="Welcome back"
+      subtitle="Use your Gather account to open the command center."
+    >
       <SignInForm onSuccess={onSuccess} />
-      <TestLoginButton onSuccess={onSuccess} />
-    </main>
+    </PublicPageFrame>
   )
 }

--- a/src/routes/sign-up.tsx
+++ b/src/routes/sign-up.tsx
@@ -1,16 +1,21 @@
 import { SignUpForm, useAuthConfig } from '@appelent/auth'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { PublicPageFrame } from '../components/app/PublicPageFrame'
 
 export const Route = createFileRoute('/sign-up')({ component: SignUpPage })
 
-function SignUpPage() {
+export function SignUpPage() {
   const navigate = useNavigate()
   const { paths } = useAuthConfig()
   const onSuccess = () => navigate({ to: paths.afterAuth })
 
   return (
-    <main className="mx-auto flex min-h-svh max-w-md flex-col justify-center px-4">
+    <PublicPageFrame
+      eyebrow="Create account"
+      title="Start using Gather"
+      subtitle="Create your account and set up a shared command center."
+    >
       <SignUpForm onSuccess={onSuccess} />
-    </main>
+    </PublicPageFrame>
   )
 }


### PR DESCRIPTION
## Summary
- Introduce a shared `PublicPageFrame` for sign-in, sign-up, password recovery, about, and not-found pages.
- Update public-facing copy and layout to match the Gather command-center brand.
- Redirect already signed-in users away from the sign-in page.
- Add route/component tests covering the new public page frame, page copy, not-found recovery path, and sign-in behavior.

## Testing
- Added unit tests for the shared frame and public routes.
- Verified signed-in redirect behavior and form success navigation in the sign-in flow.
- Not run (not requested)