### PR TITLE
Record the decisions deferred while the Group rebuild landed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,22 @@ on dev and as a preview-type default (`convex env default set --type preview`);
 deployment URL from writing a fake household into the real database. The
 internal `seedCatalog` / `seedPreview` entrypoints do not consult it.
 
+## One-shot code states its own end condition
+
+Migration mutations, backfills and compatibility shims are written to run against
+a data shape and then be dead — but they sit in `convex/` and `src/` looking
+exactly like live code, with tests that go on passing whether or not the shape
+still exists anywhere. So each one says, where it lives, what would retire it:
+
+- **Migration code** is deleted when its document in `docs/migrations/` records
+  that it has been run everywhere, or that something else has superseded it.
+- **A compatibility shim** names the date or the event after which it goes.
+- Code with no end condition does not get to be one-shot code. It is just code,
+  and it will be maintained forever.
+
+`src/lib/legacyPaths.ts` was the cautionary case: excellent about why it existed,
+silent about when it stopped, and on course to outlive every link it served.
+
 ## CI / PR previews
 
 - `.github/workflows/ci.yml` — check/typecheck/test/build gate on push to `master`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,10 +20,18 @@ Member.
 _Avoid_: Private space, Personal workspace, Inbox
 
 **Member**:
-A person within a Group. Members are either **admins**, who can change the Group
-and its membership, or plain members.
+A person within a Group. Any Member may let somebody in; **admins** may
+additionally rename the Group, delete it, change roles, and put somebody out
+(ADR-0006).
 _Avoid_: Owner, Participant. (A *user* is a person; a Member is a person
 *within* a Group.)
+
+**Invite code**:
+The code that admits somebody to a Group. Any Member may read it and pass it on
+— inviting a housemate is not an administrative act. It is a capability rather
+than a property of the Group: it is asked for by name, and it changes whenever
+somebody is removed, because a code that outlives a removal undoes it.
+_Avoid_: Invite link, Token, Join key
 
 **Slug**:
 The short, readable, globally unique name identifying a Group in a URL. Readable
@@ -68,28 +76,41 @@ Module: every Module is available in every Group either way.
 _Avoid_: Favourite, Shortcut, Bookmark, Enabled module
 
 **Home**:
-A Group's shared surface — what a Member sees on opening it. It carries the
-Group's activity, and is where conversation will live.
+A Group's shared surface — what a Member sees on opening it. It carries a
+summary of the Group's recent activity, and is where conversation will live. A
+summary and not an archive: every entry links to the Module that holds the whole
+record, which is why there is nothing older to page back to (ADR-0008).
 _Avoid_: Dashboard, Command center
 
 **Attribution**:
 The person who created a piece of Group-scoped content. Attribution records
-*who*; it never confers ownership or access.
+*who*; it never confers ownership or access. Every table holding a Group's
+content carries it (ADR-0008).
 _Avoid_: Owner, Author
 
 **Share**:
 Making Group-scoped content visible to an additional Group without changing
-where it lives.
-_Avoid_: Publish, Copy, Cross-post
+where it lives. The Group it is shared into may read it and no more: writing
+follows the home Group.
+_Avoid_: Publish, Cross-post. (**Copy** is a different verb — see below — and
+not a synonym for this one.)
 
 **Move**:
 Changing which Group a piece of content lives in.
 
+**Copy**:
+Making an independent recipe out of one you can see, in a Group of your own. The
+copy has its own life: the original may change or be deleted and the copy will
+not notice. Recipes only — a recipe you cooked and changed *is* a different
+recipe, and no other Module is like that, so Copy is not a verb of the boundary
+the way Share and Move are (ADR-0007).
+_Avoid_: Clone, Duplicate, Fork
+
 **Provenance**:
