### PR TITLE
fix: delete a photo's blob in the mutation that orphans it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ cheeses, wines) built on the standard AppElent stack:
 - **Convex** backend (`convex/`) — functions: `recipes.ts`, `groups.ts`, `users.ts`,
   `recipeImport.ts`, `recipeNutrition.ts`, `foods.ts`, `foodsLookup.ts`, `consumption.ts`,
   `taskLists.ts`, `tasks.ts`, `integrations.ts`, `lib/sharing.ts`, `lib/nutrition.ts`,
-  `lib/offMapping.ts`, `lib/offFetch.ts`, `lib/consumption.ts`, `lib/taskAccess.ts`,
+  `lib/offMapping.ts`, `lib/offFetch.ts`, `lib/consumption.ts`, `lib/taskAccess.ts`, `lib/storedFiles.ts`,
   `lib/taskProviders/` (adapter pattern for Notion/Todoist), `seed.ts` +
   `lib/seed/` (see "Seed data" below). Schema in `convex/schema.ts`.
 - **Clerk** auth (`@clerk/clerk-react`), JWT-bridged to Convex via `CLERK_JWT_ISSUER_DOMAIN`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -143,10 +143,11 @@ _Avoid_: Demo data, Dummy data, Test data, Seed data
 - A photo a person chooses is stored as prepared and never as chosen, so one
   that cannot be prepared is not stored at all. An image Gather fetches for
   itself is neither chosen nor prepared (ADR-0010).
-- A stored file lives exactly as long as the row that points at it. The mutation
-  that replaces, clears or deletes that pointer deletes the file with it, so a
-  photo nobody can reach is not a thing storage holds. A file uploaded before any
-  row references it is the exception, and is not yet handled.
+- A stored file lives exactly as long as some row points at it. The mutation
+  that replaces, clears or deletes the last pointer deletes the file with it, so
+  a photo nobody can reach is not a thing storage holds — and a photo two rows
+  hold survives the first of them going. A file uploaded before any row
+  references it is the exception, and is not yet handled.
 - A refusal inside a Group never says which refusal it is. "No such record" and
   "not in this Group" are one answer; refusing the Group itself is a separate,
   distinct one.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -143,6 +143,10 @@ _Avoid_: Demo data, Dummy data, Test data, Seed data
 - A photo a person chooses is stored as prepared and never as chosen, so one
   that cannot be prepared is not stored at all. An image Gather fetches for
   itself is neither chosen nor prepared (ADR-0010).
+- A stored file lives exactly as long as the row that points at it. The mutation
+  that replaces, clears or deletes that pointer deletes the file with it, so a
+  photo nobody can reach is not a thing storage holds. A file uploaded before any
+  row references it is the exception, and is not yet handled.
 - A refusal inside a Group never says which refusal it is. "No such record" and
   "not in this Group" are one answer; refusing the Group itself is a separate,
   distinct one.

--- a/convex/babies.test.ts
+++ b/convex/babies.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { testConvex } from '../test/convexHarness'
 import { api } from './_generated/api'
