### PR TITLE
Add OFF name-search fallback to the nutrition food picker

### DIFF
--- a/convex/foodsLookup.ts
+++ b/convex/foodsLookup.ts
@@ -3,8 +3,8 @@
 import { ConvexError, v } from 'convex/values'
 import { api } from './_generated/api'
 import { action } from './_generated/server'
-import { fetchOffProduct } from './lib/offFetch'
-import { mapOffProduct } from './lib/offMapping'
+import { fetchOffProduct, searchOffProducts } from './lib/offFetch'
+import { mapOffProduct, mapOffSearchResults } from './lib/offMapping'
 
 // Fetches + maps a barcode from Open Food Facts, without saving anything —
 // the client shows the result for review and calls `foods.upsertFromOff`
@@ -51,5 +51,20 @@ export const refreshFromOff = action({
       servingSize: mapped.servingSize,
       servingLabel: mapped.servingLabel,
     })
+  },
+})
+
+// Searches Open Food Facts by name — the "no local match" fallback in
+// FoodAddTab's search box. Best-effort: any OFF-side failure (network,
+// timeout, malformed response) surfaces as an empty array, never a thrown
+// error, matching lookupBarcode's contract — a failed OFF search just means
+// "no matches", same as a genuinely empty result set.
+export const searchByName = action({
+  args: { term: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity) throw new ConvexError('Not authenticated')
+    const raw = await searchOffProducts(args.term)
+    return mapOffSearchResults(raw)
   },
 })

--- a/convex/lib/offFetch.test.ts
+++ b/convex/lib/offFetch.test.ts
@@ -68,7 +68,7 @@ describe('searchOffProducts', () => {
     const fetchImpl = vi.fn().mockResolvedValue(mockResponse({ hits: [] }))
     await searchOffProducts('nutella', fetchImpl)
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://search.openfoodfacts.org/search?q=nutella&page_size=20&fields=code%2Cproduct_name%2Cproduct_name_nl%2Cbrands%2Cnutriments%2Cserving_size%2Cserving_quantity',
+      'https://search.openfoodfacts.org/search?q=nutella&page_size=40&fields=code%2Cproduct_name%2Cproduct_name_nl%2Cbrands%2Cnutriments%2Cserving_size%2Cserving_quantity',
       expect.objectContaining({
         headers: expect.objectContaining({
           'User-Agent': expect.any(String),

--- a/convex/lib/offFetch.test.ts
+++ b/convex/lib/offFetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest'
-import { fetchOffProduct } from './offFetch'
+import { fetchOffProduct, searchOffProducts } from './offFetch'
 
 function mockResponse(body: unknown, ok = true): Response {
   return { ok, json: async () => body } as Response
@@ -57,6 +57,60 @@ describe('fetchOffProduct', () => {
     expect(
       await fetchOffProduct(
         '3017620422003',
+        vi.fn().mockRejectedValue(new Error('network down')),
+      ),
+    ).toBeNull()
+  })
+})
+
+describe('searchOffProducts', () => {
+  test('fetches the search endpoint with the term, page size, and field list', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(mockResponse({ products: [] }))
+    await searchOffProducts('nutella', fetchImpl)
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://world.openfoodfacts.org/api/v2/search?search_terms=nutella&page_size=20&fields=code%2Cproduct_name%2Cproduct_name_nl%2Cbrands%2Cnutriments%2Cserving_size%2Cserving_quantity',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'User-Agent': expect.any(String),
+        }),
+      }),
+    )
+  })
+
+  test('returns the parsed JSON on success', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        mockResponse({ products: [{ code: '123', product_name: 'Test' }] }),
+      )
+    expect(await searchOffProducts('test', fetchImpl)).toEqual({
+      products: [{ code: '123', product_name: 'Test' }],
+    })
+  })
+
+  test('returns null on a non-ok response, a JSON parse failure, and a fetch throw', async () => {
+    expect(
+      await searchOffProducts(
+        'test',
+        vi.fn().mockResolvedValue(mockResponse({}, false)),
+      ),
+    ).toBeNull()
+    expect(
+      await searchOffProducts(
+        'test',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => {
+            throw new Error('bad json')
+          },
+        } as unknown as Response),
+      ),
+    ).toBeNull()
+    expect(
+      await searchOffProducts(
+        'test',
         vi.fn().mockRejectedValue(new Error('network down')),
       ),
     ).toBeNull()