-A reference from a Personal record back to the Group-scoped content it was
-created from — a diary entry recording which recipe it came from. Provenance
-never grants access: it is checked on read, and it may point at something the
-reader can no longer see.
+A reference back to the content something was created from — a diary entry
+recording which recipe it came from, a copied recipe recording the one it was
+taken from. Provenance never grants access: it is checked on read, and it may
+point at something the reader can no longer see.
 _Avoid_: Link, Source
 
 **Sample household**:
@@ -107,3 +128,11 @@ _Avoid_: Demo data, Dummy data, Test data, Seed data
   something lives in, never from a flag on the content.
 - The Catalog is read-only and always reflects the shipped version. A person
   who needs a different entry creates their own alongside it.
+- The Group you are in is in the URL. Nothing stores which one you are in, and
+  nothing falls back to a Group you happen to belong to.
+- Whether you may change something follows its home Group from anywhere. *Where*
+  you change it is the address: a write happens where the URL names the Group
+  that is about to change.
+- A refusal inside a Group never says which refusal it is. "No such record" and
+  "not in this Group" are one answer; refusing the Group itself is a separate,
+  distinct one.

--- a/docs/adr/0006-any-member-invites-only-an-admin-removes.md
+++ b/docs/adr/0006-any-member-invites-only-an-admin-removes.md
@@ -1,0 +1,47 @@
+# Any Member invites; only an admin removes
+
+Status: accepted (2026-08-03)
+
+Letting somebody into a Group is any Member's to do: they read the Group's
+invite code and pass it on. Taking somebody out is an admin's. The two halves of
+"changing the membership" are deliberately not held by the same people.
+
+## Why
+
+A household is not an organisation with a gatekeeper. Asking Mum to wait for Dad
+before her sister can see the recipes buys nothing that a family of four wants,
+and a Group whose only admin is on holiday is still a household. So inviting is
+not an administrative act, and `groups.inviteCode` is readable by any Member.
+
+Removal is different, and the asymmetry is the point rather than an oversight.
+Removing somebody is done *to* a person rather than offered to them, it is the
+only membership change that takes content away from a reader, and it is the one
+a household will want to be deliberate about — a departing lodger, an ex. It sits
+with the same people who can rename and delete the Group.
+
+## Consequences
+
+**Removal only means something if the code rotates with it.** An invite code is a
+bearer token: anyone who ever read it can rejoin through `joinByInvite` forever,
+so an admin who removes a Member and leaves the code standing has not removed
+them. Rotation is therefore part of removal rather than a separate button an
+admin has to know to press — a forgotten rotation fails silently and leaves
+somebody believing a door is shut. The cost is that rotating to lock one person
+out also breaks the code another Member handed to their sister yesterday. In a
+household that is one message to fix, and it is the cheaper of the two failures.
+
+**One code per Group rather than a token per invitation.** Per-invite records
+would let a removal revoke exactly the way one person got in, and would say who
+let them in. They are also a table, a lifecycle and a page that a household of
+four will never exercise. Revisit if invitations ever need to expire, be
+withdrawn individually, or be audited.
+
+**A Group can never be left unadministered.** `leaveGroup` refuses the last admin
+of a Group that still has other Members, because nothing short of database repair
+can put an unadministered Group right — there is no self-service way back into a
+room nobody administers. `setMemberRole` is what unblocks that door.
+
+**`myGroups` does not carry the invite code.** A capability is handed out by a
+query that exists to hand it out, not by the one that answers "which Groups am I
+in" for the sidebar, the switcher and the sharing panel. Same rule as
+`groups.bySlug` and `groups.members`.