+import type { Id } from './_generated/dataModel'
 
 /**
  * Who can read which household's baby log, asserted through the real queries.
@@ -81,6 +82,30 @@ async function seed() {
   })
 
   return { t, ...ids }
+}
+
+type Harness = Awaited<ReturnType<typeof seed>>['t']
+
+/** A photo in storage, as an upload from the form would leave one. */
+async function storePhoto(t: Harness) {
+  return await t.run(async (ctx) => await ctx.storage.store(new Blob(['photo'])))
+}
+
+/** Give a child that photo, as `babies.create`/`update` would. */
+async function attachPhoto(
+  t: Harness,
+  babyId: Id<'babies'>,
+  photoId: Id<'_storage'>,
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.patch(babyId, { photoId })
+  })
+}
+
+async function photoExists(t: Harness, photoId: Id<'_storage'>) {
+  return await t.run(
+    async (ctx) => (await ctx.storage.getUrl(photoId)) !== null,
+  )
 }
 
 describe('reading a household log through its Group', () => {
@@ -242,5 +267,166 @@ describe('editing a child under the wrong Group', () => {
         groupSlug: 'jansen-household',
       }),
     ).rejects.toThrow(/Baby not found/)
+  })
+})
+
+/**
+ * A child's photo is a blob in Convex storage that only their row points at, so
+ * the mutation that stops pointing at it is the last chance anything has to
+ * delete it (#38).
+ */
+describe("a child's photo does not outlive the row that held it", () => {
+  const noorsDetails = { name: 'Noor', birthDate: '2026-01-05' }
+
+  test('replacing it deletes the one that was there', async () => {
+    const { t, noor } = await seed()
+    const old = await storePhoto(t)
+    await attachPhoto(t, noor, old)
+    const replacement = await storePhoto(t)
+
+    await t.withIdentity(alice).mutation(api.babies.update, {
+      id: noor,
+      groupSlug: 'jansen-household',
+      ...noorsDetails,
+      photoId: replacement,
+    })
+
+    expect(await photoExists(t, old)).toBe(false)
+    expect(await photoExists(t, replacement)).toBe(true)
+    const baby = await t
+      .withIdentity(alice)
+      .query(api.babies.get, { id: noor, groupSlug: 'jansen-household' })
+    expect(baby?.photoId).toBe(replacement)
+  })
+
+  test('removing it deletes it and leaves the field absent', async () => {
+    const { t, noor } = await seed()
+    const photo = await storePhoto(t)
+    await attachPhoto(t, noor, photo)
+
+    await t.withIdentity(alice).mutation(api.babies.update, {
+      id: noor,
+      groupSlug: 'jansen-household',
+      ...noorsDetails,
+      photoId: null,
+    })
+
+    expect(await photoExists(t, photo)).toBe(false)
+    const baby = await t
+      .withIdentity(alice)
+      .query(api.babies.get, { id: noor, groupSlug: 'jansen-household' })
+    expect(baby?.photoId).toBeUndefined()
+  })
+
+  test('an edit that leaves the photo alone keeps it', async () => {
+    const { t, noor } = await seed()
+    const photo = await storePhoto(t)
+    await attachPhoto(t, noor, photo)
+
+    await t.withIdentity(alice).mutation(api.babies.update, {
+      id: noor,
+      groupSlug: 'jansen-household',
+      name: 'Noortje',
+      birthDate: noorsDetails.birthDate,
+    })
+    // Passing the same id back is the same non-event as omitting it.
+    await t.withIdentity(alice).mutation(api.babies.update, {
+      id: noor,
+      groupSlug: 'jansen-household',
+      name: 'Noortje',
+      birthDate: noorsDetails.birthDate,
+      photoId: photo,
+    })
+
+    expect(await photoExists(t, photo)).toBe(true)
+  })
+
+  test('deleting the child deletes their photo', async () => {
+    const { t, noor } = await seed()
+    const photo = await storePhoto(t)
+    await attachPhoto(t, noor, photo)
+
+    await t
+      .withIdentity(alice)
+      .mutation(api.babies.remove, { id: noor, groupSlug: 'jansen-household' })
+
+    expect(await photoExists(t, photo)).toBe(false)
+  })
+
+  test('a child with no photo is edited and deleted without incident', async () => {
+    const { t, noor } = await seed()
+
+    await t.withIdentity(alice).mutation(api.babies.update, {
+      id: noor,
+      groupSlug: 'jansen-household',
+      ...noorsDetails,
+      photoId: null,
+    })
+    await t
+      .withIdentity(alice)
+      .mutation(api.babies.remove, { id: noor, groupSlug: 'jansen-household' })
+
+    const jansen = await t
+      .withIdentity(alice)
+      .query(api.babies.list, { groupSlug: 'jansen-household' })
+    expect(jansen).toEqual([])
+  })
+
+  // The delete sits behind the access check, so the refusal path never reaches
+  // it — a caller who may not write the row cannot take its picture either.
+  test('a refused edit deletes nothing', async () => {
+    const { t, sam } = await seed()
+    const photo = await storePhoto(t)
+    await attachPhoto(t, sam, photo)
+
+    await expect(
+      t.withIdentity(alice).mutation(api.babies.update, {
+        id: sam,
+        groupSlug: 'jansen-household',
+        name: 'Renamed',
+        birthDate: '2025-11-20',
+        photoId: null,
+      }),
+    ).rejects.toThrow(/Baby not found/)
+
+    expect(await photoExists(t, photo)).toBe(true)
+  })
+
+  test('a refused delete deletes nothing', async () => {
+    const { t, sam } = await seed()
+    const photo = await storePhoto(t)
+    await attachPhoto(t, sam, photo)
+
+    await expect(
+      t
+        .withIdentity(alice)
+        .mutation(api.babies.remove, { id: sam, groupSlug: 'jansen-household' }),
+    ).rejects.toThrow(/Baby not found/)
+
+    expect(await photoExists(t, photo)).toBe(true)
+  })
+
+  test('a photo already gone stops neither the edit nor the delete', async () => {
+    const { t, noor } = await seed()
+    const photo = await storePhoto(t)
+    await attachPhoto(t, noor, photo)
+    await t.run(async (ctx) => {
+      await ctx.storage.delete(photo)
+    })
+
+    await t.withIdentity(alice).mutation(api.babies.update, {
+      id: noor,
+      groupSlug: 'jansen-household',
+      ...noorsDetails,
+      photoId: null,
+    })
+    await t
+      .withIdentity(alice)
+      .mutation(api.babies.remove, { id: noor, groupSlug: 'jansen-household' })
+
+    const jansen = await t
+      .withIdentity(alice)
+      .query(api.babies.list, { groupSlug: 'jansen-household' })
+    expect(jansen).toEqual([])
   })
 })

--- a/convex/babies.test.ts
+++ b/convex/babies.test.ts
@@ -406,6 +406,37 @@ describe("a child's photo does not outlive the row that held it", () => {
     expect(await photoExists(t, photo)).toBe(true)
   })
 