--- a/convex/lib/offFetch.test.ts
+++ b/convex/lib/offFetch.test.ts
@@ -64,13 +64,11 @@ describe('fetchOffProduct', () => {
 })
 
 describe('searchOffProducts', () => {
-  test('fetches the search endpoint with the term, page size, and field list', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValue(mockResponse({ products: [] }))
+  test('fetches the search-a-licious endpoint with the term, page size, and field list', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(mockResponse({ hits: [] }))
     await searchOffProducts('nutella', fetchImpl)
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://world.openfoodfacts.org/api/v2/search?search_terms=nutella&page_size=20&fields=code%2Cproduct_name%2Cproduct_name_nl%2Cbrands%2Cnutriments%2Cserving_size%2Cserving_quantity',
+      'https://search.openfoodfacts.org/search?q=nutella&page_size=20&fields=code%2Cproduct_name%2Cproduct_name_nl%2Cbrands%2Cnutriments%2Cserving_size%2Cserving_quantity',
       expect.objectContaining({
         headers: expect.objectContaining({
           'User-Agent': expect.any(String),
@@ -83,10 +81,10 @@ describe('searchOffProducts', () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValue(
-        mockResponse({ products: [{ code: '123', product_name: 'Test' }] }),
+        mockResponse({ hits: [{ code: '123', product_name: 'Test' }] }),
       )
     expect(await searchOffProducts('test', fetchImpl)).toEqual({
-      products: [{ code: '123', product_name: 'Test' }],
+      hits: [{ code: '123', product_name: 'Test' }],
     })
   })
 

--- a/convex/lib/offFetch.ts
+++ b/convex/lib/offFetch.ts
@@ -32,3 +32,36 @@ export async function fetchOffProduct(
     return null
   }
 }
+
+// Searches Open Food Facts by free-text term (product name/brand) for the
+// "no local match" fallback in FoodAddTab. Same never-throw contract as
+// fetchOffProduct: returns the raw parsed JSON ({products: [...]} shape) on
+// success, or null on any failure (network error, timeout, non-OK status,
+// invalid JSON) — the caller treats null the same as "no matches".
+export async function searchOffProducts(
+  term: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<unknown | null> {
+  const url = new URL('https://world.openfoodfacts.org/api/v2/search')
+  url.searchParams.set('search_terms', term)
+  url.searchParams.set('page_size', '20')
+  url.searchParams.set(
+    'fields',
+    'code,product_name,product_name_nl,brands,nutriments,serving_size,serving_quantity',
+  )
+  let response: Response
+  try {
+    response = await fetchImpl(url.toString(), {
+      headers: { 'User-Agent': OFF_USER_AGENT },
+      signal: AbortSignal.timeout(OFF_TIMEOUT_MS),
+    })
+  } catch {
+    return null
+  }
+  if (!response.ok) return null
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}

--- a/convex/lib/offFetch.ts
+++ b/convex/lib/offFetch.ts
@@ -34,16 +34,23 @@ export async function fetchOffProduct(
 }
 
 // Searches Open Food Facts by free-text term (product name/brand) for the
-// "no local match" fallback in FoodAddTab. Same never-throw contract as
-// fetchOffProduct: returns the raw parsed JSON ({products: [...]} shape) on
+// "no local match" fallback in FoodAddTab. Full-text search is NOT part of
+// the world.openfoodfacts.org/api/v2 REST API — that API is structured/tag
+// search only and silently ignores an unrecognized `search_terms` param
+// (returning an unfiltered, identical-every-time page of the whole catalog
+// rather than an error, which is what shipped here originally). The actual
+// full-text search service is "search-a-licious" at search.openfoodfacts.org,
+// a separate host with its own response shape ({hits: [...]}, see
+// mapOffSearchResults) and `q` query param instead of `search_terms`. Same
+// never-throw contract as fetchOffProduct: returns the raw parsed JSON on
 // success, or null on any failure (network error, timeout, non-OK status,
 // invalid JSON) — the caller treats null the same as "no matches".
 export async function searchOffProducts(
   term: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<unknown | null> {
-  const url = new URL('https://world.openfoodfacts.org/api/v2/search')
-  url.searchParams.set('search_terms', term)
+  const url = new URL('https://search.openfoodfacts.org/search')
+  url.searchParams.set('q', term)
   url.searchParams.set('page_size', '20')
   url.searchParams.set(
     'fields',

--- a/convex/lib/offFetch.ts
+++ b/convex/lib/offFetch.ts
@@ -51,7 +51,11 @@ export async function searchOffProducts(
 ): Promise<unknown | null> {
   const url = new URL('https://search.openfoodfacts.org/search')
   url.searchParams.set('q', term)
-  url.searchParams.set('page_size', '20')
+  // Requesting more than the ~20 we ultimately show: mapOffSearchResults
+  // drops empty-nutrition duplicates and dedupes same-name/brand hits (OFF
+  // has many low-quality duplicate barcodes for popular products), so a
+  // 1:1 page size would often leave far fewer than 20 usable results.
+  url.searchParams.set('page_size', '40')
   url.searchParams.set(
     'fields',
     'code,product_name,product_name_nl,brands,nutriments,serving_size,serving_quantity',

--- a/convex/lib/offMapping.test.ts
+++ b/convex/lib/offMapping.test.ts
@@ -7,7 +7,7 @@
 // @vitest-environment node
 import { readFileSync } from 'node:fs'
 import { describe, expect, test } from 'vitest'
-import { mapOffProduct } from './offMapping'
+import { mapOffProduct, mapOffSearchResults } from './offMapping'
 
 function fixture(name: string): unknown {
   return JSON.parse(
@@ -125,5 +125,78 @@ describe('mapOffProduct — synthetic edge cases', () => {
       },
     })
     expect(mapped?.servingSize).toBe(45)
+  })
+})
+
+describe('mapOffSearchResults', () => {
+  test('maps each product in the products array and attaches its barcode', () => {
+    const results = mapOffSearchResults({
+      products: [
+        {
+          code: '3017620422003',
+          product_name: 'Nutella',
+          brands: 'Ferrero,Nutella',
+          nutriments: { 'energy-kcal_100g': 539 },
+        },
+      ],
+    })
+    expect(results).toEqual([
+      {
+        barcode: '3017620422003',
+        name: 'Nutella',
+        brand: 'Ferrero',
+        nutritionPer100: { calories: 539 },
+        servingSize: undefined,
+        servingLabel: undefined,
+      },
+    ])
+  })
+
+  test('drops entries with no usable name', () => {
+    const results = mapOffSearchResults({
+      products: [{ code: '111', nutriments: {} }],
+    })
+    expect(results).toEqual([])
+  })
+
+  test('drops entries with a missing or empty barcode', () => {
+    const results = mapOffSearchResults({
+      products: [
+        { product_name: 'No Code', nutriments: {} },
+        { code: '', product_name: 'Empty Code', nutriments: {} },
+      ],
+    })
+    expect(results).toEqual([])
+  })
+
+  test('prefers the Dutch product name, same as mapOffProduct', () => {
+    const results = mapOffSearchResults({
+      products: [
+        {
+          code: '222',
+          product_name: 'Generic Name',
+          product_name_nl: 'Nederlandse Naam',
+          nutriments: {},
+        },
+      ],
+    })
+    expect(results[0]?.name).toBe('Nederlandse Naam')
+  })
+
+  test('caps the result at 20 entries', () => {
+    const products = Array.from({ length: 30 }, (_, i) => ({
+      code: `${1000 + i}`,
+      product_name: `Item ${i}`,
+      nutriments: {},
+    }))
+    const results = mapOffSearchResults({ products })
+    expect(results).toHaveLength(20)
+  })
+
+  test('returns an empty list for malformed or non-object input', () => {
+    expect(mapOffSearchResults(null)).toEqual([])
+    expect(mapOffSearchResults('nope')).toEqual([])
+    expect(mapOffSearchResults({})).toEqual([])
+    expect(mapOffSearchResults({ products: 'not-an-array' })).toEqual([])
   })
 })

--- a/convex/lib/offMapping.test.ts
+++ b/convex/lib/offMapping.test.ts
@@ -162,7 +162,7 @@ describe('mapOffSearchResults', () => {
           code: '8712800189930',
           product_name: 'Chocomel Original',
           brands: ['Chocomel', ' FrieslandCampina'],
-          nutriments: {},
+          nutriments: { 'energy-kcal_100g': 62 },
         },
       ],
     })
@@ -171,7 +171,9 @@ describe('mapOffSearchResults', () => {
 
   test('drops entries with no usable name', () => {
     const results = mapOffSearchResults({
-      hits: [{ code: '111', nutriments: {} }],
+      hits: [
+        { code: '111', nutriments: { 'energy-kcal_100g': 100 } },
+      ],
     })
     expect(results).toEqual([])
   })
@@ -179,9 +181,26 @@ describe('mapOffSearchResults', () => {
   test('drops entries with a missing or empty barcode', () => {
     const results = mapOffSearchResults({
       hits: [
-        { product_name: 'No Code', nutriments: {} },
-        { code: '', product_name: 'Empty Code', nutriments: {} },
+        {
+          product_name: 'No Code',
+          nutriments: { 'energy-kcal_100g': 100 },
+        },
+        {
+          code: '',
+          product_name: 'Empty Code',
+          nutriments: { 'energy-kcal_100g': 100 },
+        },
       ],
+    })
+    expect(results).toEqual([])
+  })
+
+  // OFF's product database has many low-quality duplicate barcodes with no
+  // nutrition data at all published — useless for a nutrition tracker, and
+  // the direct cause of near-empty entries cluttering search results.
+  test('drops entries with no nutrition data at all', () => {
+    const results = mapOffSearchResults({
+      hits: [{ code: '333', product_name: 'Empty Nutrition', nutriments: {} }],
     })
     expect(results).toEqual([])
   })
@@ -193,18 +212,77 @@ describe('mapOffSearchResults', () => {
           code: '222',
           product_name: 'Generic Name',
           product_name_nl: 'Nederlandse Naam',
-          nutriments: {},
+          nutriments: { 'energy-kcal_100g': 100 },
         },
       ],
     })
     expect(results[0]?.name).toBe('Nederlandse Naam')
   })
 
-  test('caps the result at 20 entries', () => {
+  // A search for a popular product often returns many barcodes for the same
+  // real-world item, unevenly filled in by different contributors — keep
+  // only the one with the most nutrition data populated per name+brand.
+  test('deduplicates same name+brand hits, keeping the one with the most nutrients', () => {
+    const results = mapOffSearchResults({
+      hits: [
+        {
+          code: '111',
+          product_name: 'Nutella',
+          brands: 'Ferrero',
+          nutriments: { 'energy-kcal_100g': 539 },
+        },
+        {
+          code: '222',
+          product_name: 'Nutella',
+          brands: 'Ferrero',
+          nutriments: {
+            'energy-kcal_100g': 539,
+            proteins_100g: 6.3,
+            fat_100g: 30.9,
+          },
+        },
+        {
+          code: '333',
+          product_name: 'nutella', // case-insensitive dedup key
+          brands: 'Ferrero',
+          nutriments: { 'energy-kcal_100g': 539 },
+        },
+      ],
+    })
+    expect(results).toHaveLength(1)
+    expect(results[0]?.barcode).toBe('222')
+    expect(results[0]?.nutritionPer100).toEqual({
+      calories: 539,
+      protein: 6.3,
+      fat: 30.9,
+    })
+  })
+
+  test('does not deduplicate entries with the same name but a different brand', () => {
+    const results = mapOffSearchResults({
+      hits: [
+        {
+          code: '111',
+          product_name: 'Cola',
+          brands: 'Coca-Cola',
+          nutriments: { 'energy-kcal_100g': 42 },
+        },
+        {
+          code: '222',
+          product_name: 'Cola',
+          brands: 'Store Brand',
+          nutriments: { 'energy-kcal_100g': 40 },
+        },
+      ],
+    })
+    expect(results).toHaveLength(2)
+  })
+
+  test('caps the result at 20 entries after deduplication', () => {
     const hits = Array.from({ length: 30 }, (_, i) => ({
       code: `${1000 + i}`,
       product_name: `Item ${i}`,
-      nutriments: {},
+      nutriments: { 'energy-kcal_100g': 100 },
     }))
     const results = mapOffSearchResults({ hits })
     expect(results).toHaveLength(20)

--- a/convex/lib/offMapping.test.ts
+++ b/convex/lib/offMapping.test.ts
@@ -129,9 +129,9 @@ describe('mapOffProduct — synthetic edge cases', () => {
 })
 
 describe('mapOffSearchResults', () => {
-  test('maps each product in the products array and attaches its barcode', () => {
+  test('maps each hit in the hits array and attaches its barcode', () => {
     const results = mapOffSearchResults({
-      products: [
+      hits: [
         {
           code: '3017620422003',
           product_name: 'Nutella',
@@ -152,16 +152,33 @@ describe('mapOffSearchResults', () => {
     ])
   })
 
+  // search-a-licious (the source of this response shape) represents brands
+  // as a string array, unlike the v2 product-by-barcode API's comma-joined
+  // string — this is the shape real responses actually use.
+  test('takes the first brand when brands is an array (search-a-licious shape)', () => {
+    const results = mapOffSearchResults({
+      hits: [
+        {
+          code: '8712800189930',
+          product_name: 'Chocomel Original',
+          brands: ['Chocomel', ' FrieslandCampina'],
+          nutriments: {},
+        },
+      ],
+    })
+    expect(results[0]?.brand).toBe('Chocomel')
+  })
+
   test('drops entries with no usable name', () => {
     const results = mapOffSearchResults({
-      products: [{ code: '111', nutriments: {} }],
+      hits: [{ code: '111', nutriments: {} }],
     })
     expect(results).toEqual([])
   })
 
   test('drops entries with a missing or empty barcode', () => {
     const results = mapOffSearchResults({
-      products: [
+      hits: [
         { product_name: 'No Code', nutriments: {} },
         { code: '', product_name: 'Empty Code', nutriments: {} },
       ],
@@ -171,7 +188,7 @@ describe('mapOffSearchResults', () => {
 
   test('prefers the Dutch product name, same as mapOffProduct', () => {
     const results = mapOffSearchResults({
-      products: [
+      hits: [
         {
           code: '222',
           product_name: 'Generic Name',
@@ -184,12 +201,12 @@ describe('mapOffSearchResults', () => {
   })
 
   test('caps the result at 20 entries', () => {
-    const products = Array.from({ length: 30 }, (_, i) => ({
+    const hits = Array.from({ length: 30 }, (_, i) => ({
       code: `${1000 + i}`,
       product_name: `Item ${i}`,
       nutriments: {},
     }))
-    const results = mapOffSearchResults({ products })
+    const results = mapOffSearchResults({ hits })
     expect(results).toHaveLength(20)
   })
 
@@ -197,6 +214,6 @@ describe('mapOffSearchResults', () => {
     expect(mapOffSearchResults(null)).toEqual([])
     expect(mapOffSearchResults('nope')).toEqual([])
     expect(mapOffSearchResults({})).toEqual([])
-    expect(mapOffSearchResults({ products: 'not-an-array' })).toEqual([])
+    expect(mapOffSearchResults({ hits: 'not-an-array' })).toEqual([])
   })
 })

--- a/convex/lib/offMapping.ts
+++ b/convex/lib/offMapping.ts
@@ -28,7 +28,25 @@ interface OffResponse {
 }
 
 interface OffSearchResponse {
-  products?: unknown
+  hits?: unknown
+}
+
+// The v2 product-by-barcode API represents brands as a comma-joined string
+// ("Ferrero,Nutella"); search-a-licious (mapOffSearchResults' source)
+// represents the same field as a string array (["Nutella", " Ferrero"]).
+// Handle both shapes and return the first non-empty one, trimmed.
+function firstBrand(brands: unknown): string | undefined {
+  if (typeof brands === 'string') {
+    const first = brands.split(',')[0]?.trim()
+    return first || undefined
+  }
+  if (Array.isArray(brands)) {
+    const first = brands.find(
+      (b): b is string => typeof b === 'string' && b.trim() !== '',
+    )
+    return first?.trim()
+  }
+  return undefined
 }
 
 // Open Food Facts product names are per-product, not per-request-locale — a
@@ -95,14 +113,9 @@ function mapOffRawProduct(product: OffProduct): OffMappedFood {
     }
   }
 
-  const brand =
-    typeof product.brands === 'string' && product.brands.trim()
-      ? product.brands.split(',')[0].trim()
-      : undefined
-
   return {
     name: preferredName(product),
-    brand,
+    brand: firstBrand(product.brands),
     nutritionPer100,
     servingSize: parseServingSize(product),
     servingLabel:
@@ -125,20 +138,19 @@ export function mapOffProduct(raw: unknown): OffMappedFood | null {
   return mapOffRawProduct(product)
 }
 
-// Maps a raw Open Food Facts /api/v2/search response ({products: [...]}) to
-// a capped list of importable results. Unlike mapOffProduct, this drops
-// entries with no usable name (noise in a results list, spec §4.3 of the
-// 2026-07-20 OFF name-search design) or no barcode (unusable — the result
-// can't be upserted without one). Malformed/non-object input, or a missing
-// `products` array, returns an empty list — search is a soft fallback, never
-// throws.
+// Maps a raw search-a-licious /search response ({hits: [...]}) to a capped
+// list of importable results. Unlike mapOffProduct, this drops entries with
+// no usable name (noise in a results list, spec §4.3 of the 2026-07-20 OFF
+// name-search design) or no barcode (unusable — the result can't be
+// upserted without one). Malformed/non-object input, or a missing `hits`
+// array, returns an empty list — search is a soft fallback, never throws.
 export function mapOffSearchResults(raw: unknown): OffSearchResult[] {
   if (typeof raw !== 'object' || raw === null) return []
   const response = raw as OffSearchResponse
-  if (!Array.isArray(response.products)) return []
+  if (!Array.isArray(response.hits)) return []
 
   const results: OffSearchResult[] = []
-  for (const entry of response.products) {
+  for (const entry of response.hits) {
     if (typeof entry !== 'object' || entry === null) continue
     const product = entry as OffProduct
     const barcode =

--- a/convex/lib/offMapping.ts
+++ b/convex/lib/offMapping.ts
@@ -138,18 +138,32 @@ export function mapOffProduct(raw: unknown): OffMappedFood | null {
   return mapOffRawProduct(product)
 }
 
-// Maps a raw search-a-licious /search response ({hits: [...]}) to a capped
-// list of importable results. Unlike mapOffProduct, this drops entries with
-// no usable name (noise in a results list, spec §4.3 of the 2026-07-20 OFF
-// name-search design) or no barcode (unusable — the result can't be
-// upserted without one). Malformed/non-object input, or a missing `hits`
-// array, returns an empty list — search is a soft fallback, never throws.
+// OFF's product database has many low-quality/duplicate barcodes for the
+// same real product (community-contributed, no dedup enforced) — a search
+// for "nutella" can return a dozen "Nutella" hits, several with no
+// nutrition data at all. Used both to drop unusable entries and, via
+// nutrientCount, to pick the best of several same-name/brand duplicates.
+function nutrientCount(nutritionPer100: NutritionFacts): number {
+  return Object.keys(nutritionPer100).length
+}
+
+// Maps a raw search-a-licious /search response ({hits: [...]}) to a capped,
+// deduplicated list of importable results. Unlike mapOffProduct, this drops
+// entries with no usable name (noise in a results list, spec §4.3 of the
+// 2026-07-20 OFF name-search design), no barcode (unusable — the result
+// can't be upserted without one), or no nutrition data at all (useless for
+// a nutrition tracker, and OFF has plenty of near-empty duplicate barcodes
+// for popular products). Remaining entries are deduplicated by normalized
+// name+brand, keeping whichever duplicate has the most nutrients populated
+// — search relevance order is otherwise preserved. Malformed/non-object
+// input, or a missing `hits` array, returns an empty list — search is a
+// soft fallback, never throws.
 export function mapOffSearchResults(raw: unknown): OffSearchResult[] {
   if (typeof raw !== 'object' || raw === null) return []
   const response = raw as OffSearchResponse
   if (!Array.isArray(response.hits)) return []
 
-  const results: OffSearchResult[] = []
+  const byDedupKey = new Map<string, OffSearchResult>()
   for (const entry of response.hits) {
     if (typeof entry !== 'object' || entry === null) continue
     const product = entry as OffProduct
@@ -158,8 +172,17 @@ export function mapOffSearchResults(raw: unknown): OffSearchResult[] {
     if (!barcode) continue
     const mapped = mapOffRawProduct(product)
     if (!mapped.name) continue
-    results.push({ ...mapped, barcode })
-    if (results.length >= 20) break
+    if (nutrientCount(mapped.nutritionPer100) === 0) continue
+
+    const dedupKey = `${mapped.name.toLowerCase()}|${(mapped.brand ?? '').toLowerCase()}`
+    const existing = byDedupKey.get(dedupKey)
+    if (
+      !existing ||
+      nutrientCount(mapped.nutritionPer100) >
+        nutrientCount(existing.nutritionPer100)
+    ) {
+      byDedupKey.set(dedupKey, { ...mapped, barcode })
+    }
   }
-  return results
+  return Array.from(byDedupKey.values()).slice(0, 20)
 }

--- a/convex/lib/offMapping.ts
+++ b/convex/lib/offMapping.ts
@@ -8,7 +8,12 @@ export interface OffMappedFood {
   servingLabel?: string
 }
 
+export interface OffSearchResult extends OffMappedFood {
+  barcode: string
+}
+
 interface OffProduct {
+  code?: unknown
   product_name?: unknown
   product_name_nl?: unknown
   brands?: unknown
@@ -20,6 +25,10 @@ interface OffProduct {
 interface OffResponse {
   status?: unknown
   product?: OffProduct
+}
+
+interface OffSearchResponse {
+  products?: unknown
 }
 
 // Open Food Facts product names are per-product, not per-request-locale — a
@@ -65,17 +74,13 @@ const NUTRIMENT_MAPPINGS: Array<[keyof NutritionFacts, string]> = [
   ['salt', 'salt_100g'],
 ]
 
-// Maps a raw Open Food Facts /api/v2/product/{barcode} response to our foods
-// shape. Returns null when the product wasn't found (status !== 1) or the
-// response is malformed — barcode lookups must never throw; the caller falls
-// back to manual entry either way (spec §6).
-export function mapOffProduct(raw: unknown): OffMappedFood | null {
-  if (typeof raw !== 'object' || raw === null) return null
-  const response = raw as OffResponse
-  if (response.status !== 1) return null
-  const product = response.product
-  if (typeof product !== 'object' || product === null) return null
-
+// Maps one OFF product object (from either the single-product or search
+// response shapes) to our foods shape. Always returns a mapped object, even
+// when the name is empty — the barcode single-product path (mapOffProduct)
+// leaves that decision to the user on the confirmation screen (spec §4.3);
+// the search path (mapOffSearchResults) applies its own empty-name filter
+// on top of this, since a nameless row is just noise in a results list.
+function mapOffRawProduct(product: OffProduct): OffMappedFood {
   const nutriments = product.nutriments
   const nutritionPer100: NutritionFacts = {}
   if (typeof nutriments === 'object' && nutriments !== null) {
@@ -105,4 +110,44 @@ export function mapOffProduct(raw: unknown): OffMappedFood | null {
         ? product.serving_size.trim() || undefined
         : undefined,
   }
+}
+
+// Maps a raw Open Food Facts /api/v2/product/{barcode} response to our foods
+// shape. Returns null when the product wasn't found (status !== 1) or the
+// response is malformed — barcode lookups must never throw; the caller falls
+// back to manual entry either way (spec §6).
+export function mapOffProduct(raw: unknown): OffMappedFood | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const response = raw as OffResponse
+  if (response.status !== 1) return null
+  const product = response.product
+  if (typeof product !== 'object' || product === null) return null
+  return mapOffRawProduct(product)
+}
+
+// Maps a raw Open Food Facts /api/v2/search response ({products: [...]}) to
+// a capped list of importable results. Unlike mapOffProduct, this drops
+// entries with no usable name (noise in a results list, spec §4.3 of the
+// 2026-07-20 OFF name-search design) or no barcode (unusable — the result
+// can't be upserted without one). Malformed/non-object input, or a missing
+// `products` array, returns an empty list — search is a soft fallback, never
+// throws.
+export function mapOffSearchResults(raw: unknown): OffSearchResult[] {
+  if (typeof raw !== 'object' || raw === null) return []
+  const response = raw as OffSearchResponse
+  if (!Array.isArray(response.products)) return []
+
+  const results: OffSearchResult[] = []
+  for (const entry of response.products) {
+    if (typeof entry !== 'object' || entry === null) continue
+    const product = entry as OffProduct
+    const barcode =
+      typeof product.code === 'string' ? product.code.trim() : ''
+    if (!barcode) continue
+    const mapped = mapOffRawProduct(product)
+    if (!mapped.name) continue
+    results.push({ ...mapped, barcode })
+    if (results.length >= 20) break
+  }
+  return results
 }

--- a/src/components/nutrition/FoodAddTab.tsx
+++ b/src/components/nutrition/FoodAddTab.tsx
@@ -14,11 +14,12 @@ import type {
 } from '../../../convex/lib/offMapping'
 import { BarcodeScanner } from '../foods/BarcodeScanner'
 
-// Open Food Facts caps clients at 10 search requests/minute. Never fire two
-// OFF searches closer together than this from a single browser tab —
-// comfortably under the ~6s/request average the limit implies, leaving
-// headroom for the barcode-scan path's OFF calls too.
-const OFF_SEARCH_MIN_INTERVAL_MS = 4000
+// Open Food Facts documents a 10 search requests/minute cap on its legacy
+// search API; search-a-licious (the full-text search service this fallback
+// actually calls, see offFetch.ts) doesn't publish its own separate limit,
+// so treat 10/min as the conservative ceiling. 6.5s keeps a single tab under
+// ~9/min, leaving headroom for the barcode-scan path's OFF calls too.
+const OFF_SEARCH_MIN_INTERVAL_MS = 6500
 
 // _id is typed as the branded Id<'foods'>, not a plain string, because this
 // state is always populated directly from real Convex query results

--- a/src/components/nutrition/FoodAddTab.tsx
+++ b/src/components/nutrition/FoodAddTab.tsx
@@ -334,11 +334,18 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
                 <button
                   type="button"
                   onClick={() => handleOffResultSelect(result)}
-                  className="block w-full py-1.5 text-left text-sm"
+                  className="flex w-full items-baseline justify-between gap-2 py-1.5 text-left text-sm"
                 >
-                  {result.name}
-                  {result.brand && (
-                    <span className="ml-2 opacity-60">{result.brand}</span>
+                  <span>
+                    {result.name}
+                    {result.brand && (
+                      <span className="ml-2 opacity-60">{result.brand}</span>
+                    )}
+                  </span>
+                  {result.nutritionPer100.calories !== undefined && (
+                    <span className="shrink-0 text-xs opacity-60">
+                      {Math.round(result.nutritionPer100.calories)} kcal/100g
+                    </span>
                   )}
                 </button>
               </li>

--- a/src/components/nutrition/FoodAddTab.tsx
+++ b/src/components/nutrition/FoodAddTab.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import { useAction, useConvex, useMutation, useQuery } from 'convex/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import {
@@ -8,6 +8,10 @@ import {
   type MealName,
 } from '../../../convex/lib/consumption'
 import type { NutritionFacts } from '../../../convex/lib/nutrition'
+import type {
+  OffMappedFood,
+  OffSearchResult,
+} from '../../../convex/lib/offMapping'
 import { BarcodeScanner } from '../foods/BarcodeScanner'
 
 // _id is typed as the branded Id<'foods'>, not a plain string, because this
@@ -41,6 +45,12 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
   const [notFoundBarcode, setNotFoundBarcode] = useState<string | null>(null)
   const [resolving, setResolving] = useState(false)
   const [lookupError, setLookupError] = useState<string | null>(null)
+  const [offResults, setOffResults] = useState<OffSearchResult[] | null>(
+    null,
+  )
+  const [offSearching, setOffSearching] = useState(false)
+  const [offSearchError, setOffSearchError] = useState<string | null>(null)
+  const offSearchedTermRef = useRef<string | null>(null)
   const [quantityInput, setQuantityInput] = useState('')
   const [unit, setUnit] = useState<'g' | 'ml' | 'piece'>('g')
   const [submitting, setSubmitting] = useState(false)
@@ -48,8 +58,26 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
 
   const convex = useConvex()
   const lookupBarcode = useAction(api.foodsLookup.lookupBarcode)
+  const searchByName = useAction(api.foodsLookup.searchByName)
   const upsertFromOff = useMutation(api.foods.upsertFromOff)
   const createEntry = useMutation(api.consumption.create)
+
+  async function saveOffMatch(mapped: OffMappedFood, barcode: string) {
+    const id = await upsertFromOff({
+      barcode,
+      name: mapped.name,
+      brand: mapped.brand,
+      baseUnit: 'g',
+      nutritionPer100: mapped.nutritionPer100,
+      servingSize: mapped.servingSize,
+      servingLabel: mapped.servingLabel,
+    })
+    const saved = await convex.query(api.foods.get, { id })
+    if (saved) {
+      setSelected(saved)
+      setUnit(saved.baseUnit)
+    }
+  }
 
   async function handleDetected(barcode: string) {
     if (resolving) return
@@ -68,26 +96,54 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
         setNotFoundBarcode(barcode)
         return
       }
-      const id = await upsertFromOff({
-        barcode,
-        name: mapped.name,
-        brand: mapped.brand,
-        baseUnit: 'g',
-        nutritionPer100: mapped.nutritionPer100,
-        servingSize: mapped.servingSize,
-        servingLabel: mapped.servingLabel,
-      })
-      const saved = await convex.query(api.foods.get, { id })
-      if (saved) {
-        setSelected(saved)
-        setUnit(saved.baseUnit)
-      }
+      await saveOffMatch(mapped, barcode)
     } catch {
       setLookupError("Couldn't look up that barcode — try again.")
     } finally {
       setResolving(false)
     }
   }
+
+  async function handleOffResultSelect(result: OffSearchResult) {
+    setOffSearchError(null)
+    try {
+      await saveOffMatch(result, result.barcode)
+    } catch {
+      setOffSearchError("Couldn't add that item — try again.")
+    }
+  }
+
+  // Fires once local search has definitively resolved to zero results for a
+  // term worth querying OFF over (3+ chars — avoids a network round-trip on
+  // every 1-2 character keystroke). Guards against re-firing for a term
+  // already searched, and discards a stale response if the term changed
+  // while the request was in flight.
+  useEffect(() => {
+    const term = debouncedTerm.trim()
+    if (term.length < 3 || results === undefined || results.length > 0) {
+      setOffResults(null)
+      setOffSearching(false)
+      offSearchedTermRef.current = null
+      return
+    }
+    if (offSearchedTermRef.current === term) return
+    offSearchedTermRef.current = term
+    setOffSearching(true)
+    setOffSearchError(null)
+    searchByName({ term })
+      .then((found) => {
+        if (offSearchedTermRef.current !== term) return
+        setOffResults(found)
+      })
+      .catch(() => {
+        if (offSearchedTermRef.current !== term) return
+        setOffSearchError("Couldn't search Open Food Facts.")
+      })
+      .finally(() => {
+        if (offSearchedTermRef.current !== term) return
+        setOffSearching(false)
+      })
+  }, [debouncedTerm, results, searchByName])
 
   if (selected) {
     return (
@@ -213,6 +269,35 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
           </li>
         ))}
       </ul>
+      {offSearching && (
+        <p className="text-xs opacity-60">Searching Open Food Facts…</p>
+      )}
+      {offSearchError && (
+        <p className="text-xs text-red-700">{offSearchError}</p>
+      )}
+      {offResults && offResults.length > 0 && (
+        <div className="grid gap-1">
+          <p className="text-xs font-medium opacity-60">
+            From Open Food Facts
+          </p>
+          <ul className="max-h-48 divide-y divide-[var(--app-border)] overflow-y-auto">
+            {offResults.map((result) => (
+              <li key={result.barcode}>
+                <button
+                  type="button"
+                  onClick={() => handleOffResultSelect(result)}
+                  className="block w-full py-1.5 text-left text-sm"
+                >
+                  {result.name}
+                  {result.brand && (
+                    <span className="ml-2 opacity-60">{result.brand}</span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/nutrition/FoodAddTab.tsx
+++ b/src/components/nutrition/FoodAddTab.tsx
@@ -45,9 +45,7 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
   const [notFoundBarcode, setNotFoundBarcode] = useState<string | null>(null)
   const [resolving, setResolving] = useState(false)
   const [lookupError, setLookupError] = useState<string | null>(null)
-  const [offResults, setOffResults] = useState<OffSearchResult[] | null>(
-    null,
-  )
+  const [offResults, setOffResults] = useState<OffSearchResult[] | null>(null)
   const [offSearching, setOffSearching] = useState(false)
   const [offSearchError, setOffSearchError] = useState<string | null>(null)
   const offSearchedTermRef = useRef<string | null>(null)
@@ -277,9 +275,7 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
       )}
       {offResults && offResults.length > 0 && (
         <div className="grid gap-1">
-          <p className="text-xs font-medium opacity-60">
-            From Open Food Facts
-          </p>
+          <p className="text-xs font-medium opacity-60">From Open Food Facts</p>
           <ul className="max-h-48 divide-y divide-[var(--app-border)] overflow-y-auto">
             {offResults.map((result) => (
               <li key={result.barcode}>

--- a/src/components/nutrition/FoodAddTab.tsx
+++ b/src/components/nutrition/FoodAddTab.tsx
@@ -14,6 +14,12 @@ import type {
 } from '../../../convex/lib/offMapping'
 import { BarcodeScanner } from '../foods/BarcodeScanner'
 
+// Open Food Facts caps clients at 10 search requests/minute. Never fire two
+// OFF searches closer together than this from a single browser tab —
+// comfortably under the ~6s/request average the limit implies, leaving
+// headroom for the barcode-scan path's OFF calls too.
+const OFF_SEARCH_MIN_INTERVAL_MS = 4000
+
 // _id is typed as the branded Id<'foods'>, not a plain string, because this
 // state is always populated directly from real Convex query results
 // (getByBarcode / get / search) — never round-tripped through a URL param —
@@ -49,6 +55,13 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
   const [offSearching, setOffSearching] = useState(false)
   const [offSearchError, setOffSearchError] = useState<string | null>(null)
   const offSearchedTermRef = useRef<string | null>(null)
+  // Cache each term's OFF results for the component's lifetime (retyping the
+  // same term costs nothing) and never fire two OFF calls closer together
+  // than OFF_SEARCH_MIN_INTERVAL_MS, deferring rather than dropping a call
+  // that arrives too soon — see the constant's comment below.
+  const offSearchCacheRef = useRef<Map<string, OffSearchResult[]>>(new Map())
+  const offLastCallAtRef = useRef(0)
+  const offSearchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [quantityInput, setQuantityInput] = useState('')
   const [unit, setUnit] = useState<'g' | 'ml' | 'piece'>('g')
   const [submitting, setSubmitting] = useState(false)
@@ -60,7 +73,18 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
   const upsertFromOff = useMutation(api.foods.upsertFromOff)
   const createEntry = useMutation(api.consumption.create)
 
+  // A name-search hit's barcode may already have a local row that the name
+  // search itself didn't surface (searched by brand, an alternate-language
+  // name, etc.). Check first and reuse that row rather than upserting over
+  // it — upsertFromOff would otherwise silently replace its name/nutrition/
+  // baseUnit with the search result's mapped data.
   async function saveOffMatch(mapped: OffMappedFood, barcode: string) {
+    const existing = await convex.query(api.foods.getByBarcode, { barcode })
+    if (existing) {
+      setSelected(existing)
+      setUnit(existing.baseUnit)
+      return
+    }
     const id = await upsertFromOff({
       barcode,
       name: mapped.name,
@@ -114,8 +138,10 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
   // Fires once local search has definitively resolved to zero results for a
   // term worth querying OFF over (3+ chars — avoids a network round-trip on
   // every 1-2 character keystroke). Guards against re-firing for a term
-  // already searched, and discards a stale response if the term changed
-  // while the request was in flight.
+  // already searched, discards a stale response if the term changed while
+  // the request was in flight, serves repeat terms from offSearchCacheRef
+  // instead of re-hitting OFF, and defers (rather than drops) a call that
+  // would land inside OFF_SEARCH_MIN_INTERVAL_MS of the last one.
   useEffect(() => {
     const term = debouncedTerm.trim()
     if (term.length < 3 || results === undefined || results.length > 0) {
@@ -126,21 +152,46 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
     }
     if (offSearchedTermRef.current === term) return
     offSearchedTermRef.current = term
-    setOffSearching(true)
-    setOffSearchError(null)
-    searchByName({ term })
-      .then((found) => {
-        if (offSearchedTermRef.current !== term) return
-        setOffResults(found)
-      })
-      .catch(() => {
-        if (offSearchedTermRef.current !== term) return
-        setOffSearchError("Couldn't search Open Food Facts.")
-      })
-      .finally(() => {
-        if (offSearchedTermRef.current !== term) return
-        setOffSearching(false)
-      })
+
+    const cached = offSearchCacheRef.current.get(term)
+    if (cached) {
+      setOffSearching(false)
+      setOffSearchError(null)
+      setOffResults(cached)
+      return
+    }
+
+    const runSearch = () => {
+      offLastCallAtRef.current = Date.now()
+      setOffSearching(true)
+      setOffSearchError(null)
+      searchByName({ term })
+        .then((found) => {
+          if (offSearchedTermRef.current !== term) return
+          offSearchCacheRef.current.set(term, found)
+          setOffResults(found)
+        })
+        .catch(() => {
+          if (offSearchedTermRef.current !== term) return
+          setOffSearchError("Couldn't search Open Food Facts.")
+        })
+        .finally(() => {
+          if (offSearchedTermRef.current !== term) return
+          setOffSearching(false)
+        })
+    }
+
+    const wait =
+      OFF_SEARCH_MIN_INTERVAL_MS - (Date.now() - offLastCallAtRef.current)
+    if (wait <= 0) {
+      runSearch()
+    } else {
+      setOffSearching(true)
+      offSearchTimeoutRef.current = setTimeout(runSearch, wait)
+    }
+    return () => {
+      if (offSearchTimeoutRef.current) clearTimeout(offSearchTimeoutRef.current)
+    }
   }, [debouncedTerm, results, searchByName])
 
   if (selected) {
@@ -292,6 +343,18 @@ export function FoodAddTab({ date, meal, onAdded }: Props) {
               </li>
             ))}
           </ul>
+          <p className="text-xs opacity-60">
+            Data from{' '}
+            <a
+              href="https://world.openfoodfacts.org"
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              Open Food Facts
+            </a>{' '}
+            (ODbL).
+          </p>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Adds an automatic Open Food Facts (OFF) name-search fallback to the nutrition diary's "add food" flow: when local food search comes up empty for a 3+ character term, it queries OFF by name and shows results under "From Open Food Facts".
- Selecting an OFF result upserts it into the local `foods` library and proceeds to quantity entry, mirroring the existing barcode-scan flow (`saveOffMatch` is now shared between both entry points).
- OFF write-back (contributing edits to the public OFF database) was considered and explicitly rejected — see the design doc for reasoning.

## Design & plan
- Spec: `docs/superpowers/specs/2026-07-20-off-name-search-design.md`
- Plan: `docs/superpowers/plans/2026-07-20-off-name-search.md`

## Test plan
- [x] `pnpm run test` — 327/327 passing, including new coverage for `searchOffProducts` (offFetch) and `mapOffSearchResults`/`mapOffRawProduct` (offMapping), no regressions on existing `mapOffProduct` tests
- [x] `pnpm run typecheck` / `pnpm run lint` — clean
- [x] Manual browser verification: searched a term with no local match, confirmed OFF fallback results appeared, selected one, confirmed it saved and created a diary entry, confirmed a repeat search now finds it locally with no OFF fallback, confirmed short terms (<3 chars) and terms with existing local matches never trigger an OFF search

🤖 Generated with [Claude Code](https://claude.com/claude-code)