--- a/docs/adr/0007-a-write-happens-at-the-address-that-names-its-group.md
+++ b/docs/adr/0007-a-write-happens-at-the-address-that-names-its-group.md
@@ -1,0 +1,57 @@
+# A write happens at the address that names its Group
+
+Status: accepted (2026-08-03)
+
+Whether you *may* change a piece of content is answered by membership of its home
+Group, from wherever you are reading it. **Where** you change it is answered by
+the URL. A page addressed to a Group that is not the content's home offers a link
+to the home address instead of the write controls.
+
+## Why
+
+`recipes.get` computes `canEdit` from membership of the recipe's home Group, and
+that is right: writing follows the home Group and not the shared list, so a
+household may fix its own typo and a Group that was merely shown the recipe may
+not touch it. Nothing here changes that rule, and the backend enforces it
+unchanged.
+
+But the controls were being drawn wherever `canEdit` was true, which produced
+three things that ADR-0002 exists to prevent. Delete removed a recipe from the
+household while the address said `cooking-club`, and then returned the reader to
+the club's list — the Group that lost something was never named on screen. Edit
+navigated to `/g/cooking-club/recipes/<id>/edit`, so the slug that is readable
+*precisely so you notice where a write lands* was readable and wrong. And the
+sharing panel offered to unshare the Group being stood in, which destroys the
+page it is drawn on.
+
+ADR-0002 pays for a human-readable slug with global uniqueness, collision
+suffixes and a reserved-segment list, on the grounds that the Group you are
+acting in has to be noticeable. A write that lands somewhere other than the Group
+in the address spends that safety property and returns nothing.
+
+## Consequences
+
+A Member of the home Group standing at a guest address gets one link — the home
+Group named, and the way there — where Edit, Delete, Move and Unshare would
+otherwise be. One extra click on the fix-a-typo path, which is the right price
+for never deleting under an address that does not name the Group losing content.
+
+A reader who is *not* in the home Group is told where the content lives, which
+they could not previously see at all: `homeGroupName` was passed only to the
+sharing panel, and so reached only the people who already knew.
+
+**Copy is a Recipes affordance, not a Group verb.** The boundary has exactly two
+verbs — Share and Move — and both mean the same thing for a recipe, a task list
+and a child. Copy does not: cloning a child is meaningless and cloning a task
+list raises questions about its tasks that nobody has asked. So a guest who wants
+a recipe copies it into a Group of their own, and that lives in Recipes rather
+than in the vocabulary every Module must answer for. The copy is independent and
+carries a provenance-style reference to what it came from — snapshotted, checked
+on read, allowed to dangle, exactly as ADR-0003 already defines for Personal
+records.
+
+**Unshare stops meaning "take it back."** Once a recipe can be copied, withdrawing
+a Share removes only the sharer's copy from view; the Group that copied it keeps
+an independent one and the home Group cannot reach it. This is accepted rather
+than designed around: any Member of that Group could always have retyped the
+recipe, and a Share that can be un-rung is a promise the app cannot keep.