+  /**
+   * `photoId` is client-supplied and every read of a child hands it back, so
+   * one row's photo can end up on another — Alice is in both households and can
+   * put Sam's photo on Noor. The child she can write is not the one that owns
+   * the picture, and deleting her own must not take it (PR #58 review).
+   */
+  test('a photo another child still points at is not deleted', async () => {
+    const { t, noor, sam } = await seed()
+    const photo = await storePhoto(t)
+    await attachPhoto(t, sam, photo)
+
+    const seen = await t
+      .withIdentity(alice)
+      .query(api.babies.get, { id: sam, groupSlug: 'de-vries-household' })
+    await t.withIdentity(alice).mutation(api.babies.update, {
+      id: noor,
+      groupSlug: 'jansen-household',
+      ...noorsDetails,
+      photoId: seen?.photoId,
+    })
+    await t
+      .withIdentity(alice)
+      .mutation(api.babies.remove, { id: noor, groupSlug: 'jansen-household' })
+
+    expect(await photoExists(t, photo)).toBe(true)
+    const stillSam = await t
+      .withIdentity(alice)
+      .query(api.babies.get, { id: sam, groupSlug: 'de-vries-household' })
+    expect(stillSam?.photoId).toBe(photo)
+  })
+
   test('a photo already gone stops neither the edit nor the delete', async () => {
     const { t, noor } = await seed()
     const photo = await storePhoto(t)

--- a/convex/babies.ts
+++ b/convex/babies.ts
@@ -3,6 +3,7 @@ import type { Doc, Id } from './_generated/dataModel'
 import { findBabyInGroup, requireBabyAccess } from './lib/babyAccess'
 import { requireGroupBySlug } from './lib/groupAccess'
 import { getCurrentUser } from './lib/sharing'
+import { deleteStoredFile, replaceStoredFile } from './lib/storedFiles'
 import type { MutationCtx } from './_generated/server'
 import { mutation, query } from './_generated/server'
 
@@ -161,7 +162,7 @@ export const update = mutation({
     photoId: v.optional(v.union(v.id('_storage'), v.null())),
   },
   handler: async (ctx, args) => {
-    await requireBabyAccess(ctx, args.groupSlug, args.id)
+    const { baby } = await requireBabyAccess(ctx, args.groupSlug, args.id)
     const { sex, photoId } = args
     await ctx.db.patch(args.id, {
       name: args.name,
@@ -169,6 +170,9 @@ export const update = mutation({
       ...(sex !== undefined ? { sex: sex ?? undefined } : {}),
       ...(photoId !== undefined ? { photoId: photoId ?? undefined } : {}),
     })
+    // Behind the access check, and only once the row has stopped pointing at
+    // the old photo: nothing else in the app can reach it after this.
+    await replaceStoredFile(ctx, baby.photoId, photoId)
   },
 })
 
@@ -196,6 +200,7 @@ export const remove = mutation({
     await Promise.all(events.map((e) => ctx.db.delete(e._id)))
     await deleteAuxTaskList(ctx, baby.taskListId)
     await deleteAuxTaskList(ctx, baby.questionsListId)
+    await deleteStoredFile(ctx, baby.photoId)
     await ctx.db.delete(args.id)
   },
 })

--- a/convex/babies.ts
+++ b/convex/babies.ts
@@ -200,7 +200,9 @@ export const remove = mutation({
     await Promise.all(events.map((e) => ctx.db.delete(e._id)))
     await deleteAuxTaskList(ctx, baby.taskListId)
     await deleteAuxTaskList(ctx, baby.questionsListId)
-    await deleteStoredFile(ctx, baby.photoId)
     await ctx.db.delete(args.id)
+    // After the row is gone, so that the child being deleted is not itself
+    // counted as still holding the photo.
+    await deleteStoredFile(ctx, baby.photoId)
   },
 })

--- a/convex/lib/storedFiles.test.ts
+++ b/convex/lib/storedFiles.test.ts
@@ -127,6 +127,80 @@ describe('replacing the file a row points at', () => {
   })
 })
 
