### PR TITLE
Add breastfeed duration, multi-entry logging and chronological PDF

### DIFF
--- a/convex/lib/babyEvents.test.ts
+++ b/convex/lib/babyEvents.test.ts
@@ -20,6 +20,21 @@ describe('isValidEventData', () => {
     expect(isValidEventData('feeding', {})).toBe(false)
   })
 
+  test('feeding accepts per-side minutes but rejects impossible ones', () => {
+    expect(
+      isValidEventData('feeding', { method: 'breast', leftMin: 10, rightMin: 8 }),
+    ).toBe(true)
+    expect(isValidEventData('feeding', { method: 'breast', leftMin: 0 })).toBe(
+      true,
+    )
+    expect(isValidEventData('feeding', { method: 'breast', leftMin: -1 })).toBe(
+      false,
+    )
+    expect(
+      isValidEventData('feeding', { method: 'breast', rightMin: Number.NaN }),
+    ).toBe(false)
+  })
+
   test('diaper requires a known kind', () => {
     expect(isValidEventData('diaper', { kind: 'wet' })).toBe(true)
     expect(isValidEventData('diaper', { kind: 'both' })).toBe(true)

--- a/convex/lib/babyEvents.ts
+++ b/convex/lib/babyEvents.ts
@@ -75,10 +75,15 @@ export const temperatureDataValidator = v.object({
   method: v.optional(temperatureMethodValidator),
 })
 
+// leftMin/rightMin: per-side breastfeed duration in minutes. `side` stays as
+// the coarse record (and is what pre-duration entries have); it is derived
+// from whichever sides have minutes when they're given.
 export const feedingDataValidator = v.object({
   method: feedingMethodValidator,
   side: v.optional(feedingSideValidator),
   amountMl: v.optional(v.number()),
+  leftMin: v.optional(v.number()),
+  rightMin: v.optional(v.number()),
 })
 
 export const diaperDataValidator = v.object({
@@ -120,6 +125,12 @@ export const babyEventDataValidator = v.union(
 
 export type BabyEventData = Record<string, unknown>
 
+/** Absent, or a finite non-negative number of minutes. */
+function isValidMinutes(value: unknown): boolean {
+  if (value === undefined) return true
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
 // Confirms `data` actually satisfies the shape the given `type` implies —
 // the schema validator only checks `data` against *some* member of the
 // union, not the one matching `type`.
@@ -132,9 +143,11 @@ export function isValidEventData(
       return typeof data.celsius === 'number'
     case 'feeding':
       return (
-        data.method === 'breast' ||
-        data.method === 'bottle' ||
-        data.method === 'solid'
+        (data.method === 'breast' ||
+          data.method === 'bottle' ||
+          data.method === 'solid') &&
+        isValidMinutes(data.leftMin) &&
+        isValidMinutes(data.rightMin)
       )
     case 'diaper':
       return data.kind === 'wet' || data.kind === 'dirty' || data.kind === 'both'

--- a/src/components/baby/EventForm.tsx
+++ b/src/components/baby/EventForm.tsx
@@ -10,18 +10,14 @@ import {
   toDateInputValue,
   toTimeInputValue,
 } from '../../lib/babyDate'
+import { BABY_INPUT_CLASS as inputClass } from '../../lib/babyEventFields'
+import type { EventValues } from '../../lib/babyEventFormValues'
 import {
-  DEFAULT_TEMPERATURE_CELSIUS,
-  DIAPER_KIND_LABELS,
-  FEEDING_METHOD_LABELS,
-  FEEDING_SIDE_LABELS,
-  TEMPERATURE_METHOD_LABELS,
-  TEMPERATURE_OPTIONS,
-} from '../../lib/babyEventFields'
-import { readLastUsed, writeLastUsed } from '../../lib/lastUsed'
-
-const inputClass =
-  'w-full min-w-0 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)] disabled:cursor-not-allowed disabled:opacity-60'
+  buildEventInput,
+  initialEventValues,
+  rememberEventChoices,
+} from '../../lib/babyEventFormValues'
+import { EventTypeFields } from './EventTypeFields'
 
 type BabyEventDoc = Doc<'babyEvents'>
 
@@ -33,7 +29,7 @@ interface EventFormProps {
   onCancel: () => void
 }
 
-function errorMessage(err: unknown, fallback: string): string {
+export function errorMessage(err: unknown, fallback: string): string {
   if (err instanceof ConvexError) {
     return typeof err.data === 'string' ? err.data : fallback
   }
@@ -49,175 +45,23 @@ export function EventForm({
 }: EventFormProps) {
   const add = useMutation(api.babyEvents.add)
   const update = useMutation(api.babyEvents.update)
-  const data = (event?.data ?? {}) as Record<string, unknown>
 
   const [timestampMs, setTimestampMs] = useState(event?.timestamp ?? Date.now())
-  const [endTimestampMs, setEndTimestampMs] = useState<number | undefined>(
-    event?.endTimestamp,
+  const [values, setValues] = useState<EventValues>(() =>
+    initialEventValues(type, event),
   )
   const [notes, setNotes] = useState(event?.notes ?? '')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  function setEndDate(dateStr: string) {
-    if (!dateStr) {
-      setEndTimestampMs(undefined)
-      return
-    }
-    const time = endTimestampMs
-      ? toTimeInputValue(endTimestampMs)
-      : toTimeInputValue(timestampMs)
-    setEndTimestampMs(combineDateTime(dateStr, time))
-  }
-
-  function setEndTime(timeStr: string) {
-    const date = endTimestampMs
-      ? toDateInputValue(endTimestampMs)
-      : toDateInputValue(timestampMs)
-    setEndTimestampMs(combineDateTime(date, timeStr))
-  }
-
-  const [celsius, setCelsius] = useState(
-    typeof data.celsius === 'number'
-      ? data.celsius.toFixed(1)
-      : (readLastUsed('temperatureCelsius') ?? DEFAULT_TEMPERATURE_CELSIUS),
-  )
-  const temperatureOptions = TEMPERATURE_OPTIONS.includes(celsius)
-    ? TEMPERATURE_OPTIONS
-    : [celsius, ...TEMPERATURE_OPTIONS]
-  const [tempMethod, setTempMethod] = useState(
-    typeof data.method === 'string'
-      ? data.method
-      : (readLastUsed('temperatureMethod') ?? ''),
-  )
-
-  const [feedingMethod, setFeedingMethod] = useState(
-    typeof data.method === 'string'
-      ? data.method
-      : (readLastUsed('feedingMethod') ?? 'bottle'),
-  )
-  const [feedingSide, setFeedingSide] = useState(
-    typeof data.side === 'string'
-      ? data.side
-      : (readLastUsed('feedingSide') ?? ''),
-  )
-  const [amountMl, setAmountMl] = useState(
-    typeof data.amountMl === 'number' ? String(data.amountMl) : '',
-  )
-
-  const [diaperKind, setDiaperKind] = useState(
-    typeof data.kind === 'string'
-      ? data.kind
-      : (readLastUsed('diaperKind') ?? 'wet'),
-  )
-
-  const [weightKg, setWeightKg] = useState(
-    typeof data.weightKg === 'number' ? String(data.weightKg) : '',
-  )
-  const [heightCm, setHeightCm] = useState(
-    typeof data.heightCm === 'number' ? String(data.heightCm) : '',
-  )
-  const [headCircumferenceCm, setHeadCircumferenceCm] = useState(
-    typeof data.headCircumferenceCm === 'number'
-      ? String(data.headCircumferenceCm)
-      : '',
-  )
-
-  const [medName, setMedName] = useState(
-    typeof data.name === 'string' ? data.name : '',
-  )
-  const [doseAmount, setDoseAmount] = useState(
-    typeof data.doseAmount === 'number' ? String(data.doseAmount) : '',
-  )
-  const [doseUnit, setDoseUnit] = useState(
-    typeof data.doseUnit === 'string' ? data.doseUnit : '',
-  )
-
-  const [vaccineName, setVaccineName] = useState(
-    typeof data.name === 'string' ? data.name : '',
-  )
-
-  const [milestone, setMilestone] = useState(data.milestone === true)
-
-  function buildData(): { data: Record<string, unknown>; error?: string } {
-    switch (type) {
-      case 'temperature':
-        return {
-          data: { celsius: Number(celsius), method: tempMethod || undefined },
-        }
-      case 'feeding':
-        return {
-          data: {
-            method: feedingMethod,
-            side:
-              feedingMethod === 'breast' ? feedingSide || undefined : undefined,
-            amountMl: amountMl.trim() ? Number(amountMl) : undefined,
-          },
-        }
-      case 'diaper':
-        return { data: { kind: diaperKind } }
-      case 'sleep':
-        return { data: {} }
-      case 'growth': {
-        const weight = weightKg.trim() ? Number(weightKg) : undefined
-        const height = heightCm.trim() ? Number(heightCm) : undefined
-        const head = headCircumferenceCm.trim()
-          ? Number(headCircumferenceCm)
-          : undefined
-        if (
-          weight === undefined &&
-          height === undefined &&
-          head === undefined
-        ) {
-          return { data: {}, error: 'Enter at least one measurement' }
-        }
-        return {
-          data: {
-            weightKg: weight,
-            heightCm: height,
-            headCircumferenceCm: head,
-          },
-        }
-      }
-      case 'medication':
-        if (!medName.trim())
-          return { data: {}, error: 'Enter a medication name' }
-        return {
-          data: {
-            name: medName.trim(),
-            doseAmount: doseAmount.trim() ? Number(doseAmount) : undefined,
-            doseUnit: doseUnit.trim() || undefined,
-          },
-        }
-      case 'vaccination':
-        if (!vaccineName.trim())
-          return { data: {}, error: 'Enter a vaccine name' }
-        return { data: { name: vaccineName.trim() } }
-      case 'note':
-        return { data: { milestone: milestone || undefined } }
-    }
-  }
-
-  function rememberChoices() {
-    if (type === 'temperature') {
-      writeLastUsed('temperatureCelsius', celsius)
-      if (tempMethod) writeLastUsed('temperatureMethod', tempMethod)
-    } else if (type === 'feeding') {
-      writeLastUsed('feedingMethod', feedingMethod)
-      if (feedingSide) writeLastUsed('feedingSide', feedingSide)
-    } else if (type === 'diaper') {
-      writeLastUsed('diaperKind', diaperKind)
-    }
-  }
-
   async function submit(e: React.FormEvent) {
     e.preventDefault()
-    const built = buildData()
+    const built = buildEventInput(type, values, timestampMs)
     if (built.error) {
       setError(built.error)
       return
     }
-    rememberChoices()
+    rememberEventChoices(type, values)
     setSubmitting(true)
     setError(null)
     try {
@@ -225,7 +69,7 @@ export function EventForm({
         await update({
           eventId: event._id,
           timestamp: timestampMs,
-          endTimestamp: endTimestampMs ?? null,
+          endTimestamp: built.endTimestamp ?? null,
           notes: notes.trim() || null,
           data: built.data,
         })
@@ -234,7 +78,7 @@ export function EventForm({
           babyId,
           type,
           timestamp: timestampMs,
-          endTimestamp: endTimestampMs,
+          endTimestamp: built.endTimestamp,
           notes: notes.trim() || undefined,
           data: built.data,
         })
@@ -252,258 +96,42 @@ export function EventForm({
         {event ? 'Edit' : 'Log'} {BABY_EVENT_LABELS[type].toLowerCase()}
       </h3>
 
-      <div className="grid gap-3 sm:grid-cols-2">
-        <div className="min-w-0">
-          <span className="mb-1 block text-sm font-medium">
-            {type === 'sleep' ? 'Start' : 'When'}
-          </span>
-          <div className="flex gap-2">
-            <input
-              type="date"
-              className={inputClass}
-              value={toDateInputValue(timestampMs)}
-              onChange={(e) =>
-                setTimestampMs(
-                  combineDateTime(
-                    e.target.value,
-                    toTimeInputValue(timestampMs),
-                  ),
-                )
-              }
-              required
-            />
-            <input
-              type="time"
-              className={inputClass}
-              value={toTimeInputValue(timestampMs)}
-              onChange={(e) =>
-                setTimestampMs(
-                  combineDateTime(
-                    toDateInputValue(timestampMs),
-                    e.target.value,
-                  ),
-                )
-              }
-              required
-            />
-          </div>
-        </div>
-        {(type === 'sleep' || type === 'feeding') && (
-          <div className="min-w-0">
-            <span className="mb-1 block text-sm font-medium">
-              End (optional)
-            </span>
-            <div className="flex gap-2">
-              <input
-                type="date"
-                className={inputClass}
-                value={endTimestampMs ? toDateInputValue(endTimestampMs) : ''}
-                onChange={(e) => setEndDate(e.target.value)}
-              />
-              <input
-                type="time"
-                className={inputClass}
-                value={endTimestampMs ? toTimeInputValue(endTimestampMs) : ''}
-                onChange={(e) => setEndTime(e.target.value)}
-                disabled={!endTimestampMs}
-              />
-            </div>
-          </div>
-        )}
-      </div>
-
-      {type === 'temperature' && (
-        <div className="grid gap-3 sm:grid-cols-2">
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium">Temperature (°C)</span>
-            <select
-              className={inputClass}
-              value={celsius}
-              onChange={(e) => setCelsius(e.target.value)}
-            >
-              {temperatureOptions.map((v) => (
-                <option key={v} value={v}>
-                  {v}°C
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium">Method</span>
-            <select
-              className={inputClass}
-              value={tempMethod}
-              onChange={(e) => setTempMethod(e.target.value)}
-            >
-              <option value="">Not specified</option>
-              {Object.entries(TEMPERATURE_METHOD_LABELS).map(([k, l]) => (
-                <option key={k} value={k}>
-                  {l}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-      )}
-
-      {type === 'feeding' && (
-        <div className="grid gap-3 sm:grid-cols-2">
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium">Method</span>
-            <select
-              className={inputClass}
-              value={feedingMethod}
-              onChange={(e) => setFeedingMethod(e.target.value)}
-            >
-              {Object.entries(FEEDING_METHOD_LABELS).map(([k, l]) => (
-                <option key={k} value={k}>
-                  {l}
-                </option>
-              ))}
-            </select>
-          </label>
-          {feedingMethod === 'breast' ? (
-            <label className="block text-sm">
-              <span className="mb-1 block font-medium">Side</span>
-              <select
-                className={inputClass}
-                value={feedingSide}
-                onChange={(e) => setFeedingSide(e.target.value)}
-              >
-                <option value="">Not specified</option>
-                {Object.entries(FEEDING_SIDE_LABELS).map(([k, l]) => (
-                  <option key={k} value={k}>
-                    {l}
-                  </option>
-                ))}
-              </select>
-            </label>
-          ) : (
-            <label className="block text-sm">
-              <span className="mb-1 block font-medium">Amount (ml)</span>
-              <input
-                type="number"
-                inputMode="numeric"
-                className={inputClass}
-                value={amountMl}
-                onChange={(e) => setAmountMl(e.target.value)}
-              />
-            </label>
-          )}
-        </div>
-      )}
-
-      {type === 'diaper' && (
-        <label className="block text-sm">
-          <span className="mb-1 block font-medium">Kind</span>
-          <select
-            className={inputClass}
-            value={diaperKind}
-            onChange={(e) => setDiaperKind(e.target.value)}
-          >
-            {Object.entries(DIAPER_KIND_LABELS).map(([k, l]) => (
-              <option key={k} value={k}>
-                {l}
-              </option>
-            ))}
-          </select>
-        </label>
-      )}
-
-      {type === 'growth' && (
-        <div className="grid gap-3 sm:grid-cols-3">
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium">Weight (kg)</span>
-            <input
-              type="number"
-              step="0.01"
-              inputMode="decimal"
-              className={inputClass}
-              value={weightKg}
-              onChange={(e) => setWeightKg(e.target.value)}
-            />
-          </label>
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium">Height (cm)</span>
-            <input
-              type="number"
-              step="0.1"
-              inputMode="decimal"
-              className={inputClass}
-              value={heightCm}
-              onChange={(e) => setHeightCm(e.target.value)}
-            />
-          </label>
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium">Head circ. (cm)</span>
-            <input
-              type="number"
-              step="0.1"
-              inputMode="decimal"
-              className={inputClass}
-              value={headCircumferenceCm}
-              onChange={(e) => setHeadCircumferenceCm(e.target.value)}
-            />
-          </label>
-        </div>
-      )}
-
-      {type === 'medication' && (
-        <div className="grid gap-3 sm:grid-cols-3">
-          <label className="block text-sm sm:col-span-1">
-            <span className="mb-1 block font-medium">Name</span>
-            <input
-              className={inputClass}
-              value={medName}
-              onChange={(e) => setMedName(e.target.value)}
-              required
-            />
-          </label>
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium">Dose amount</span>
-            <input
-              type="number"
-              step="0.01"
-              inputMode="decimal"
-              className={inputClass}
-              value={doseAmount}
-              onChange={(e) => setDoseAmount(e.target.value)}
-            />
-          </label>
-          <label className="block text-sm">
-            <span className="mb-1 block font-medium">Dose unit</span>
-            <input
-              className={inputClass}
-              placeholder="ml, mg…"
-              value={doseUnit}
-              onChange={(e) => setDoseUnit(e.target.value)}
-            />
-          </label>
-        </div>
-      )}
-
-      {type === 'vaccination' && (
-        <label className="block text-sm">
-          <span className="mb-1 block font-medium">Vaccine name</span>
+      <div className="min-w-0 sm:max-w-sm">
+        <span className="mb-1 block text-sm font-medium">
+          {type === 'sleep' ? 'Start' : 'When'}
+        </span>
+        <div className="flex gap-2">
           <input
+            type="date"
             className={inputClass}
-            value={vaccineName}
-            onChange={(e) => setVaccineName(e.target.value)}
+            value={toDateInputValue(timestampMs)}
+            onChange={(e) =>
+              setTimestampMs(
+                combineDateTime(e.target.value, toTimeInputValue(timestampMs)),
+              )
+            }
             required
           />
-        </label>
-      )}
-
-      {type === 'note' && (
-        <label className="flex items-center gap-2 text-sm">
           <input
-            type="checkbox"
-            checked={milestone}
-            onChange={(e) => setMilestone(e.target.checked)}
+            type="time"
+            className={inputClass}
+            value={toTimeInputValue(timestampMs)}
+            onChange={(e) =>
+              setTimestampMs(
+                combineDateTime(toDateInputValue(timestampMs), e.target.value),
+              )
+            }
+            required
           />
-          <span className="font-medium">Mark as a milestone</span>
-        </label>
-      )}
+        </div>
+      </div>
+
+      <EventTypeFields
+        type={type}
+        values={values}
+        timestampMs={timestampMs}
+        onChange={(patch) => setValues((prev) => ({ ...prev, ...patch }))}
+      />
 
       <label className="block text-sm">
         <span className="mb-1 block font-medium">Notes</span>

--- a/src/components/baby/EventIcon.tsx
+++ b/src/components/baby/EventIcon.tsx
@@ -1,0 +1,18 @@
+import type { LucideIcon } from 'lucide-react'
+import * as Icons from 'lucide-react'
+import { EVENT_TYPE_ICONS } from '../../lib/babyEventFields'
+
+/** Lucide glyph for a baby event type, falling back to a plain circle. */
+export function EventIcon({
+  type,
+  className = 'h-4 w-4',
+}: {
+  type: string
+  className?: string
+}) {
+  const Icon =
+    (Icons as unknown as Record<string, LucideIcon>)[
+      EVENT_TYPE_ICONS[type] ?? 'Circle'
+    ] ?? Icons.Circle
+  return <Icon className={className} aria-hidden="true" />
+}

--- a/src/components/baby/EventTypeFields.tsx
+++ b/src/components/baby/EventTypeFields.tsx
@@ -1,0 +1,297 @@
+import type { BabyEventType } from '../../../convex/lib/babyEvents'
+import {
+  combineDateTime,
+  toDateInputValue,
+  toTimeInputValue,
+} from '../../lib/babyDate'
+import {
+  DIAPER_KIND_LABELS,
+  FEEDING_METHOD_LABELS,
+  BABY_INPUT_CLASS as inputClass,
+  TEMPERATURE_METHOD_LABELS,
+  TEMPERATURE_OPTIONS,
+} from '../../lib/babyEventFields'
+import type { EventValues } from '../../lib/babyEventFormValues'
+
+interface EventTypeFieldsProps {
+  type: BabyEventType
+  values: EventValues
+  /** The entry's start time — end date/time inputs default their missing half to it. */
+  timestampMs: number
+  onChange: (patch: EventValues) => void
+}
+
+/** The type-specific half of a baby-log entry form. Fully controlled, so one
+ * parent can render several of these at once (MultiEventForm). */
+export function EventTypeFields({
+  type,
+  values,
+  timestampMs,
+  onChange,
+}: EventTypeFieldsProps) {
+  const str = (key: string) =>
+    typeof values[key] === 'string' ? (values[key] as string) : ''
+
+  const endMs = str('endTimestamp') ? Number(str('endTimestamp')) : undefined
+
+  function setEndDate(dateStr: string) {
+    if (!dateStr) {
+      onChange({ endTimestamp: '' })
+      return
+    }
+    const time = toTimeInputValue(endMs ?? timestampMs)
+    onChange({ endTimestamp: String(combineDateTime(dateStr, time)) })
+  }
+
+  function setEndTime(timeStr: string) {
+    const date = toDateInputValue(endMs ?? timestampMs)
+    onChange({ endTimestamp: String(combineDateTime(date, timeStr)) })
+  }
+
+  const endFields = (
+    <div className="min-w-0">
+      <span className="mb-1 block text-sm font-medium">End (optional)</span>
+      <div className="flex gap-2">
+        <input
+          type="date"
+          className={inputClass}
+          value={endMs ? toDateInputValue(endMs) : ''}
+          onChange={(e) => setEndDate(e.target.value)}
+        />
+        <input
+          type="time"
+          className={inputClass}
+          value={endMs ? toTimeInputValue(endMs) : ''}
+          onChange={(e) => setEndTime(e.target.value)}
+          disabled={!endMs}
+        />
+      </div>
+    </div>
+  )
+
+  switch (type) {
+    case 'temperature': {
+      const celsius = str('celsius')
+      const options = TEMPERATURE_OPTIONS.includes(celsius)
+        ? TEMPERATURE_OPTIONS
+        : [celsius, ...TEMPERATURE_OPTIONS]
+      return (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Temperature (°C)</span>
+            <select
+              className={inputClass}
+              value={celsius}
+              onChange={(e) => onChange({ celsius: e.target.value })}
+            >
+              {options.map((v) => (
+                <option key={v} value={v}>
+                  {v}°C
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Method</span>
+            <select
+              className={inputClass}
+              value={str('method')}
+              onChange={(e) => onChange({ method: e.target.value })}
+            >
+              <option value="">Not specified</option>
+              {Object.entries(TEMPERATURE_METHOD_LABELS).map(([k, l]) => (
+                <option key={k} value={k}>
+                  {l}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      )
+    }
+
+    case 'feeding': {
+      const method = str('method')
+      return (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Method</span>
+            <select
+              className={inputClass}
+              value={method}
+              onChange={(e) => onChange({ method: e.target.value })}
+            >
+              {Object.entries(FEEDING_METHOD_LABELS).map(([k, l]) => (
+                <option key={k} value={k}>
+                  {l}
+                </option>
+              ))}
+            </select>
+          </label>
+          {method === 'breast' ? (
+            <div className="grid grid-cols-2 gap-3">
+              <label className="block text-sm">
+                <span className="mb-1 block font-medium">Left (min)</span>
+                <input
+                  type="number"
+                  min="0"
+                  inputMode="numeric"
+                  className={inputClass}
+                  value={str('leftMin')}
+                  onChange={(e) => onChange({ leftMin: e.target.value })}
+                />
+              </label>
+              <label className="block text-sm">
+                <span className="mb-1 block font-medium">Right (min)</span>
+                <input
+                  type="number"
+                  min="0"
+                  inputMode="numeric"
+                  className={inputClass}
+                  value={str('rightMin')}
+                  onChange={(e) => onChange({ rightMin: e.target.value })}
+                />
+              </label>
+            </div>
+          ) : (
+            <label className="block text-sm">
+              <span className="mb-1 block font-medium">Amount (ml)</span>
+              <input
+                type="number"
+                inputMode="numeric"
+                className={inputClass}
+                value={str('amountMl')}
+                onChange={(e) => onChange({ amountMl: e.target.value })}
+              />
+            </label>
+          )}
+          {/* Breast feeds get their duration from the per-side minutes, so the
+              end time is derived rather than asked for. */}
+          {method !== 'breast' && endFields}
+        </div>
+      )
+    }
+
+    case 'diaper':
+      return (
+        <label className="block text-sm">
+          <span className="mb-1 block font-medium">Kind</span>
+          <select
+            className={inputClass}
+            value={str('kind')}
+            onChange={(e) => onChange({ kind: e.target.value })}
+          >
+            {Object.entries(DIAPER_KIND_LABELS).map(([k, l]) => (
+              <option key={k} value={k}>
+                {l}
+              </option>
+            ))}
+          </select>
+        </label>
+      )
+
+    case 'sleep':
+      return <div className="grid gap-3 sm:grid-cols-2">{endFields}</div>
+
+    case 'growth':
+      return (
+        <div className="grid gap-3 sm:grid-cols-3">
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Weight (kg)</span>
+            <input
+              type="number"
+              step="0.01"
+              inputMode="decimal"
+              className={inputClass}
+              value={str('weightKg')}
+              onChange={(e) => onChange({ weightKg: e.target.value })}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Height (cm)</span>
+            <input
+              type="number"
+              step="0.1"
+              inputMode="decimal"
+              className={inputClass}
+              value={str('heightCm')}
+              onChange={(e) => onChange({ heightCm: e.target.value })}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Head circ. (cm)</span>
+            <input
+              type="number"
+              step="0.1"
+              inputMode="decimal"
+              className={inputClass}
+              value={str('headCircumferenceCm')}
+              onChange={(e) =>
+                onChange({ headCircumferenceCm: e.target.value })
+              }
+            />
+          </label>
+        </div>
+      )
+
+    case 'medication':
+      return (
+        <div className="grid gap-3 sm:grid-cols-3">
+          <label className="block text-sm sm:col-span-1">
+            <span className="mb-1 block font-medium">Name</span>
+            <input
+              className={inputClass}
+              value={str('name')}
+              onChange={(e) => onChange({ name: e.target.value })}
+              required
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Dose amount</span>
+            <input
+              type="number"
+              step="0.01"
+              inputMode="decimal"
+              className={inputClass}
+              value={str('doseAmount')}
+              onChange={(e) => onChange({ doseAmount: e.target.value })}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Dose unit</span>
+            <input
+              className={inputClass}
+              placeholder="ml, mg…"
+              value={str('doseUnit')}
+              onChange={(e) => onChange({ doseUnit: e.target.value })}
+            />
+          </label>
+        </div>
+      )
+
+    case 'vaccination':
+      return (
+        <label className="block text-sm">
+          <span className="mb-1 block font-medium">Vaccine name</span>
+          <input
+            className={inputClass}
+            value={str('name')}
+            onChange={(e) => onChange({ name: e.target.value })}
+            required
+          />
+        </label>
+      )
+
+    case 'note':
+      return (
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={values.milestone === true}
+            onChange={(e) => onChange({ milestone: e.target.checked })}
+          />
+          <span className="font-medium">Mark as a milestone</span>
+        </label>
+      )
+  }
+}

--- a/src/components/baby/ExportPdfPanel.tsx
+++ b/src/components/baby/ExportPdfPanel.tsx
@@ -12,6 +12,7 @@ import {
   toDateInputValue,
   toTimeInputValue,
 } from '../../lib/babyDate'
+import type { BabyPdfLayout } from '../../lib/babyPdfExport'
 import { SurfaceCard } from '../app/ShellPrimitives'
 
 const inputClass =
@@ -39,6 +40,7 @@ export function ExportPdfPanel({
   )
   const [toMs, setToMs] = useState(() => Date.now())
   const [types, setTypes] = useState<BabyEventType[]>([...BABY_EVENT_TYPES])
+  const [layout, setLayout] = useState<BabyPdfLayout>('category')
   const [exporting, setExporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -66,6 +68,7 @@ export function ExportPdfPanel({
         from: fromMs,
         to: toMs,
         types,
+        layout,
       })
       onClose()
     } catch {
@@ -126,6 +129,30 @@ export function ExportPdfPanel({
           </div>
         </div>
       </div>
+
+      <fieldset className="mt-3">
+        <legend className="mb-1 text-sm font-medium">Layout</legend>
+        <div className="grid gap-1 sm:grid-cols-2">
+          <label className="flex items-center gap-1.5 text-sm">
+            <input
+              type="radio"
+              name="pdf-layout"
+              checked={layout === 'category'}
+              onChange={() => setLayout('category')}
+            />
+            By category
+          </label>
+          <label className="flex items-center gap-1.5 text-sm">
+            <input
+              type="radio"
+              name="pdf-layout"
+              checked={layout === 'chronological'}
+              onChange={() => setLayout('chronological')}
+            />
+            Chronological
+          </label>
+        </div>
+      </fieldset>
 
       <fieldset className="mt-3">
         <legend className="mb-1 text-sm font-medium">Include</legend>

--- a/src/components/baby/MultiEventForm.test.tsx
+++ b/src/components/baby/MultiEventForm.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, expect, test, vi } from 'vitest'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { MultiEventForm } from './MultiEventForm'
+
+const add = vi.fn()
+
+vi.mock('convex/react', () => ({
+  useMutation: () => add,
+}))
+
+const babyId = 'baby1' as Id<'babies'>
+
+beforeEach(() => {
+  add.mockReset()
+  add.mockResolvedValue('event1')
+  window.localStorage.clear()
+})
+
+function renderForm(onDone = vi.fn()) {
+  return render(
+    <MultiEventForm babyId={babyId} onDone={onDone} onCancel={vi.fn()} />,
+  )
+}
+
+test('starts on the usual round — diaper, temperature and feeding', () => {
+  renderForm()
+  expect(screen.getByText('Kind')).toBeDefined()
+  expect(screen.getByText('Temperature (°C)')).toBeDefined()
+  expect(screen.getByText('Amount (ml)')).toBeDefined()
+  expect(screen.getByRole('button', { name: 'Save 3 entries' })).toBeDefined()
+})
+
+test('saves one entry per checked type, all at the same timestamp', async () => {
+  const onDone = vi.fn()
+  renderForm(onDone)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Save 3 entries' }))
+
+  await waitFor(() => expect(add).toHaveBeenCalledTimes(3))
+  const calls = add.mock.calls.map(([args]) => args)
+  expect(calls.map((c) => c.type)).toEqual(['temperature', 'feeding', 'diaper'])
+  expect(new Set(calls.map((c) => c.timestamp)).size).toBe(1)
+  expect(calls.every((c) => c.babyId === babyId)).toBe(true)
+  await waitFor(() => expect(onDone).toHaveBeenCalled())
+})
+
+test('unchecking a type drops its block and its entry', async () => {
+  renderForm()
+
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Diaper' }))
+  expect(screen.queryByText('Kind')).toBeNull()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Save 2 entries' }))
+
+  await waitFor(() => expect(add).toHaveBeenCalledTimes(2))
+  expect(add.mock.calls.map(([args]) => args.type)).toEqual([
+    'temperature',
+    'feeding',
+  ])
+})
+
+test('breast minutes become the feed duration', async () => {
+  renderForm()
+
+  fireEvent.change(screen.getByDisplayValue('Bottle'), {
+    target: { value: 'breast' },
+  })
+  fireEvent.change(screen.getByLabelText('Left (min)'), {
+    target: { value: '10' },
+  })
+  fireEvent.change(screen.getByLabelText('Right (min)'), {
+    target: { value: '8' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Save 3 entries' }))
+
+  await waitFor(() => expect(add).toHaveBeenCalledTimes(3))
+  const feed = add.mock.calls
+    .map(([args]) => args)
+    .find((c) => c.type === 'feeding')
+  expect(feed.data).toMatchObject({
+    method: 'breast',
+    side: 'both',
+    leftMin: 10,
+    rightMin: 8,
+  })
+  expect(feed.endTimestamp).toBe(feed.timestamp + 18 * 60000)
+})
+
+test('a failed save keeps the unsaved entries on screen', async () => {
+  add
+    .mockResolvedValueOnce('event1')
+    .mockRejectedValueOnce(new Error('Network down'))
+  renderForm()
+
+  fireEvent.click(screen.getByRole('button', { name: 'Save 3 entries' }))
+
+  await waitFor(() =>
+    expect(screen.getByText(/Saved 1 of 3 entries/)).toBeDefined(),
+  )
+  // Temperature saved, so only feeding and diaper are still pending.
+  expect(screen.queryByText('Temperature (°C)')).toBeNull()
+  expect(screen.getByRole('button', { name: 'Save 2 entries' })).toBeDefined()
+})

--- a/src/components/baby/MultiEventForm.tsx
+++ b/src/components/baby/MultiEventForm.tsx
@@ -1,0 +1,255 @@
+import { useMutation } from 'convex/react'
+import { useState } from 'react'
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import type { BabyEventType } from '../../../convex/lib/babyEvents'
+import {
+  BABY_EVENT_LABELS,
+  BABY_EVENT_TYPES,
+} from '../../../convex/lib/babyEvents'
+import {
+  combineDateTime,
+  toDateInputValue,
+  toTimeInputValue,
+} from '../../lib/babyDate'
+import { BABY_INPUT_CLASS as inputClass } from '../../lib/babyEventFields'
+import type { EventValues } from '../../lib/babyEventFormValues'
+import {
+  buildEventInput,
+  initialEventValues,
+  rememberEventChoices,
+} from '../../lib/babyEventFormValues'
+import { readLastUsed, writeLastUsed } from '../../lib/lastUsed'
+import { errorMessage } from './EventForm'
+import { EventIcon } from './EventIcon'
+import { EventTypeFields } from './EventTypeFields'
+
+interface MultiEventFormProps {
+  babyId: Id<'babies'>
+  onDone: () => void
+  onCancel: () => void
+}
+
+const LAST_USED_KEY = 'multiLogTypes'
+// The common round: check the diaper, take the temperature, then feed.
+const DEFAULT_SELECTION: BabyEventType[] = ['diaper', 'temperature', 'feeding']
+
+function initialSelection(): BabyEventType[] {
+  const stored = readLastUsed(LAST_USED_KEY)
+  if (!stored) return DEFAULT_SELECTION
+  const parsed = stored
+    .split(',')
+    .filter((t): t is BabyEventType =>
+      (BABY_EVENT_TYPES as readonly string[]).includes(t),
+    )
+  return parsed.length > 0 ? parsed : DEFAULT_SELECTION
+}
+
+/** Logs several entries at one shared timestamp — one separate babyEvents row
+ * per checked type, so everything downstream (timeline, charts, per-category
+ * export) keeps working unchanged. */
+export function MultiEventForm({
+  babyId,
+  onDone,
+  onCancel,
+}: MultiEventFormProps) {
+  const add = useMutation(api.babyEvents.add)
+
+  const [timestampMs, setTimestampMs] = useState(() => Date.now())
+  const [selected, setSelected] = useState<BabyEventType[]>(initialSelection)
+  const [valuesByType, setValuesByType] = useState<
+    Partial<Record<BabyEventType, EventValues>>
+  >(() => {
+    const initial: Partial<Record<BabyEventType, EventValues>> = {}
+    for (const type of initialSelection()) {
+      initial[type] = initialEventValues(type)
+    }
+    return initial
+  })
+  const [notesByType, setNotesByType] = useState<
+    Partial<Record<BabyEventType, string>>
+  >({})
+  const [fieldErrors, setFieldErrors] = useState<
+    Partial<Record<BabyEventType, string>>
+  >({})
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  function toggleType(type: BabyEventType) {
+    setSelected((prev) =>
+      prev.includes(type) ? prev.filter((t) => t !== type) : [...prev, type],
+    )
+    setValuesByType((prev) =>
+      prev[type] ? prev : { ...prev, [type]: initialEventValues(type) },
+    )
+  }
+
+  // Rendered in the canonical type order rather than the order they were
+  // checked, so the form doesn't reshuffle as boxes are ticked.
+  const activeTypes = BABY_EVENT_TYPES.filter((t) => selected.includes(t))
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    const inputs: { type: BabyEventType; values: EventValues }[] = []
+    const errors: Partial<Record<BabyEventType, string>> = {}
+    for (const type of activeTypes) {
+      const values = valuesByType[type] ?? initialEventValues(type)
+      const built = buildEventInput(type, values, timestampMs)
+      if (built.error) errors[type] = built.error
+      else inputs.push({ type, values })
+    }
+    setFieldErrors(errors)
+    if (Object.keys(errors).length > 0) return
+
+    setSubmitting(true)
+    const saved: BabyEventType[] = []
+    try {
+      for (const { type, values } of inputs) {
+        const built = buildEventInput(type, values, timestampMs)
+        await add({
+          babyId,
+          type,
+          timestamp: timestampMs,
+          endTimestamp: built.endTimestamp,
+          notes: notesByType[type]?.trim() || undefined,
+          data: built.data,
+        })
+        rememberEventChoices(type, values)
+        saved.push(type)
+      }
+      writeLastUsed(LAST_USED_KEY, activeTypes.join(','))
+      onDone()
+    } catch (err) {
+      // Keep only what still needs saving on screen, so a retry doesn't
+      // duplicate the entries that already went through.
+      setSelected((prev) => prev.filter((t) => !saved.includes(t)))
+      const detail = errorMessage(err, 'Could not save this entry')
+      setError(
+        saved.length > 0
+          ? `Saved ${saved.length} of ${inputs.length} entries — ${detail}`
+          : detail,
+      )
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="grid gap-3">
+      <h3 className="m-0 text-sm font-semibold">Log several entries</h3>
+
+      <div className="min-w-0 sm:max-w-sm">
+        <span className="mb-1 block text-sm font-medium">When</span>
+        <div className="flex gap-2">
+          <input
+            type="date"
+            className={inputClass}
+            value={toDateInputValue(timestampMs)}
+            onChange={(e) =>
+              setTimestampMs(
+                combineDateTime(e.target.value, toTimeInputValue(timestampMs)),
+              )
+            }
+            required
+          />
+          <input
+            type="time"
+            className={inputClass}
+            value={toTimeInputValue(timestampMs)}
+            onChange={(e) =>
+              setTimestampMs(
+                combineDateTime(toDateInputValue(timestampMs), e.target.value),
+              )
+            }
+            required
+          />
+        </div>
+      </div>
+
+      <fieldset className="m-0 border-0 p-0">
+        <legend className="mb-1 text-sm font-medium">Include</legend>
+        <div className="grid grid-cols-2 gap-1 sm:grid-cols-4">
+          {BABY_EVENT_TYPES.map((type) => (
+            <label key={type} className="flex items-center gap-1.5 text-sm">
+              <input
+                type="checkbox"
+                checked={selected.includes(type)}
+                onChange={() => toggleType(type)}
+              />
+              {BABY_EVENT_LABELS[type]}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {activeTypes.map((type) => (
+        <div
+          key={type}
+          className="grid gap-3 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface-muted)] p-3"
+        >
+          <p className="m-0 flex items-center gap-2 text-sm font-semibold">
+            <EventIcon type={type} />
+            {BABY_EVENT_LABELS[type]}
+          </p>
+          <EventTypeFields
+            type={type}
+            values={valuesByType[type] ?? initialEventValues(type)}
+            timestampMs={timestampMs}
+            onChange={(patch) =>
+              setValuesByType((prev) => ({
+                ...prev,
+                [type]: {
+                  ...(prev[type] ?? initialEventValues(type)),
+                  ...patch,
+                },
+              }))
+            }
+          />
+          <label className="block text-sm">
+            <span className="mb-1 block font-medium">Notes</span>
+            <input
+              className={inputClass}
+              value={notesByType[type] ?? ''}
+              onChange={(e) =>
+                setNotesByType((prev) => ({ ...prev, [type]: e.target.value }))
+              }
+            />
+          </label>
+          {fieldErrors[type] && (
+            <p className="m-0 text-sm text-red-800">{fieldErrors[type]}</p>
+          )}
+        </div>
+      ))}
+
+      {activeTypes.length === 0 && (
+        <p className="m-0 text-sm text-[var(--app-muted)]">
+          Pick at least one thing to log.
+        </p>
+      )}
+
+      {error && <p className="m-0 text-sm text-red-800">{error}</p>}
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={submitting || activeTypes.length === 0}
+          className="min-h-9 rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-3 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {submitting
+            ? 'Saving…'
+            : `Save ${activeTypes.length || ''} ${
+                activeTypes.length === 1 ? 'entry' : 'entries'
+              }`.trim()}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="min-h-9 px-2 text-sm text-[var(--app-muted)]"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/baby/QuickLogButtons.tsx
+++ b/src/components/baby/QuickLogButtons.tsx
@@ -1,5 +1,4 @@
-import type { LucideIcon } from 'lucide-react'
-import * as Icons from 'lucide-react'
+import { Layers } from 'lucide-react'
 import { useState } from 'react'
 import type { Id } from '../../../convex/_generated/dataModel'
 import type { BabyEventType } from '../../../convex/lib/babyEvents'
@@ -7,17 +6,36 @@ import {
   BABY_EVENT_LABELS,
   BABY_EVENT_TYPES,
 } from '../../../convex/lib/babyEvents'
-import { EVENT_TYPE_ICONS } from '../../lib/babyEventFields'
 import { SurfaceCard } from '../app/ShellPrimitives'
 import { EventForm } from './EventForm'
+import { EventIcon } from './EventIcon'
+import { MultiEventForm } from './MultiEventForm'
 
 export function QuickLogButtons({ babyId }: { babyId: Id<'babies'> }) {
-  const [active, setActive] = useState<BabyEventType | null>(null)
+  const [active, setActive] = useState<BabyEventType | 'multi' | null>(null)
 
   return (
     <SurfaceCard>
-      <h2 className="m-0 mb-3 text-sm font-semibold">Log an entry</h2>
-      {active ? (
+      {active === null && (
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="m-0 text-sm font-semibold">Log an entry</h2>
+          <button
+            type="button"
+            onClick={() => setActive('multi')}
+            className="inline-flex min-h-9 items-center gap-1.5 rounded-[var(--app-radius)] border border-[var(--app-border)] px-2.5 text-sm font-semibold"
+          >
+            <Layers className="h-4 w-4" aria-hidden="true" />
+            Log several
+          </button>
+        </div>
+      )}
+      {active === 'multi' ? (
+        <MultiEventForm
+          babyId={babyId}
+          onDone={() => setActive(null)}
+          onCancel={() => setActive(null)}
+        />
+      ) : active ? (
         <EventForm
           babyId={babyId}
           type={active}
@@ -26,23 +44,17 @@ export function QuickLogButtons({ babyId }: { babyId: Id<'babies'> }) {
         />
       ) : (
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-          {BABY_EVENT_TYPES.map((type) => {
-            const Icon =
-              (Icons as unknown as Record<string, LucideIcon>)[
-                EVENT_TYPE_ICONS[type] ?? 'Circle'
-              ] ?? Icons.Circle
-            return (
-              <button
-                key={type}
-                type="button"
-                onClick={() => setActive(type)}
-                className="flex min-h-16 flex-col items-center justify-center gap-1 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] text-xs font-semibold"
-              >
-                <Icon className="h-5 w-5" aria-hidden="true" />
-                {BABY_EVENT_LABELS[type]}
-              </button>
-            )
-          })}
+          {BABY_EVENT_TYPES.map((type) => (
+            <button
+              key={type}
+              type="button"
+              onClick={() => setActive(type)}
+              className="flex min-h-16 flex-col items-center justify-center gap-1 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] text-xs font-semibold"
+            >
+              <EventIcon type={type} className="h-5 w-5" />
+              {BABY_EVENT_LABELS[type]}
+            </button>
+          ))}
         </div>
       )}
     </SurfaceCard>

--- a/src/components/baby/Timeline.tsx
+++ b/src/components/baby/Timeline.tsx
@@ -1,6 +1,4 @@
 import { useMutation } from 'convex/react'
-import type { LucideIcon } from 'lucide-react'
-import * as Icons from 'lucide-react'
 import { ChevronRight, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
@@ -11,22 +9,14 @@ import {
   formatEventDateHeading,
   formatEventTimestamp,
 } from '../../lib/babyDate'
-import { EVENT_TYPE_ICONS } from '../../lib/babyEventFields'
 import { summarizeEvent } from '../../lib/babyEventSummary'
 import { SurfaceCard } from '../app/ShellPrimitives'
 import { EventForm } from './EventForm'
+import { EventIcon } from './EventIcon'
 
 interface TimelineProps {
   babyId: Id<'babies'>
   events: Doc<'babyEvents'>[]
-}
-
-function EventIcon({ type }: { type: string }) {
-  const Icon =
-    (Icons as unknown as Record<string, LucideIcon>)[
-      EVENT_TYPE_ICONS[type] ?? 'Circle'
-    ] ?? Icons.Circle
-  return <Icon className="h-4 w-4" aria-hidden="true" />
 }
 
 export function Timeline({ babyId, events }: TimelineProps) {

--- a/src/lib/babyEventFields.ts
+++ b/src/lib/babyEventFields.ts
@@ -1,5 +1,9 @@
 export const DEFAULT_TEMPERATURE_CELSIUS = '37.5'
 
+/** Shared input styling for every baby-log form control. */
+export const BABY_INPUT_CLASS =
+  'w-full min-w-0 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)] disabled:cursor-not-allowed disabled:opacity-60'
+
 // 34.0–42.0°C in 0.1° steps — a select instead of free text: fewer taps,
 // no keyboard popup, and it can't produce an out-of-range typo.
 export const TEMPERATURE_OPTIONS: string[] = Array.from(

--- a/src/lib/babyEventFormValues.test.ts
+++ b/src/lib/babyEventFormValues.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import type { Doc } from '../../convex/_generated/dataModel'
+import type { BabyEventType } from '../../convex/lib/babyEvents'
+import { isValidEventData } from '../../convex/lib/babyEvents'
+import { buildEventInput, initialEventValues } from './babyEventFormValues'
+
+const START = new Date('2026-07-25T09:00:00').getTime()
+
+/** A babyEvents doc with just the fields these helpers read. */
+function eventDoc(
+  type: BabyEventType,
+  data: Record<string, unknown>,
+  endTimestamp?: number,
+): Doc<'babyEvents'> {
+  return {
+    _id: 'event1' as Doc<'babyEvents'>['_id'],
+    _creationTime: START,
+    babyId: 'baby1' as Doc<'babyEvents'>['babyId'],
+    type,
+    timestamp: START,
+    endTimestamp,
+    loggedBy: 'user1' as Doc<'babyEvents'>['loggedBy'],
+    data,
+  } as Doc<'babyEvents'>
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+describe('initialEventValues', () => {
+  test('seeds each type from an existing event', () => {
+    const values = initialEventValues(
+      'feeding',
+      eventDoc('feeding', {
+        method: 'breast',
+        side: 'left',
+        leftMin: 12,
+      }),
+    )
+    expect(values).toMatchObject({
+      method: 'breast',
+      side: 'left',
+      leftMin: '12',
+      rightMin: '',
+    })
+  })
+
+  test('falls back to defaults for a new entry', () => {
+    expect(initialEventValues('feeding').method).toBe('bottle')
+    expect(initialEventValues('diaper').kind).toBe('wet')
+    expect(initialEventValues('temperature').celsius).toBe('37.5')
+    expect(initialEventValues('note').milestone).toBe(false)
+  })
+
+  test('round-trips a growth entry back into the same data', () => {
+    const values = initialEventValues(
+      'growth',
+      eventDoc('growth', { weightKg: 4.2, headCircumferenceCm: 38 }),
+    )
+    expect(buildEventInput('growth', values, START).data).toEqual({
+      weightKg: 4.2,
+      heightCm: undefined,
+      headCircumferenceCm: 38,
+    })
+  })
+})
+
+describe('buildEventInput — breast feeds', () => {
+  test('derives the side from whichever sides have minutes', () => {
+    const build = (leftMin: string, rightMin: string) =>
+      buildEventInput('feeding', { method: 'breast', leftMin, rightMin }, START)
+
+    expect(build('10', '8').data).toMatchObject({ side: 'both' })
+    expect(build('10', '').data).toMatchObject({ side: 'left' })
+    expect(build('', '8').data).toMatchObject({ side: 'right' })
+    expect(build('', '').data).toMatchObject({ side: undefined })
+  })
+
+  test('keeps the stored side when no minutes are entered', () => {
+    const values = initialEventValues(
+      'feeding',
+      eventDoc('feeding', { method: 'breast', side: 'both' }),
+    )
+    expect(buildEventInput('feeding', values, START).data).toMatchObject({
+      side: 'both',
+    })
+  })
+
+  test('derives endTimestamp from the total minutes', () => {
+    const built = buildEventInput(
+      'feeding',
+      { method: 'breast', leftMin: '10', rightMin: '8' },
+      START,
+    )
+    expect(built.endTimestamp).toBe(START + 18 * 60000)
+  })
+
+  test('preserves an existing end time when there are no minutes', () => {
+    const values = initialEventValues(
+      'feeding',
+      eventDoc('feeding', { method: 'breast' }, START + 15 * 60000),
+    )
+    expect(buildEventInput('feeding', values, START).endTimestamp).toBe(
+      START + 15 * 60000,
+    )
+  })
+
+  test('rejects negative minutes', () => {
+    expect(
+      buildEventInput('feeding', { method: 'breast', leftMin: '-5' }, START)
+        .error,
+    ).toBe('Minutes cannot be negative')
+  })
+
+  test('produces data the server validator accepts', () => {
+    const built = buildEventInput(
+      'feeding',
+      { method: 'breast', leftMin: '10', rightMin: '8' },
+      START,
+    )
+    expect(isValidEventData('feeding', built.data)).toBe(true)
+  })
+})
+
+describe('buildEventInput — other types', () => {
+  test('bottle feeds keep the amount and their own end time', () => {
+    const built = buildEventInput(
+      'feeding',
+      {
+        method: 'bottle',
+        amountMl: '120',
+        endTimestamp: String(START + 60000),
+      },
+      START,
+    )
+    expect(built.data).toMatchObject({ method: 'bottle', amountMl: 120 })
+    expect(built.data.side).toBeUndefined()
+    expect(built.endTimestamp).toBe(START + 60000)
+  })
+
+  test('sleep carries only its end time', () => {
+    const built = buildEventInput(
+      'sleep',
+      { endTimestamp: String(START + 3600000) },
+      START,
+    )
+    expect(built.data).toEqual({})
+    expect(built.endTimestamp).toBe(START + 3600000)
+  })
+
+  test('reports the incomplete-entry errors', () => {
+    expect(buildEventInput('growth', {}, START).error).toBe(
+      'Enter at least one measurement',
+    )
+    expect(buildEventInput('medication', { name: '  ' }, START).error).toBe(
+      'Enter a medication name',
+    )
+    expect(buildEventInput('vaccination', { name: '' }, START).error).toBe(
+      'Enter a vaccine name',
+    )
+  })
+
+  test('a note is only a milestone when ticked', () => {
+    expect(buildEventInput('note', { milestone: true }, START).data).toEqual({
+      milestone: true,
+    })
+    expect(buildEventInput('note', { milestone: false }, START).data).toEqual({
+      milestone: undefined,
+    })
+  })
+})

--- a/src/lib/babyEventFormValues.test.ts
+++ b/src/lib/babyEventFormValues.test.ts
@@ -106,6 +106,25 @@ describe('buildEventInput — breast feeds', () => {
     )
   })
 
+  test('clearing the minutes clears the duration they produced', () => {
+    const values = initialEventValues(
+      'feeding',
+      eventDoc(
+        'feeding',
+        { method: 'breast', side: 'both', leftMin: 10, rightMin: 8 },
+        START + 18 * 60000,
+      ),
+    )
+    const built = buildEventInput(
+      'feeding',
+      { ...values, leftMin: '', rightMin: '' },
+      START,
+    )
+    expect(built.endTimestamp).toBeUndefined()
+    expect(built.data.leftMin).toBeUndefined()
+    expect(built.data.rightMin).toBeUndefined()
+  })
+
   test('rejects negative minutes', () => {
     expect(
       buildEventInput('feeding', { method: 'breast', leftMin: '-5' }, START)

--- a/src/lib/babyEventFormValues.ts
+++ b/src/lib/babyEventFormValues.ts
@@ -76,6 +76,11 @@ export function initialEventValues(
         amountMl: seedNumber(event, 'amountMl'),
         leftMin: seedNumber(event, 'leftMin'),
         rightMin: seedNumber(event, 'rightMin'),
+        // Distinguishes "duration cleared" from "entry predates per-side
+        // minutes" once both minute fields are empty — see buildFeeding.
+        hadSideMinutes:
+          typeof fromData(event, 'leftMin') === 'number' ||
+          typeof fromData(event, 'rightMin') === 'number',
         endTimestamp,
       }
     case 'diaper':
@@ -127,10 +132,16 @@ function buildFeeding(values: EventValues, timestampMs: number): EventInput {
   else if (rightMin !== undefined) side = 'right'
   else side = str(values.side) || undefined
 
+  // With no minutes, only a legacy entry — one whose duration was recorded
+  // through the old End inputs — keeps its stored end. If the entry *had*
+  // per-side minutes, emptying both fields is how you clear the duration, and
+  // breast feeds have no End inputs to clear it any other way.
   const totalMin = (leftMin ?? 0) + (rightMin ?? 0)
   const endTimestamp =
     leftMin === undefined && rightMin === undefined
-      ? storedEnd
+      ? values.hadSideMinutes === true
+        ? undefined
+        : storedEnd
       : timestampMs + totalMin * 60000
 
   return {

--- a/src/lib/babyEventFormValues.ts
+++ b/src/lib/babyEventFormValues.ts
@@ -1,0 +1,209 @@
+import type { Doc } from '../../convex/_generated/dataModel'
+import type { BabyEventData, BabyEventType } from '../../convex/lib/babyEvents'
+import { DEFAULT_TEMPERATURE_CELSIUS } from './babyEventFields'
+import { readLastUsed, writeLastUsed } from './lastUsed'
+
+/** Flat, string-keyed form state for one event type. Kept as plain values
+ * (rather than a `useState` per field) so a single form can hold several
+ * types at once — see MultiEventForm. */
+export type EventValues = Record<string, string | boolean>
+
+export interface EventInput {
+  data: BabyEventData
+  /** Absent means "no end time"; callers editing an event should send null. */
+  endTimestamp?: number
+  error?: string
+}
+
+function str(value: string | boolean | undefined): string {
+  return typeof value === 'string' ? value : ''
+}
+
+/** Trimmed numeric field → number, or undefined when blank/unparseable. */
+function num(value: string | boolean | undefined): number | undefined {
+  const raw = str(value).trim()
+  if (!raw) return undefined
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function fromData(event: Doc<'babyEvents'> | undefined, key: string): unknown {
+  return (event?.data as Record<string, unknown> | undefined)?.[key]
+}
+
+function seedString(
+  event: Doc<'babyEvents'> | undefined,
+  key: string,
+  lastUsedKey?: string,
+  fallback = '',
+): string {
+  const existing = fromData(event, key)
+  if (typeof existing === 'string') return existing
+  if (event) return ''
+  return (lastUsedKey ? readLastUsed(lastUsedKey) : null) ?? fallback
+}
+
+function seedNumber(event: Doc<'babyEvents'> | undefined, key: string): string {
+  const existing = fromData(event, key)
+  return typeof existing === 'number' ? String(existing) : ''
+}
+
+/** Initial form state for `type`, seeded from `event` when editing and from
+ * the last-used choices otherwise. */
+export function initialEventValues(
+  type: BabyEventType,
+  event?: Doc<'babyEvents'>,
+): EventValues {
+  const endTimestamp = event?.endTimestamp ? String(event.endTimestamp) : ''
+  switch (type) {
+    case 'temperature': {
+      const celsius = fromData(event, 'celsius')
+      return {
+        celsius:
+          typeof celsius === 'number'
+            ? celsius.toFixed(1)
+            : (readLastUsed('temperatureCelsius') ??
+              DEFAULT_TEMPERATURE_CELSIUS),
+        method: seedString(event, 'method', 'temperatureMethod'),
+      }
+    }
+    case 'feeding':
+      return {
+        method: seedString(event, 'method', 'feedingMethod', 'bottle'),
+        // Not an input any more (per-side minutes replaced it) — carried
+        // through so editing a pre-duration entry keeps its side.
+        side: seedString(event, 'side'),
+        amountMl: seedNumber(event, 'amountMl'),
+        leftMin: seedNumber(event, 'leftMin'),
+        rightMin: seedNumber(event, 'rightMin'),
+        endTimestamp,
+      }
+    case 'diaper':
+      return { kind: seedString(event, 'kind', 'diaperKind', 'wet') }
+    case 'sleep':
+      return { endTimestamp }
+    case 'growth':
+      return {
+        weightKg: seedNumber(event, 'weightKg'),
+        heightCm: seedNumber(event, 'heightCm'),
+        headCircumferenceCm: seedNumber(event, 'headCircumferenceCm'),
+      }
+    case 'medication':
+      return {
+        name: seedString(event, 'name'),
+        doseAmount: seedNumber(event, 'doseAmount'),
+        doseUnit: seedString(event, 'doseUnit'),
+      }
+    case 'vaccination':
+      return { name: seedString(event, 'name') }
+    case 'note':
+      return { milestone: fromData(event, 'milestone') === true }
+  }
+}
+
+function buildFeeding(values: EventValues, timestampMs: number): EventInput {
+  const method = str(values.method)
+  const amountMl = num(values.amountMl)
+  const storedEnd = num(values.endTimestamp)
+
+  if (method !== 'breast') {
+    return {
+      data: { method, amountMl },
+      endTimestamp: storedEnd,
+    }
+  }
+
+  const leftMin = num(values.leftMin)
+  const rightMin = num(values.rightMin)
+  if ((leftMin ?? 0) < 0 || (rightMin ?? 0) < 0) {
+    return { data: {}, error: 'Minutes cannot be negative' }
+  }
+
+  // Which side(s) got minutes *is* the side. With no minutes at all, keep
+  // whatever the entry already had rather than dropping it.
+  let side: string | undefined
+  if (leftMin !== undefined && rightMin !== undefined) side = 'both'
+  else if (leftMin !== undefined) side = 'left'
+  else if (rightMin !== undefined) side = 'right'
+  else side = str(values.side) || undefined
+
+  const totalMin = (leftMin ?? 0) + (rightMin ?? 0)
+  const endTimestamp =
+    leftMin === undefined && rightMin === undefined
+      ? storedEnd
+      : timestampMs + totalMin * 60000
+
+  return {
+    data: { method, side, amountMl, leftMin, rightMin },
+    endTimestamp,
+  }
+}
+
+/** Form state → the `data` payload and `endTimestamp` for a babyEvents write,
+ * or a user-facing `error` when the entry is incomplete. */
+export function buildEventInput(
+  type: BabyEventType,
+  values: EventValues,
+  timestampMs: number,
+): EventInput {
+  switch (type) {
+    case 'temperature': {
+      const celsius = num(values.celsius)
+      if (celsius === undefined) {
+        return { data: {}, error: 'Select a temperature' }
+      }
+      return { data: { celsius, method: str(values.method) || undefined } }
+    }
+    case 'feeding':
+      return buildFeeding(values, timestampMs)
+    case 'diaper':
+      return { data: { kind: str(values.kind) } }
+    case 'sleep':
+      return { data: {}, endTimestamp: num(values.endTimestamp) }
+    case 'growth': {
+      const weightKg = num(values.weightKg)
+      const heightCm = num(values.heightCm)
+      const headCircumferenceCm = num(values.headCircumferenceCm)
+      if (
+        weightKg === undefined &&
+        heightCm === undefined &&
+        headCircumferenceCm === undefined
+      ) {
+        return { data: {}, error: 'Enter at least one measurement' }
+      }
+      return { data: { weightKg, heightCm, headCircumferenceCm } }
+    }
+    case 'medication': {
+      const name = str(values.name).trim()
+      if (!name) return { data: {}, error: 'Enter a medication name' }
+      return {
+        data: {
+          name,
+          doseAmount: num(values.doseAmount),
+          doseUnit: str(values.doseUnit).trim() || undefined,
+        },
+      }
+    }
+    case 'vaccination': {
+      const name = str(values.name).trim()
+      if (!name) return { data: {}, error: 'Enter a vaccine name' }
+      return { data: { name } }
+    }
+    case 'note':
+      return {
+        data: { milestone: values.milestone === true ? true : undefined },
+      }
+  }
+}
+
+/** Persist the repetitive choices so the next entry of this type defaults to them. */
+export function rememberEventChoices(type: BabyEventType, values: EventValues) {
+  if (type === 'temperature') {
+    writeLastUsed('temperatureCelsius', str(values.celsius))
+    if (values.method) writeLastUsed('temperatureMethod', str(values.method))
+  } else if (type === 'feeding') {
+    writeLastUsed('feedingMethod', str(values.method))
+  } else if (type === 'diaper') {
+    writeLastUsed('diaperKind', str(values.kind))
+  }
+}

--- a/src/lib/babyEventSummary.test.ts
+++ b/src/lib/babyEventSummary.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest'
+import type { Doc } from '../../convex/_generated/dataModel'
+import { summarizeEvent } from './babyEventSummary'
+
+const START = new Date('2026-07-25T09:00:00').getTime()
+
+function feeding(
+  data: Record<string, unknown>,
+  endTimestamp?: number,
+): Doc<'babyEvents'> {
+  return {
+    _id: 'event1' as Doc<'babyEvents'>['_id'],
+    _creationTime: START,
+    babyId: 'baby1' as Doc<'babyEvents'>['babyId'],
+    type: 'feeding',
+    timestamp: START,
+    endTimestamp,
+    loggedBy: 'user1' as Doc<'babyEvents'>['loggedBy'],
+    data,
+  } as Doc<'babyEvents'>
+}
+
+describe('summarizeEvent — feeding', () => {
+  test('shows both sides with their minutes', () => {
+    expect(
+      summarizeEvent(
+        feeding({ method: 'breast', side: 'both', leftMin: 10, rightMin: 8 }),
+      ),
+    ).toBe('Breastfeeding · Left 10m · Right 8m')
+  })
+
+  test('shows only the side that was fed', () => {
+    expect(
+      summarizeEvent(feeding({ method: 'breast', side: 'right', rightMin: 7 })),
+    ).toBe('Breastfeeding · Right 7m')
+  })
+
+  test('falls back to the plain side for entries without minutes', () => {
+    expect(summarizeEvent(feeding({ method: 'breast', side: 'left' }))).toBe(
+      'Breastfeeding · Left',
+    )
+  })
+
+  test('bottle feeds still show the amount', () => {
+    expect(summarizeEvent(feeding({ method: 'bottle', amountMl: 120 }))).toBe(
+      'Bottle · 120 ml',
+    )
+  })
+})

--- a/src/lib/babyEventSummary.ts
+++ b/src/lib/babyEventSummary.ts
@@ -23,12 +23,24 @@ export function summarizeEvent(event: Doc<'babyEvents'>): string {
         typeof data.method === 'string'
           ? (FEEDING_METHOD_LABELS[data.method] ?? data.method)
           : ''
+      const amount =
+        typeof data.amountMl === 'number' ? ` · ${data.amountMl} ml` : ''
+      // Per-side minutes supersede the coarse side label when present —
+      // "Left 10m · Right 8m" already says which side(s).
+      const sides: string[] = []
+      if (typeof data.leftMin === 'number') {
+        sides.push(`${FEEDING_SIDE_LABELS.left} ${data.leftMin}m`)
+      }
+      if (typeof data.rightMin === 'number') {
+        sides.push(`${FEEDING_SIDE_LABELS.right} ${data.rightMin}m`)
+      }
+      if (sides.length > 0) {
+        return `${method} · ${sides.join(' · ')}${amount}`
+      }
       const side =
         typeof data.side === 'string'
           ? ` · ${FEEDING_SIDE_LABELS[data.side] ?? data.side}`
           : ''
-      const amount =
-        typeof data.amountMl === 'number' ? ` · ${data.amountMl} ml` : ''
       return `${method}${side}${amount}`
     }
     case 'diaper': {

--- a/src/lib/babyPdfExport.test.ts
+++ b/src/lib/babyPdfExport.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest'
+import type { Doc } from '../../convex/_generated/dataModel'
+import type { BabyEventType } from '../../convex/lib/babyEvents'
+import { groupEventsByMinute } from './babyPdfExport'
+
+const START = new Date('2026-07-25T09:00:00').getTime()
+
+function event(
+  id: string,
+  type: BabyEventType,
+  timestamp: number,
+): Doc<'babyEvents'> {
+  return {
+    _id: id as Doc<'babyEvents'>['_id'],
+    _creationTime: timestamp,
+    babyId: 'baby1' as Doc<'babyEvents'>['babyId'],
+    type,
+    timestamp,
+    loggedBy: 'user1' as Doc<'babyEvents'>['loggedBy'],
+    data: {},
+  } as Doc<'babyEvents'>
+}
+
+describe('groupEventsByMinute', () => {
+  test('merges everything logged in the same minute', () => {
+    const groups = groupEventsByMinute([
+      event('a', 'diaper', START),
+      event('b', 'temperature', START),
+      event('c', 'feeding', START),
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].events.map((e) => e._id)).toEqual(['a', 'b', 'c'])
+  })
+
+  test('groups by the clock minute, not the exact millisecond', () => {
+    const groups = groupEventsByMinute([
+      event('a', 'diaper', START + 1200),
+      event('b', 'feeding', START + 45_000),
+    ])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].minuteMs).toBe(START)
+  })
+
+  test('keeps different minutes apart and in time order', () => {
+    const groups = groupEventsByMinute([
+      event('later', 'feeding', START + 120_000),
+      event('earlier', 'diaper', START),
+    ])
+    expect(groups.map((g) => g.minuteMs)).toEqual([START, START + 120_000])
+    expect(groups.map((g) => g.events[0]._id)).toEqual(['earlier', 'later'])
+  })
+
+  test('drops types that were not included in the export', () => {
+    const groups = groupEventsByMinute(
+      [event('a', 'diaper', START), event('b', 'note', START)],
+      ['diaper'],
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0].events.map((e) => e._id)).toEqual(['a'])
+  })
+
+  test('returns nothing when no event matches', () => {
+    expect(groupEventsByMinute([event('a', 'note', START)], ['sleep'])).toEqual(
+      [],
+    )
+  })
+})

--- a/src/lib/babyPdfExport.ts
+++ b/src/lib/babyPdfExport.ts
@@ -9,29 +9,72 @@ import {
 import { formatAge } from './babyDate'
 import { summarizeEvent } from './babyEventSummary'
 
+export type BabyPdfLayout = 'category' | 'chronological'
+
 export interface BabyPdfExportOptions {
   baby: { name: string; birthDate: string }
   events: Doc<'babyEvents'>[]
   from: number
   to: number
   types?: BabyEventType[]
+  /** 'category' (default): one table per event type. 'chronological': a single
+   * table in time order, entries logged in the same minute merged into one row. */
+  layout?: BabyPdfLayout
+}
+
+export interface MinuteGroup {
+  minuteMs: number
+  events: Doc<'babyEvents'>[]
 }
 
 const PAGE_BOTTOM_MARGIN = 270
+const TABLE_STYLES = {
+  styles: { fontSize: 9 },
+  headStyles: { fillColor: [70, 130, 140] as [number, number, number] },
+  margin: { left: 14, right: 14 },
+}
 
-/** Client-side PDF export (no server-side PDF capability on this stack —
- * see the Baby log module plan). One table per included event category,
- * chronological within each. */
-export function exportBabyLogPdf({
-  baby,
-  events,
-  from,
-  to,
-  types,
-}: BabyPdfExportOptions) {
-  const included = types ?? [...BABY_EVENT_TYPES]
-  const doc = new jsPDF()
+function formatDate(ms: number): string {
+  return new Date(ms).toLocaleDateString()
+}
 
+function formatTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+/** Chronological events bucketed by the minute they were logged in — entries
+ * saved together by the multi-entry form share a timestamp and so land in one
+ * bucket. */
+export function groupEventsByMinute(
+  events: Doc<'babyEvents'>[],
+  types?: BabyEventType[],
+): MinuteGroup[] {
+  const included = new Set(types ?? BABY_EVENT_TYPES)
+  const groups = new Map<number, MinuteGroup>()
+  for (const event of events) {
+    if (!included.has(event.type)) continue
+    const minuteMs = Math.floor(event.timestamp / 60000) * 60000
+    const group = groups.get(minuteMs)
+    if (group) group.events.push(event)
+    else groups.set(minuteMs, { minuteMs, events: [event] })
+  }
+  return Array.from(groups.values())
+    .sort((a, b) => a.minuteMs - b.minuteMs)
+    .map((group) => ({
+      minuteMs: group.minuteMs,
+      events: [...group.events].sort((a, b) => a.timestamp - b.timestamp),
+    }))
+}
+
+function drawHeader(
+  doc: jsPDF,
+  baby: { name: string; birthDate: string },
+  from: number,
+  to: number,
+) {
   doc.setFontSize(16)
   doc.text(`${baby.name} — baby log`, 14, 18)
   doc.setFontSize(10)
@@ -41,13 +84,16 @@ export function exportBabyLogPdf({
     14,
     25,
   )
-  doc.text(
-    `${new Date(from).toLocaleDateString()} – ${new Date(to).toLocaleDateString()}`,
-    14,
-    31,
-  )
+  doc.text(`${formatDate(from)} – ${formatDate(to)}`, 14, 31)
   doc.setTextColor(0)
+}
 
+/** One table per event type, chronological within each. */
+function drawByCategory(
+  doc: jsPDF,
+  events: Doc<'babyEvents'>[],
+  included: BabyEventType[],
+): boolean {
   let cursorY = 40
   let printedAny = false
 
@@ -69,21 +115,13 @@ export function exportBabyLogPdf({
     autoTable(doc, {
       startY: cursorY + 3,
       head: [['Date', 'Time', 'Details', 'Notes']],
-      body: rows.map((e) => {
-        const d = new Date(e.timestamp)
-        return [
-          d.toLocaleDateString(),
-          d.toLocaleTimeString(undefined, {
-            hour: 'numeric',
-            minute: '2-digit',
-          }),
-          summarizeEvent(e),
-          e.notes ?? '',
-        ]
-      }),
-      styles: { fontSize: 9 },
-      headStyles: { fillColor: [70, 130, 140] },
-      margin: { left: 14, right: 14 },
+      body: rows.map((e) => [
+        formatDate(e.timestamp),
+        formatTime(e.timestamp),
+        summarizeEvent(e),
+        e.notes ?? '',
+      ]),
+      ...TABLE_STYLES,
     })
 
     const finalY = (doc as unknown as { lastAutoTable?: { finalY: number } })
@@ -91,9 +129,67 @@ export function exportBabyLogPdf({
     cursorY = (finalY ?? cursorY + 10) + 12
   }
 
+  return printedAny
+}
+
+/** A single time-ordered table, one row per minute — everything logged in the
+ * same minute (a diaper check, a temperature and a feed) reads as one line. */
+function drawChronological(
+  doc: jsPDF,
+  events: Doc<'babyEvents'>[],
+  included: BabyEventType[],
+): boolean {
+  const groups = groupEventsByMinute(events, included)
+  if (groups.length === 0) return false
+
+  autoTable(doc, {
+    startY: 40,
+    head: [['Date', 'Time', 'Entries', 'Notes']],
+    body: groups.map((group) => [
+      formatDate(group.minuteMs),
+      formatTime(group.minuteMs),
+      group.events
+        .map((e) => `${BABY_EVENT_LABELS[e.type]}: ${summarizeEvent(e)}`)
+        .join('\n'),
+      group.events
+        .filter((e) => e.notes)
+        .map((e) =>
+          // Only worth labelling whose note it is when the row holds several.
+          group.events.length > 1
+            ? `${BABY_EVENT_LABELS[e.type]}: ${e.notes}`
+            : e.notes,
+        )
+        .join('\n'),
+    ]),
+    ...TABLE_STYLES,
+  })
+
+  return true
+}
+
+/** Client-side PDF export (no server-side PDF capability on this stack —
+ * see the Baby log module plan). */
+export function exportBabyLogPdf({
+  baby,
+  events,
+  from,
+  to,
+  types,
+  layout = 'category',
+}: BabyPdfExportOptions) {
+  const included = types ?? [...BABY_EVENT_TYPES]
+  const doc = new jsPDF()
+
+  drawHeader(doc, baby, from, to)
+
+  const printedAny =
+    layout === 'chronological'
+      ? drawChronological(doc, events, included)
+      : drawByCategory(doc, events, included)
+
   if (!printedAny) {
     doc.setFontSize(11)
-    doc.text('No entries in this date range.', 14, cursorY)
+    doc.text('No entries in this date range.', 14, 40)
   }
 
   const dateStamp = new Date(to).toISOString().slice(0, 10)


### PR DESCRIPTION
Three changes to the baby log, driven by daily use:

- Breast feeds record per-side minutes. `feedingDataValidator` gains
  optional `leftMin`/`rightMin`; the side select is replaced by two
  minute inputs, with `side` and `endTimestamp` derived from them.
  Entries logged before this keep their side when edited without
  minutes, and bottle/solid feeds are untouched.

- A "Log several" form writes several entries at one shared timestamp
  — the usual round is a diaper check, a temperature and a feed. Each
  checked type still becomes its own babyEvents row, so the timeline,
  charts and per-category export are unaffected. The selection is
  remembered between visits.

  This needed the per-type form state out of EventForm's ~15 useStates
  (a single form now holds several types at once): it moves to a
  controlled values object with pure builders in babyEventFormValues.ts
  and a presentational EventTypeFields component, both shared by the
  single- and multi-entry forms.

- The PDF export takes a layout option. "Chronological" emits one
  time-ordered table where everything logged in the same minute merges
  into a single row, so a night check reads as one line instead of
  three rows in three tables. "By category" stays the default and is
  unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HNJs63yKwhizKtiDNX345o