--- a/docs/adr/0008-the-activity-stream-is-derived-from-rows-that-testify.md
+++ b/docs/adr/0008-the-activity-stream-is-derived-from-rows-that-testify.md
@@ -1,0 +1,70 @@
+# The activity stream is derived from rows that testify
+
+Status: accepted (2026-08-03)
+
+Home's stream is derived from the Group-scoped tables themselves rather than from
+an events table. A Module joins the stream by carrying an actor and a time — not
+by remembering to append an event. We have **deliberately not** chosen between
+this and a real events log; this records the deferral and what would end it.
+
+## Why deferred rather than decided
+
+The original argument for deriving was partly built on a production history that
+turned out not to exist: no data to backfill, and no household that had been
+using the app for months and would find an events table empty on its first visit.
+Both of those reasons are gone. What survives is the coupling cost — every
+mutation carrying an emit obligation, where the one that forgets leaves a hole
+nobody notices for months.
+
+That alone did not feel like enough to commit either way, and it does not have to
+be, because the two directions are not symmetric. Deriving now and building an
+events table later is cheap: creations backfill perfectly from rows that already
+carry `_creationTime` and attribution, so the only history lost is the edits and
+deletions that are not recorded today anyway. The reverse is just deleting work.
+And `activity.forGroup` already returns `GroupActivityEntry[]`, so either
+implementation hands the same interface to the same component.
+
+The deadline we thought we had is not one. A composer does **not** force an events
+table: messages are content — rows with an author, a time and a body, exactly like
+baby events — and join the stream as one more source.
+
+## What the rule buys
+
+Creations come free. A state transition costs the row the columns to testify with
+— which is why `tasks` gains `completedAt` and `completedBy`, since "Bob took the
+bins out" is the most wanted line on a household's shared surface and a plain
+`done` boolean cannot say it. Edits and deletions are deliberately absent: a row
+records its current state, not its history, and a household does not need to be
+told that somebody changed an oven temperature.
+
+It also settles which tables must carry Attribution, which `CONTEXT.md` defined
+without saying who had to have it. **A table holding a Group's content records who
+created the row**, required rather than optional — an optional ownership field is
+a schema that has stopped saying who owns the row. `taskLists` and `babies` were
+the only two out of line. `groups` and `memberships` are exempt: they are the
+boundary itself rather than content within it.
+
+## What would end the deferral
+
+1. **You want an edit or a deletion in the stream.** That is the one thing
+   deriving structurally cannot do, and wanting it once is the whole answer.
+2. **A second state-transition column pair lands on the same table.** One is a
+   design; two is a denormalised event log wearing a disguise.
+3. **You want the stream to be authoritative** — "who deleted this, and when" as a
+   question answerable under pressure. That is an audit requirement rather than a
+   Home feature, and deriving can never serve it.
+
+Chat is deliberately not on that list.
+
+## Consequences
+
+**Home is a summary, not an archive.** Every entry links to a Module that holds the
+complete record, so being cut by the per-source quota is not losing information —
+it is not being in the summary. That is why there is no "load more": a summary
+with one invites the reader to treat it as the archive it is not. The quota stays
+because it decides *what is in* the summary while time alone decides the order, so
+a Group with a newborn and one recipe sees both.
+
+This changes when chat arrives, because a message exists nowhere else and has no
+Module page to fall back to. That is the same moment that reopens the question
+above.

--- a/docs/adr/0009-a-refusal-inside-a-group-never-says-which-refusal-it-is.md
+++ b/docs/adr/0009-a-refusal-inside-a-group-never-says-which-refusal-it-is.md
@@ -1,0 +1,49 @@
+# A refusal inside a Group never says which refusal it is
+
+Status: accepted (2026-08-03)
+
+"No such record" and "that record is not in this Group" are the same answer, so
+neither can be used to discover the other. Refusing the **Group** is deliberately
+the opposite: `unknown-slug` and `not-a-member` stay distinct all the way to the
+UI. Whether a mutation refuses out loud or silently is decided by idempotency,
+not by secrecy.
+
+## Why this is written down
+
+Three ticket reviews arrived at the first rule independently, each arguing it from
+scratch, and it now lives as near-identical comments in `babyAccess`, `taskAccess`
+and `recipes`. Three comments agreeing with each other is how a rule quietly stops
+being followed: the fourth Module has nothing to inherit, and any drift is a leak
+rather than an inconsistency. The two levels also look contradictory to a reader
+encountering them cold, which invites somebody to harmonise them and break one.
+
+## The three layers
+
+**A record inside a Group: identical refusals.** `findBabyInGroup` returns null for
+a child that does not exist and for a child in another Group alike. `recipes.get`
+does the same. The page cannot be used to learn that something exists somewhere
+else.
+
+**The Group itself: distinct refusals.** `GROUP_REFUSAL_MESSAGES` keeps "No group
+has that slug" and "Not a member of that group" apart. Collapsing them into the
+permission answer would tell a stranger that a slug exists; collapsing them the
+other way would show somebody a permission error for mistyping their own
+household's name, which in a four-person app is overwhelmingly the likelier event.
+
+**Mutations: idempotency decides.** `recipes.remove` and `integrations.disconnect`
+return silently, because deleting a thing that has gone lands where the caller
+asked. `recipes.move`, `share` and `unshare` throw `'Recipe not found'`, because
+they had work to do and could not do it. Both satisfy the first rule — neither
+message distinguishes missing from forbidden — and the distinction is *not* "a
+mutation you may not make is a silent no-op", which would turn a genuine error
+into silence.
+
+## Consequences
+
+**Group slugs are enumerable, and that is accepted.** Because the boundary's
+refusals stay distinct, anyone signed in can type `/g/jansen-household` and learn
+from the answer that such a Group exists — and slugs are derived from names and
+globally unique (ADR-0002), so that amounts to "this household uses Gather".
+Every record inside is protected; the existence of the boundary is not. Knowing a
+slug buys nothing, because joining needs a code, and the alternative punishes the
+common case for the sake of an attacker who has learned a family name.