+/**
+ * Nothing stops two rows holding one `_storage` id — the ids are supplied by
+ * the client and handed back on every read — so the last row to let go of a
+ * blob is the one that deletes it, not the first (PR #58 review).
+ */
+describe('a file another row still points at', () => {
+  /** A recipe row holding `imageId`, with the Group and person it needs. */
+  async function recipeHolding(
+    harness: ReturnType<typeof t>,
+    imageId: Id<'_storage'>,
+  ) {
+    return await harness.run(async (ctx) => {
+      const userId = await ctx.db.insert('users', {
+        clerkId: 'clerk_someone',
+        name: 'Someone',
+        email: 'someone@example.com',
+      })
+      const groupId = await ctx.db.insert('groups', {
+        name: 'Household',
+        slug: 'household',
+        inviteCode: 'code',
+        isPersonal: false,
+      })
+      return await ctx.db.insert('recipes', {
+        groupId,
+        sharedGroupIds: [],
+        createdByUserId: userId,
+        title: 'Holds the picture',
+        ingredients: [],
+        steps: [],
+        tags: [],
+        imageId,
+      })
+    })
+  }
+
+  test('is kept', async () => {
+    const { harness, id, exists } = await storedBlob()
+    await recipeHolding(harness, id)
+
+    await harness.run(async (ctx) => {
+      await deleteStoredFile(ctx as MutationCtx, id)
+    })
+
+    expect(await exists(id)).toBe(true)
+  })
+
+  test('goes once that row lets go of it too', async () => {
+    const { harness, id, exists } = await storedBlob()
+    const holder = await recipeHolding(harness, id)
+
+    await harness.run(async (ctx) => {
+      await ctx.db.delete(holder)
+      await deleteStoredFile(ctx as MutationCtx, id)
+    })
+
+    expect(await exists(id)).toBe(false)
+  })
+
+  test('is kept when a replacement leaves the other row holding it', async () => {
+    const { harness, id, exists } = await storedBlob()
+    await recipeHolding(harness, id)
+    const next = await harness.run(async (ctx) =>
+      ctx.storage.store(new Blob(['y'])),
+    )
+
+    await harness.run(async (ctx) => {
+      await replaceStoredFile(ctx as MutationCtx, id, next)
+    })
+
+    expect(await exists(id)).toBe(true)
+  })
+})
+
 describe('deleting the file a row held', () => {
   test('removes it from storage', async () => {
     const { harness, id, exists } = await storedBlob()

--- a/convex/lib/storedFiles.test.ts
+++ b/convex/lib/storedFiles.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'vitest'
+import { testConvex } from '../../test/convexHarness'
+import type { Id } from '../_generated/dataModel'
+import type { MutationCtx } from '../_generated/server'
+import { deleteStoredFile, replaceStoredFile } from './storedFiles'
+
+/**
+ * The compare-and-delete rule on its own, away from any Module.
+ *
+ * `babies` and `recipes` each hold one photo and each call this; the four
+ * transitions below are the whole of what they get, so they are asserted once
+ * here rather than twice through the mutations.
+ */
+
+const t = () => testConvex()
+
+/** A blob in storage, plus the answer to "is it still there?". */
+async function storedBlob() {
+  const harness = t()
+  const id = await harness.run(async (ctx) => ctx.storage.store(new Blob(['x'])))
+  const exists = async (fileId: Id<'_storage'>) =>
+    await harness.run(async (ctx) => (await ctx.storage.getUrl(fileId)) !== null)
+  return { harness, id, exists }
+}
+
+/**
+ * A ctx that only remembers being asked. Storage is the one thing here with a
+ * cost per call, and "leaves the file alone" and "never asks storage anything"
+ * are different claims — the tests below assert the second, which the state
+ * assertions above cannot see.
+ */
+function recordingCtx() {
+  const calls: string[] = []
+  const ctx = {
+    db: {
+      system: {
+        get: async () => {
+          calls.push('metadata')
+          return null
+        },
+      },
+    },
+    storage: {
+      delete: async () => {
+        calls.push('delete')
+      },
+    },
+  } as unknown as MutationCtx
+  return { ctx, calls }
+}
+
+describe('the transitions that orphan nothing touch storage not at all', () => {
+  const someFile = 'file' as Id<'_storage'>
+
+  test('a row that held no file', async () => {
+    const { ctx, calls } = recordingCtx()
+
+    await deleteStoredFile(ctx, undefined)
+    await replaceStoredFile(ctx, undefined, someFile)
+
+    expect(calls).toEqual([])
+  })
+
+  test('an edit that leaves the field alone, or repeats the same id', async () => {
+    const { ctx, calls } = recordingCtx()
+
+    await replaceStoredFile(ctx, someFile, undefined)
+    await replaceStoredFile(ctx, someFile, someFile)
+
+    expect(calls).toEqual([])
+  })
+})
+
+describe('replacing the file a row points at', () => {
+  test('a different id deletes the one that was stored', async () => {
+    const { harness, id, exists } = await storedBlob()
+    const next = await harness.run(async (ctx) =>
+      ctx.storage.store(new Blob(['y'])),
+    )
+
+    await harness.run(async (ctx) => {
+      await replaceStoredFile(ctx as MutationCtx, id, next)
+    })
+
+    expect(await exists(id)).toBe(false)
+    expect(await exists(next)).toBe(true)
+  })
+
+  test('null clears the row, so the stored file goes', async () => {
+    const { harness, id, exists } = await storedBlob()
+
+    await harness.run(async (ctx) => {
+      await replaceStoredFile(ctx as MutationCtx, id, null)
+    })
+
+    expect(await exists(id)).toBe(false)
+  })
+
+  test('the same id is not a replacement and deletes nothing', async () => {
+    const { harness, id, exists } = await storedBlob()
+
+    await harness.run(async (ctx) => {
+      await replaceStoredFile(ctx as MutationCtx, id, id)
+    })
+
+    expect(await exists(id)).toBe(true)
+  })
+
+  test('an absent field means "leave it alone", not "clear it"', async () => {
+    const { harness, id, exists } = await storedBlob()
+
+    await harness.run(async (ctx) => {
+      await replaceStoredFile(ctx as MutationCtx, id, undefined)
+    })
+
+    expect(await exists(id)).toBe(true)
+  })
+
+  test('a row that held no file has nothing to delete', async () => {
+    const { harness, id, exists } = await storedBlob()
+
+    await harness.run(async (ctx) => {
+      await replaceStoredFile(ctx as MutationCtx, undefined, id)
+    })
+
+    expect(await exists(id)).toBe(true)
+  })
+})
+
+describe('deleting the file a row held', () => {
+  test('removes it from storage', async () => {
+    const { harness, id, exists } = await storedBlob()
+
+    await harness.run(async (ctx) => {
+      await deleteStoredFile(ctx as MutationCtx, id)
+    })
+
+    expect(await exists(id)).toBe(false)
+  })
+
+  test('a row with no file is not a call to storage', async () => {
+    const { harness, id, exists } = await storedBlob()
+
+    await harness.run(async (ctx) => {
+      await deleteStoredFile(ctx as MutationCtx, undefined)
+    })
+
+    expect(await exists(id)).toBe(true)
+  })
+
+  // A blob deleted out of band leaves a row still pointing at it. Throwing
+  // there would make the record undeletable, which is a worse state than the
+  // stale pointer it is trying to clean up.
+  test('a file that is already gone is not an error', async () => {
+    const { harness, id, exists } = await storedBlob()
+    await harness.run(async (ctx) => {
+      await ctx.storage.delete(id)
+    })
+
+    await harness.run(async (ctx) => {
+      await deleteStoredFile(ctx as MutationCtx, id)
+    })
+
+    expect(await exists(id)).toBe(false)
+  })
+
+  test('replacing a file that is already gone is not an error either', async () => {
+    const { harness, id, exists } = await storedBlob()
+    const next = await harness.run(async (ctx) =>
+      ctx.storage.store(new Blob(['y'])),
+    )
+    await harness.run(async (ctx) => {
+      await ctx.storage.delete(id)
+    })
+
+    await harness.run(async (ctx) => {
+      await replaceStoredFile(ctx as MutationCtx, id, next)
+    })
+
+    expect(await exists(next)).toBe(true)
+  })
+})

--- a/convex/lib/storedFiles.ts
+++ b/convex/lib/storedFiles.ts
@@ -19,22 +19,79 @@
  * caller here has already resolved the record and refused whoever may not write
  * it; there is deliberately no publicly callable form of this.
  *
- * **The invariant this rests on: no two rows ever hold the same `_storage`
- * id.** True today — nothing copies a storage id from one row to another, and
- * the Copy verb described in `CONTEXT.md` is not implemented. Whoever
- * implements Copy has to give the copy its own blob, or a copy's delete starts
- * taking the original's picture with it.
+ * **A blob goes when the *last* row lets go of it, not the first.** #38 assumed
+ * no two rows ever hold one `_storage` id, and no gather code copies one — but
+ * nothing enforces it at the door either. `imageId`/`photoId` are supplied by
+ * the client on create and update, and every read hands the id back, so a
+ * Member of a Group a recipe was merely Shared into can put that id on a recipe
+ * of their own. They still cannot write the original row, and unguarded, their
+ * delete would have destroyed the original's picture (PR #58 review). So the
+ * rule is asked rather than assumed: after the write that let go, is any row
+ * still pointing at this blob? That also gives Copy a safe answer in advance —
+ * two rows on one blob keep the picture until both are gone.
+ *
+ * Reading every row of every photo-bearing table to answer it is affordable
+ * because it happens only on the paths that orphan a file, never on a read
+ * path, and `recipes.list` already scans that table on every page load.
  *
  * Out of scope, and both filed: blobs orphaned *before* any row references them
  * (abandoned forms and imports, #41), and any sweep or backfill over the
  * orphans already in storage (#38 states why that half is the hazardous one).
  */
 
-import type { Id } from '../_generated/dataModel'
+import type { Doc, Id, TableNames } from '../_generated/dataModel'
 import type { MutationCtx } from '../_generated/server'
 
 /**
- * Delete a stored file, if there is one and it is still there.
+ * The fields of one table that hold a `_storage` id, if it has any.
+ *
+ * Assignability runs field → id, not the other way about: a `_storage` id is a
+ * branded string and so is assignable *to* every plain `string` column, which
+ * would make every table in the schema look like a file holder.
+ */
+type StoredFileField<T extends TableNames> = {
+  [K in keyof Doc<T>]-?: [NonNullable<Doc<T>[K]>] extends [Id<'_storage'>]
+    ? K
+    : never
+}[keyof Doc<T>]
+
+/** Every table whose rows can point at a stored file. */
+type FileHolder = {
+  [T in TableNames]: [StoredFileField<T>] extends [never] ? never : T
+}[TableNames]
+
+/**
+ * Which field holds the file, per table that has one.
+ *
+ * Typed off the schema rather than written out, so adding a photo to a third
+ * Module fails to compile until it is registered here. A table missing from
+ * this map is invisible to the reference check, and a blob it alone still
+ * points at would be deleted out from under it — the one way this file can
+ * destroy a live photo, and worth a type error rather than vigilance.
+ */
+const FILE_HOLDERS: { [T in FileHolder]: StoredFileField<T> } = {
+  babies: 'photoId',
+  recipes: 'imageId',
+}
+
+/** Is any row — in any table — still pointing at this file? */
+async function isStillReferenced(ctx: MutationCtx, id: Id<'_storage'>) {
+  for (const table of Object.keys(FILE_HOLDERS) as FileHolder[]) {
+    const field = FILE_HOLDERS[table]
+    const rows = await ctx.db.query(table as TableNames).collect()
+    if (rows.some((row) => (row as Record<string, unknown>)[field] === id)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Delete a stored file, once nothing points at it any more.
+ *
+ * Call this *after* the write that let go of it — the patch, or the row's own
+ * delete — so the row being changed is not found holding the id it just
+ * dropped.
  *
  * Already gone is not an error. A blob deleted out of band leaves a row still
  * pointing at it, and throwing on that would make the record undeletable — a
@@ -50,6 +107,7 @@ export async function deleteStoredFile(
   // blob still here?" from inside a mutation.
   const metadata = await ctx.db.system.get(id)
   if (!metadata) return
+  if (await isStillReferenced(ctx, id)) return
   await ctx.storage.delete(id)
 }
 

--- a/convex/lib/storedFiles.ts
+++ b/convex/lib/storedFiles.ts
@@ -1,0 +1,72 @@
+/**
+ * Keeping stored files from outliving the rows that point at them.
+ *
+ * A photo is uploaded to Convex storage and the row keeps its id. Nothing else
+ * ever looks at that blob, so the moment the row stops pointing at it — the
+ * photo is replaced, cleared, or the record deleted — it is unreachable, and
+ * storage that only grows is storage that fills up with pictures nobody can
+ * ever see again (#38).
+ *
+ * So the mutation that orphans a blob deletes it, in the same transaction, and
+ * these are the two shapes that takes: reconciling the id a row *held* with the
+ * id it is *being given*, and dropping the one a deleted record held. Recipes
+ * and Baby are the two Modules with a photo today and there will be a third, so
+ * the rule lives here once rather than open-coded in each.
+ *
+ * **Deletion belongs behind the access check the mutation already makes.** A
+ * `_storage` id carries no ownership — a function that took one and deleted it
+ * would let any signed-in caller destroy any blob in the deployment. Every
+ * caller here has already resolved the record and refused whoever may not write
+ * it; there is deliberately no publicly callable form of this.
+ *
+ * **The invariant this rests on: no two rows ever hold the same `_storage`
+ * id.** True today — nothing copies a storage id from one row to another, and
+ * the Copy verb described in `CONTEXT.md` is not implemented. Whoever
+ * implements Copy has to give the copy its own blob, or a copy's delete starts
+ * taking the original's picture with it.
+ *
+ * Out of scope, and both filed: blobs orphaned *before* any row references them
+ * (abandoned forms and imports, #41), and any sweep or backfill over the
+ * orphans already in storage (#38 states why that half is the hazardous one).
+ */
+
+import type { Id } from '../_generated/dataModel'
+import type { MutationCtx } from '../_generated/server'
+
+/**
+ * Delete a stored file, if there is one and it is still there.
+ *
+ * Already gone is not an error. A blob deleted out of band leaves a row still
+ * pointing at it, and throwing on that would make the record undeletable — a
+ * worse state than the stale pointer being cleaned up. Same call `recipes.remove`
+ * already makes about the row itself.
+ */
+export async function deleteStoredFile(
+  ctx: MutationCtx,
+  id: Id<'_storage'> | undefined | null,
+) {
+  if (!id) return
+  // File metadata is a system table read, and the only way to ask "is this
+  // blob still here?" from inside a mutation.
+  const metadata = await ctx.db.system.get(id)
+  if (!metadata) return
+  await ctx.storage.delete(id)
+}
+
+/**
+ * Reconcile the file a row stored with the one it is being given, deleting the
+ * previous blob when the row stops pointing at it.
+ *
+ * `next` speaks the language the update mutations already speak: `undefined` is
+ * "the field was absent, leave it alone", `null` is "clear it". Only an id that
+ * differs from the stored one, or a clear, orphans anything.
+ */
+export async function replaceStoredFile(
+  ctx: MutationCtx,
+  previous: Id<'_storage'> | undefined,
+  next: Id<'_storage'> | null | undefined,
+) {
+  if (next === undefined) return
+  if (!previous || next === previous) return
+  await deleteStoredFile(ctx, previous)
+}

--- a/convex/recipes.test.ts
+++ b/convex/recipes.test.ts
@@ -1088,3 +1088,86 @@ describe("a recipe's picture does not outlive the row that held it", () => {
     expect(survives).toBeNull()
   })
 })
+
+/**
+ * The delete rule rests on no two rows ever holding one `_storage` id — and
+ * nothing enforces that at the door. `imageId` is client-supplied on create and
+ * update, and every read of a recipe hands the id back, so a Member of a Group
+ * a recipe was merely *shared into* can put that id on a recipe of their own.
+ * They still cannot write the original row; without a guard, deleting their
+ * copy would take the original's picture with it (PR #58 review).
+ */
+describe('a picture two rows point at survives the first of them going', () => {
+  test('deleting a recipe that borrowed another Group’s image leaves it alone', async () => {
+    const { t, ids } = await seed()
+    const image = await storeImage(t)
+    await attachImage(t, ids.sharedWithClub, image)
+
+    // Carol reads the shared recipe — the id comes back with it — and puts that
+    // id on a recipe of her own, in the one Group she can write.
+    const seen = await t
+      .withIdentity(asCarol)
+      .query(api.recipes.get, { id: ids.sharedWithClub, groupSlug: 'cooking-club' })
+    const borrowed = await t.withIdentity(asCarol).mutation(api.recipes.create, {
+      groupSlug: 'cooking-club',
+      title: 'Not mine',
+      ingredients: [],
+      steps: [],
+      tags: [],
+      imageId: seen?.imageId,
+    })
+
+    await t.withIdentity(asCarol).mutation(api.recipes.remove, { id: borrowed })
+
+    expect(await imageExists(t, image)).toBe(true)
+    const original = await t.run(async (ctx) => await ctx.db.get(ids.sharedWithClub))
+    expect(original?.imageId).toBe(image)
+  })
+
+  test('replacing the borrowed image leaves the original alone too', async () => {
+    const { t, ids } = await seed()
+    const image = await storeImage(t)
+    await attachImage(t, ids.sharedWithClub, image)
+
+    const borrowed = await t.withIdentity(asCarol).mutation(api.recipes.create, {
+      groupSlug: 'cooking-club',
+      title: 'Not mine',
+      ingredients: [],
+      steps: [],
+      tags: [],
+      imageId: image,
+    })
+    await t.withIdentity(asCarol).mutation(api.recipes.update, {
+      id: borrowed,
+      title: 'Not mine',
+      ingredients: [],
+      steps: [],
+      tags: [],
+      imageId: null,
+    })
+
+    expect(await imageExists(t, image)).toBe(true)
+  })
+
+  // The last row to let go of a blob is still the one that deletes it.
+  test('once the borrowing copy is gone, the original still deletes its own picture', async () => {
+    const { t, ids } = await seed()
+    const image = await storeImage(t)
+    await attachImage(t, ids.sharedWithClub, image)
+    const borrowed = await t.withIdentity(asCarol).mutation(api.recipes.create, {
+      groupSlug: 'cooking-club',
+      title: 'Not mine',
+      ingredients: [],
+      steps: [],
+      tags: [],
+      imageId: image,
+    })
+
+    await t.withIdentity(asCarol).mutation(api.recipes.remove, { id: borrowed })
+    await t
+      .withIdentity(asAlice)
+      .mutation(api.recipes.remove, { id: ids.sharedWithClub })
+
+    expect(await imageExists(t, image)).toBe(false)
+  })
+})

--- a/convex/recipes.test.ts
+++ b/convex/recipes.test.ts
@@ -895,3 +895,196 @@ describe('a Share is standing to read and nothing else', () => {
     ).rejects.toThrow(/not authenticated/i)
   })
 })
+
+/** A picture in storage, as an upload or a URL import would leave one. */
+async function storeImage(t: Harness) {
+  return await t.run(async (ctx) => await ctx.storage.store(new Blob(['jpeg'])))
+}
+
+async function attachImage(
+  t: Harness,
+  recipeId: Id<'recipes'>,
+  imageId: Id<'_storage'>,
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.patch(recipeId, { imageId })
+  })
+}
+
+async function imageExists(t: Harness, imageId: Id<'_storage'>) {
+  return await t.run(
+    async (ctx) => (await ctx.storage.getUrl(imageId)) !== null,
+  )
+}
+
+/** The fields `recipes.update` insists on, for an edit that is about the picture. */
+const roastFields = {
+  title: 'Sunday roast',
+  ingredients: [],
+  steps: [],
+  tags: [],
+}
+
+/**
+ * A recipe's picture is a blob in Convex storage that only its row points at,
+ * so the mutation that stops pointing at it is the last chance anything has to
+ * delete it (#38).
+ */
+describe("a recipe's picture does not outlive the row that held it", () => {
+  test('replacing it deletes the one that was there', async () => {
+    const { t, ids } = await seed()
+    const old = await storeImage(t)
+    await attachImage(t, ids.roast, old)
+    const replacement = await storeImage(t)
+
+    await t.withIdentity(asAlice).mutation(api.recipes.update, {
+      id: ids.roast,
+      ...roastFields,
+      imageId: replacement,
+    })
+
+    expect(await imageExists(t, old)).toBe(false)
+    expect(await imageExists(t, replacement)).toBe(true)
+    const recipe = await t.run(async (ctx) => await ctx.db.get(ids.roast))
+    expect(recipe?.imageId).toBe(replacement)
+  })
+
+  test('removing it deletes it and leaves the field absent', async () => {
+    const { t, ids } = await seed()
+    const image = await storeImage(t)
+    await attachImage(t, ids.roast, image)
+
+    await t.withIdentity(asAlice).mutation(api.recipes.update, {
+      id: ids.roast,
+      ...roastFields,
+      imageId: null,
+    })
+
+    expect(await imageExists(t, image)).toBe(false)
+    const recipe = await t.run(async (ctx) => await ctx.db.get(ids.roast))
+    expect(recipe?.imageId).toBeUndefined()
+  })
+
+  test('an edit that leaves the picture alone keeps it', async () => {
+    const { t, ids } = await seed()
+    const image = await storeImage(t)
+    await attachImage(t, ids.roast, image)
+
+    await t.withIdentity(asAlice).mutation(api.recipes.update, {
+      id: ids.roast,
+      ...roastFields,
+      title: 'Sunday roast, revisited',
+    })
+    // Passing the same id back is the same non-event as omitting it.
+    await t.withIdentity(asAlice).mutation(api.recipes.update, {
+      id: ids.roast,
+      ...roastFields,
+      imageId: image,
+    })
+
+    expect(await imageExists(t, image)).toBe(true)
+  })
+
+  test('deleting the recipe deletes its picture', async () => {
+    const { t, ids } = await seed()
+    const image = await storeImage(t)
+    await attachImage(t, ids.roast, image)
+
+    await t.withIdentity(asAlice).mutation(api.recipes.remove, { id: ids.roast })
+
+    expect(await imageExists(t, image)).toBe(false)
+  })
+
+  /**
+   * Deliberate, and worth stating as a consequence rather than discovering as a
+   * surprise: a Share makes content visible in a further Group without giving
+   * that Group a claim on it, and writing follows the home Group (ADR-0007). So
+   * the club loses the picture along with the recipe, because it never had
+   * anything of its own to keep.
+   */
+  test('deleting a recipe the club was shared takes the picture from the club too', async () => {
+    const { t, ids } = await seed()
+    const image = await storeImage(t)
+    await attachImage(t, ids.sharedWithClub, image)
+
+    const clubBefore = await t
+      .withIdentity(asCarol)
+      .query(api.recipes.list, { groupSlug: 'cooking-club' })
+    expect(titles(clubBefore)).toContain('Pasta for a crowd')
+
+    await t
+      .withIdentity(asAlice)
+      .mutation(api.recipes.remove, { id: ids.sharedWithClub })
+
+    expect(await imageExists(t, image)).toBe(false)
+    const clubAfter = await t
+      .withIdentity(asCarol)
+      .query(api.recipes.list, { groupSlug: 'cooking-club' })
+    expect(titles(clubAfter)).toEqual(['Club sourdough'])
+  })
+
+  test('a recipe with no picture is edited and deleted without incident', async () => {
+    const { t, ids } = await seed()
+
+    await t.withIdentity(asAlice).mutation(api.recipes.update, {
+      id: ids.roast,
+      ...roastFields,
+      imageId: null,
+    })
+    await t.withIdentity(asAlice).mutation(api.recipes.remove, { id: ids.roast })
+
+    const survives = await t.run(async (ctx) => await ctx.db.get(ids.roast))
+    expect(survives).toBeNull()
+  })
+
+  // The delete sits behind the access check, so the refusal path never reaches
+  // it — a caller who may not write the row cannot take its picture either.
+  test('a refused edit deletes nothing', async () => {
+    const { t, ids } = await seed()
+    const image = await storeImage(t)
+    await attachImage(t, ids.roast, image)
+
+    await expect(
+      t.withIdentity(asCarol).mutation(api.recipes.update, {
+        id: ids.roast,
+        ...roastFields,
+        imageId: null,
+      }),
+    ).rejects.toThrow(/recipe not found/i)
+
+    expect(await imageExists(t, image)).toBe(true)
+  })
+
+  test('a refused delete deletes nothing', async () => {
+    const { t, ids } = await seed()
+    const image = await storeImage(t)
+    await attachImage(t, ids.roast, image)
+
+    // `remove` refuses by returning, so the picture surviving is the whole of
+    // what there is to assert.
+    await t.withIdentity(asCarol).mutation(api.recipes.remove, { id: ids.roast })
+
+    expect(await imageExists(t, image)).toBe(true)
+    const survives = await t.run(async (ctx) => await ctx.db.get(ids.roast))
+    expect(survives?.title).toBe('Sunday roast')
+  })
+
+  test('a picture already gone stops neither the edit nor the delete', async () => {
+    const { t, ids } = await seed()
+    const image = await storeImage(t)
+    await attachImage(t, ids.roast, image)
+    await t.run(async (ctx) => {
+      await ctx.storage.delete(image)
+    })
+
+    await t.withIdentity(asAlice).mutation(api.recipes.update, {
+      id: ids.roast,
+      ...roastFields,
+      imageId: null,
+    })
+    await t.withIdentity(asAlice).mutation(api.recipes.remove, { id: ids.roast })
+
+    const survives = await t.run(async (ctx) => await ctx.db.get(ids.roast))
+    expect(survives).toBeNull()
+  })
+})

--- a/convex/recipes.ts
+++ b/convex/recipes.ts
@@ -14,6 +14,7 @@ import {
   nutritionValidator,
 } from './lib/nutrition'
 import { getCurrentUser, getMyGroupIds } from './lib/sharing'
+import { deleteStoredFile, replaceStoredFile } from './lib/storedFiles'
 
 /** A recipe as every list and detail page wants it: with its picture resolved. */
 async function withImageUrl<T extends { imageId?: Id<'_storage'> }>(
@@ -257,6 +258,9 @@ export const update = mutation({
         : undefined,
       nutritionStale: stale || undefined,
     })
+    // Behind the access check, and only once the row has stopped pointing at
+    // the old picture: nothing else in the app can reach it after this.
+    await replaceStoredFile(ctx, recipe.imageId, imageId)
   },
 })
 
