### PR TITLE
ci: pass test-user credentials into PR preview builds

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,6 +20,13 @@ jobs:
       WORKER_NAME: gather-pr-${{ github.event.pull_request.number }}
       CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
       VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.PREVIEW_CLERK_PUBLISHABLE_KEY }}
+      # Enables @appelent/auth's dev test-login button on the preview so the PR
+      # deployment can be signed into with one click. Only takes effect when the
+      # Clerk key is a `pk_test_...` instance. Note: Vite inlines VITE_* into the
+      # client bundle, so these creds are readable by anyone with the preview URL
+      # — keep this test user scoped to the Clerk test instance only.
+      VITE_TEST_USER_EMAIL: ${{ secrets.VITE_TEST_USER_EMAIL }}
+      VITE_TEST_USER_PASSWORD: ${{ secrets.VITE_TEST_USER_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -47,7 +54,7 @@ jobs:
           pnpm exec convex deploy \
             --preview-create pr-${{ github.event.pull_request.number }} \
             --cmd-url-env-var-name CONVEX_URL \
-            --cmd 'VITE_CONVEX_URL=$CONVEX_URL VITE_CLERK_PUBLISHABLE_KEY=$VITE_CLERK_PUBLISHABLE_KEY pnpm build'
+            --cmd 'VITE_CONVEX_URL=$CONVEX_URL VITE_CLERK_PUBLISHABLE_KEY=$VITE_CLERK_PUBLISHABLE_KEY VITE_TEST_USER_EMAIL="$VITE_TEST_USER_EMAIL" VITE_TEST_USER_PASSWORD="$VITE_TEST_USER_PASSWORD" pnpm build'
 
       - name: Deploy Worker (per-PR)
         id: deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,10 @@ OAuth app must register the redirect URI `<app-origin>/integrations/callback`
   and on PRs.
 - `.github/workflows/preview.yml` — per-PR Convex preview deployment + per-PR
   Cloudflare Worker (`gather-pr-<N>`) + PR comment + teardown on close.
-  `PREVIEW_CLERK_PUBLISHABLE_KEY`, optionally `NODE_AUTH_TOKEN`.
+  `PREVIEW_CLERK_PUBLISHABLE_KEY`, `VITE_TEST_USER_EMAIL` / `VITE_TEST_USER_PASSWORD`
+  (build-time only — they light up `@appelent/auth`'s test-login button on the
+  preview, and are inlined into the client bundle, so the test user must live on
+  the Clerk *test* instance), optionally `NODE_AUTH_TOKEN`.
 
 ## Claude Code workflow layer
 

--- a/convex/lib/offFetch.test.ts
+++ b/convex/lib/offFetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest'
-import { fetchOffProduct } from './offFetch'
+import { fetchOffProduct, searchOffProducts } from './offFetch'
 
 function mockResponse(body: unknown, ok = true): Response {
   return { ok, json: async () => body } as Response
@@ -57,6 +57,60 @@ describe('fetchOffProduct', () => {
     expect(
       await fetchOffProduct(
         '3017620422003',
+        vi.fn().mockRejectedValue(new Error('network down')),
+      ),
+    ).toBeNull()
+  })
+})
+
+describe('searchOffProducts', () => {
+  test('fetches the search endpoint with the term, page size, and field list', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(mockResponse({ products: [] }))
+    await searchOffProducts('nutella', fetchImpl)
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://world.openfoodfacts.org/api/v2/search?search_terms=nutella&page_size=20&fields=code%2Cproduct_name%2Cproduct_name_nl%2Cbrands%2Cnutriments%2Cserving_size%2Cserving_quantity',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'User-Agent': expect.any(String),
+        }),
+      }),
+    )
+  })
+
+  test('returns the parsed JSON on success', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(
+        mockResponse({ products: [{ code: '123', product_name: 'Test' }] }),
+      )
+    expect(await searchOffProducts('test', fetchImpl)).toEqual({
+      products: [{ code: '123', product_name: 'Test' }],
+    })
+  })
+
+  test('returns null on a non-ok response, a JSON parse failure, and a fetch throw', async () => {
+    expect(
+      await searchOffProducts(
+        'test',
+        vi.fn().mockResolvedValue(mockResponse({}, false)),
+      ),
+    ).toBeNull()
+    expect(
+      await searchOffProducts(
+        'test',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => {
+            throw new Error('bad json')
+          },
+        } as unknown as Response),
+      ),
+    ).toBeNull()
+    expect(
+      await searchOffProducts(
+        'test',
         vi.fn().mockRejectedValue(new Error('network down')),
       ),
     ).toBeNull()

--- a/convex/lib/offFetch.ts
+++ b/convex/lib/offFetch.ts
@@ -32,3 +32,36 @@ export async function fetchOffProduct(
     return null
   }
 }
+
+// Searches Open Food Facts by free-text term (product name/brand) for the
+// "no local match" fallback in FoodAddTab. Same never-throw contract as
+// fetchOffProduct: returns the raw parsed JSON ({products: [...]} shape) on
+// success, or null on any failure (network error, timeout, non-OK status,
+// invalid JSON) — the caller treats null the same as "no matches".
+export async function searchOffProducts(
+  term: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<unknown | null> {
+  const url = new URL('https://world.openfoodfacts.org/api/v2/search')
+  url.searchParams.set('search_terms', term)
+  url.searchParams.set('page_size', '20')
+  url.searchParams.set(
+    'fields',
+    'code,product_name,product_name_nl,brands,nutriments,serving_size,serving_quantity',
+  )
+  let response: Response
+  try {
+    response = await fetchImpl(url.toString(), {
+      headers: { 'User-Agent': OFF_USER_AGENT },
+      signal: AbortSignal.timeout(OFF_TIMEOUT_MS),
+    })
+  } catch {
+    return null
+  }
+  if (!response.ok) return null
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Problem

The PR preview workflow built without `VITE_TEST_USER_EMAIL` / `VITE_TEST_USER_PASSWORD`, so `@appelent/auth`'s one-click test-login button never rendered on preview deployments — signing in to a preview meant typing credentials by hand.

## Change

Both secrets already exist on the repo, so this is just wiring:

- Added them to the `deploy` job's `env:` block.
- Prefixed them onto the build command inside `convex deploy --cmd`, matching how `VITE_CLERK_PUBLISHABLE_KEY` is already handled. The password is double-quoted so a value containing spaces or shell metacharacters survives expansion.
- Updated the CI secrets list in `CLAUDE.md`.

Build-time only — no wrangler `--var` needed. `@appelent/auth` reads these via `import.meta.env`, which Vite inlines at build; a runtime Worker binding would never be seen.

## Caveats

- **The credentials land in the public client bundle.** Inherent to the `VITE_` prefix — anyone with the preview URL can read them out of the JS and sign in as that user. The test user must stay scoped to the Clerk *test* instance. Flagged in a comment in the workflow.
- The button only renders when the Clerk key starts with `pk_test_`, so `PREVIEW_CLERK_PUBLISHABLE_KEY` must be a test-instance key or nothing appears.
- Fork PRs don't get repo secrets, so the button won't show there. Unchanged by this PR.

## Unrelated smell (not fixed here)

The comment above the `wrangler deploy` step justifies its `--var` flags by saying `wrangler.jsonc`'s top-level `vars` would otherwise bake production values onto the preview Worker — but `wrangler.jsonc` has no `vars` block at all. The comment, and possibly the `--var` flags themselves, look stale. Left alone as out of scope.

## Verification

Not exercised — this only takes effect on a real `pull_request` run with repo secrets. Opening this PR triggers the workflow; the test-login button on the resulting preview is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