### PR DESCRIPTION
Documents only — no behaviour changes. These are the decisions that were
deliberately deferred while epic #15 landed, taken in a grilling session and
recorded so the code work has something to build against.

## Four ADRs

**0006 — Any Member invites; only an admin removes.** The asymmetry is
deliberate: a household is not an organisation with a gatekeeper, but removal is
done *to* a person and is the only membership change that takes content away
from a reader. Its consequence is that **removal must rotate the invite code** —
a code is a bearer token, so an admin who removes somebody and leaves the code
standing has not removed them.

**0007 — A write happens at the address that names its Group.** `canEdit` still
follows the home Group from anywhere; what changes is where the controls are
drawn. Today, Delete at `/g/cooking-club/recipes/<id>` removes a recipe from the
household while the address says cooking-club, Edit navigates to an edit form
under a slug that has nothing to do with the recipe, and the sharing panel offers
to unshare the Group being stood in — which destroys the page it is on. Also
records **Copy** as a Recipes affordance rather than a boundary verb, and that
Unshare consequently stops meaning "take it back".

**0008 — The activity stream is derived from rows that testify.** Two of the three
original arguments for deriving rested on a production history that does not
exist. The choice against an events table is therefore **deliberately deferred**,
with the three things that would end the deferral written down — chat is
explicitly not one of them. Settles which tables must carry Attribution, and that
Home is a summary rather than an archive.

**0009 — A refusal inside a Group never says which refusal it is.** Three ticket
reviews derived this independently and it lives as three near-identical comments,
which is how a rule stops being followed. Records all three layers, including the
two that look contradictory on purpose, and accepts slug enumerability by name.

## Glossary

`CONTEXT.md` gains **Invite code** and **Copy**, splits what a Member may do from
what an admin may do, widens **Provenance** to cover a copied recipe, says
**Home** is a summary, and adds four standing rules.

## Convention

`CLAUDE.md` gains: one-shot code states its own end condition where it lives.
`src/lib/legacyPaths.ts` is the cautionary case — excellent about why it exists,
silent about when it stops.

## Three questions that earned no ADR

B1 (Personal Modules at a Group address) is already decided by ADR-0002's
consequences section — the fix is deleting one apologetic sentence, not moving a
route. B2 (`users.defaultGroupId`) is already forbidden by ADR-0002 — it is a
migration, not a decision. E2 (the `recipes.list` scan) already carries its
reasoning next to the code and only lacked a number.

## Follow-ups

- #31 — recipes list search and tag filter (client-side; the usability wall is at
  ~80 recipes, the scan wall is at ~8,000 deployment-wide)
- #32 — proposal: public Group recipes instead of per-Group sharing. If taken, it
  unwinds ADR-0007's guest-address problem and E2's scan entirely, so worth
  settling before much code is written against these ADRs.
- AppElent/appelent-packages#14 — the hardcoded "ArchStudio" string

The code work these imply is listed in the session summary and is deliberately
not in this PR.