@@ -291,6 +295,10 @@ export const remove = mutation({
     // that is what stops the reply telling a stranger their id was real.
     const recipe = await writableRecipe(ctx, args.id)
     if (!recipe) return
+    // The Groups this was Shared into lose the picture along with the recipe.
+    // A Share is standing to read and no claim on the content, so there is
+    // nothing of theirs to keep (ADR-0007).
+    await deleteStoredFile(ctx, recipe.imageId)
     await ctx.db.delete(args.id)
   },
 })

--- a/convex/recipes.ts
+++ b/convex/recipes.ts
@@ -295,11 +295,12 @@ export const remove = mutation({
     // that is what stops the reply telling a stranger their id was real.
     const recipe = await writableRecipe(ctx, args.id)
     if (!recipe) return
+    await ctx.db.delete(args.id)
     // The Groups this was Shared into lose the picture along with the recipe.
     // A Share is standing to read and no claim on the content, so there is
-    // nothing of theirs to keep (ADR-0007).
+    // nothing of theirs to keep (ADR-0007). After the row is gone, so that the
+    // recipe being deleted is not itself counted as still holding the file.
     await deleteStoredFile(ctx, recipe.imageId)
-    await ctx.db.delete(args.id)
   },
 })
 

--- a/docs/adr/0010-a-photo-is-stored-as-prepared-never-as-chosen.md
+++ b/docs/adr/0010-a-photo-is-stored-as-prepared-never-as-chosen.md
@@ -19,11 +19,14 @@ The alternative was to keep the original as well and store a derivative beside
 it, on Convex or on an external tier. That is a different shape of problem, not a
 setting: `babies.photoId` and `recipes.imageId` are each one optional
 `_storage` id, and a photo that is two blobs in two systems needs a schema that
-says so, provider credentials, and a deletion story across both. Gather does not
-have the last of those even for one blob today — nothing in `convex/` calls
-`ctx.storage.delete`, so every replaced photo is already an orphan that outlives
-the row that referenced it. Adding a second tier would double the number of files
-whose lifetime nobody manages. The tier is deferred rather than refused: when a
+says so, provider credentials, and a deletion story across both. Gather did not
+have the last of those even for one blob when this was decided — nothing in
+`convex/` called `ctx.storage.delete`, so every replaced photo was already an
+orphan that outlived the row that referenced it. (#38 has since fixed that for
+the one-blob case: the mutation that orphans a file deletes it —
+`convex/lib/storedFiles.ts`. Files uploaded before any row points at them are
+still nobody's, #41.) Adding a second tier would double the number of files whose
+lifetime nobody manages. The tier is deferred rather than refused: when a
 Module wants full photographs rather than avatars and headers, it will be worth
 having, and this ADR is what it will have to argue against.
 


### PR DESCRIPTION
Nothing in convex/ called ctx.storage.delete, so storage only ever grew:
replacing a photo stranded the previous blob, clearing it stranded it, and
deleting a child or a recipe left its picture behind with nothing pointing
at it.

The compare-and-delete rule now lives once, in convex/lib/storedFiles.ts,
beside the other Convex lib helpers — Recipes and Baby are the two Modules
with a photo today and there will be a third. Both mutations call it behind
the access check they already make: a _storage id carries no ownership, so
there is deliberately no publicly callable form that takes one. An update
with the same id, or with the field absent, still means "leave it alone" and
touches storage not at all; a refused write deletes nothing; a blob already
gone is not an error, so a stale pointer can never make a record undeletable.

Deleting a Shared recipe takes the picture from the Groups it was Shared
into. That is the sharing model rather than an accident — a Share is standing
to read and no claim on the content (ADR-0007) — and a test says so.

The invariant this rests on is that no two rows hold one _storage id, true
today and recorded where the helper lives, because Copy would break it.

Out of scope and both filed: blobs orphaned before any row references them
(#41), and any sweep or backfill over the orphans already in storage — the
half whose failure mode is destroying photos that are still in use.

Closes #38

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017EbpL9xgJA9niwySKNirxX