### PR TITLE
Translate the whole app, in English and Dutch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,21 +131,30 @@ what a type cannot (empty strings, drifted `{placeholder}` tokens). See
 `docs/adr/0011-the-ui-is-english-at-the-source-and-translations-are-typed-dictionaries.md`
 for the chrome-vs-content boundary and the Dutch glossary.
 
-Two consequences worth knowing before you touch anything:
+The whole app is translated — shell and every Module. **Any new user-visible
+string goes in the message tree, in both locales**; there are no English
+literals left in `src/` to copy the old habit from.
 
-- **A Module's `label` and `description` are not in `lib/modules.ts`.** They live
-  in `messages/<locale>/modules.ts`, keyed by Module id and typed against
-  `ModuleId`. **When you add a Module, add its message entries in the same
-  change** — like its seed contribution above, except this one is a compile
-  error if you forget.
-- **Only the shell is translated so far.** Recipes, Nutrition, Tasks, Baby log,
-  Foods and Group settings are still English literals; extract a feature area at
-  a time via `/appelent:feature apply i18n`, never half of one.
+Four rules the conversion established, each of which will bite if ignored:
 
-Non-React code takes messages as a trailing parameter (`navItems`,
-`getRouteContext`, `formatActivityTime`) rather than importing the context —
-that is what keeps `lib/` callable from a test with no React tree. Component
-tests render through `renderWithI18n` from `src/lib/i18n/testing.tsx`;
+- **Display strings never live in `convex/` or in a plain `lib/` data file.**
+  A Module's `label`/`description`, the nutrient names, the meal names and the
+  baby-log event names all moved out, keyed by the union the schema defines
+  (`ModuleId`, `NutrientKey`, `MealName`, `BabyEventType`). **When you add a
+  Module — or a nutrient, or an event type — add its message entries in the same
+  change**; `satisfies Record<…>` makes forgetting a compile error.
+- **Non-React code takes messages as a trailing parameter** (`navItems`,
+  `getRouteContext`, `formatActivityTime`, `formatAge`, `summarizeEvent`) rather
+  than importing the context. That is what keeps `lib/` callable from a test with
+  no React tree.
+- **A validator returns a key, not a sentence** — `buildEventInput` reports
+  `'enterVaccineName'` and the form resolves it.
+- **Never read a message inside a `useEffect`** whose deps you do not want the
+  locale in. Hold a key in state and resolve it at render; Biome's
+  `useExhaustiveDependencies` will point at this and adding the dep is usually
+  the wrong fix.
+
+Component tests render through `renderWithI18n` from `src/lib/i18n/testing.tsx`;
 `useI18n` throws outside `LocaleProvider` rather than falling back.
 
 ## One-shot code states its own end condition

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,34 @@ on dev and as a preview-type default (`convex env default set --type preview`);
 deployment URL from writing a fake household into the real database. The
 internal `seedCatalog` / `seedPreview` entrypoints do not consult it.
 
+## Internationalization
+
+`@appelent/i18n` supplies the engine; gather owns `src/lib/i18n/` — the
+`messages/{en,nl}/` trees, the root-route wiring, `LanguageToggle` (topbar) and
+`LanguageSettings` (`/settings`). **English is the source language**: a string is
+written in `messages/en/` first, and `messages/nl/` `satisfies` it, so a missing
+key fails `pnpm typecheck` and `src/lib/i18n/__tests__/messages.test.ts` catches
+what a type cannot (empty strings, drifted `{placeholder}` tokens). See
+`docs/adr/0011-the-ui-is-english-at-the-source-and-translations-are-typed-dictionaries.md`
+for the chrome-vs-content boundary and the Dutch glossary.
+
+Two consequences worth knowing before you touch anything:
+
+- **A Module's `label` and `description` are not in `lib/modules.ts`.** They live
+  in `messages/<locale>/modules.ts`, keyed by Module id and typed against
+  `ModuleId`. **When you add a Module, add its message entries in the same
+  change** — like its seed contribution above, except this one is a compile
+  error if you forget.
+- **Only the shell is translated so far.** Recipes, Nutrition, Tasks, Baby log,
+  Foods and Group settings are still English literals; extract a feature area at
+  a time via `/appelent:feature apply i18n`, never half of one.
+
+Non-React code takes messages as a trailing parameter (`navItems`,
+`getRouteContext`, `formatActivityTime`) rather than importing the context —
+that is what keeps `lib/` callable from a test with no React tree. Component
+tests render through `renderWithI18n` from `src/lib/i18n/testing.tsx`;
+`useI18n` throws outside `LocaleProvider` rather than falling back.
+
 ## One-shot code states its own end condition
 
 Migration mutations, backfills and compatibility shims are written to run against

--- a/appelent.json
+++ b/appelent.json
@@ -1,6 +1,7 @@
 {
   "features": {
     "baseline": { "version": 5, "steps": [6, 9, 14, 15] },
-    "auth": { "version": 1 }
+    "auth": { "version": 1 },
+    "i18n": { "version": 1, "options": { "locales": ["en", "nl"] } }
   }
 }

--- a/convex/activity.test.ts
+++ b/convex/activity.test.ts
@@ -194,15 +194,18 @@ describe('the stream belongs to the Group in the address', () => {
       data: { kind: 'wet' },
     })
 
+    // A task's title is what somebody typed; a baby entry's is a category, and
+    // this returns its `BabyEventType` key rather than an English word so the
+    // client can name it in the reader's language (ADR-0011).
     const jansenStream = await activityIn(t, alice, JANSEN)
-    expect(titles(jansenStream).sort()).toEqual(['Buy nappies', 'Feeding'])
+    expect(titles(jansenStream).sort()).toEqual(['Buy nappies', 'feeding'])
     expect(jansenStream.map((e) => e.context).sort()).toEqual([
       'Noor',
       'Shopping',
     ])
 
     const devriesStream = await activityIn(t, alice, DE_VRIES)
-    expect(titles(devriesStream).sort()).toEqual(['Book the vet', 'Diaper'])
+    expect(titles(devriesStream).sort()).toEqual(['Book the vet', 'diaper'])
   })
 
   test('a recipe shared into a Group is not something that happened there', async () => {

--- a/convex/activity.ts
+++ b/convex/activity.ts
@@ -1,6 +1,5 @@
 import { v } from 'convex/values'
 import { requireGroupBySlug } from './lib/groupAccess'
-import { BABY_EVENT_LABELS } from './lib/babyEvents'
 import type { Doc, Id } from './_generated/dataModel'
 import type { QueryCtx } from './_generated/server'
 import { query } from './_generated/server'
@@ -60,7 +59,16 @@ export interface GroupActivityEntry {
    * from the client. Null when the row it named has gone.
    */
   byName: string | null
-  /** What changed, in the words of the thing itself. */
+  /**
+   * What changed, in the words of the thing itself — a recipe's title, a
+   * task's title. These are content: somebody typed them, and they are shown
+   * as they were typed.
+   *
+   * The one exception is `kind: 'babyEvent'`, where there is no such
+   * sentence: what changed is *a temperature*, *a feed*, a category whose
+   * name is chrome and therefore translated. For those this carries the
+   * `BabyEventType` key and the client looks the word up (ADR-0011).
+   */
   title: string
   /** Where it sits: the list a task is in, the child a log entry is about. */
   context: string | null
@@ -275,7 +283,10 @@ export const forGroup = query({
             kind: 'babyEvent',
             at: event._creationTime,
             byName: nameOf(event.loggedBy),
-            title: BABY_EVENT_LABELS[event.type],
+            // The `babyEvent` case of `title` (see the field's comment):
+            // a type key, not a sentence, because the word for it is the
+            // reader's and this file does not know which language that is.
+            title: event.type,
             context: baby.name,
             targetId: baby._id,
           }),

--- a/convex/lib/babyEvents.ts
+++ b/convex/lib/babyEvents.ts
@@ -23,16 +23,11 @@ export const babyEventTypeValidator = v.union(
   v.literal('note'),
 )
 
-export const BABY_EVENT_LABELS: Record<BabyEventType, string> = {
-  temperature: 'Temperature',
-  feeding: 'Feeding',
-  diaper: 'Diaper',
-  sleep: 'Sleep',
-  growth: 'Growth',
-  medication: 'Medication',
-  vaccination: 'Vaccination',
-  note: 'Note',
-}
+// The event-type *names* used to live here. They are read by a person, so they
+// are translated, and they now live in each locale's `baby.ts` under
+// `src/lib/i18n/messages/` keyed by `BabyEventType` (ADR-0011). `activity.ts`
+// used to read them to title an entry; it sends the type key now and lets the
+// client choose the word.
 
 export const temperatureMethodValidator = v.union(
   v.literal('oral'),

--- a/convex/lib/consumption.ts
+++ b/convex/lib/consumption.ts
@@ -11,12 +11,10 @@ export const mealValidator = v.union(
   v.literal('snack'),
 )
 
-export const MEAL_LABELS: Record<MealName, string> = {
-  breakfast: 'Breakfast',
-  lunch: 'Lunch',
-  dinner: 'Dinner',
-  snack: 'Snack',
-}
+// The meal *names* used to live here. They are read by a person, so they are
+// translated, and they now live in each locale's `nutrition.ts` under
+// `src/lib/i18n/messages/` keyed by `MealName` (ADR-0011). No Convex function
+// ever read them; three client components did.
 
 export const QUANTITY_UNITS = ['serving', 'g', 'ml', 'piece'] as const
 export type QuantityUnit = (typeof QUANTITY_UNITS)[number]

--- a/convex/lib/nutrition.ts
+++ b/convex/lib/nutrition.ts
@@ -35,16 +35,10 @@ export const nutritionSourceValidator = v.union(
 
 export type NutritionSource = 'imported' | 'ai' | 'manual'
 
-export const NUTRIENT_LABELS: Record<NutrientKey, string> = {
-  calories: 'Calories (kcal)',
-  protein: 'Protein (g)',
-  carbs: 'Carbs (g)',
-  sugars: 'Sugars (g)',
-  fat: 'Fat (g)',
-  saturatedFat: 'Saturated fat (g)',
-  fiber: 'Fiber (g)',
-  salt: 'Salt (g)',
-}
+// The nutrient *names* used to live here, next to the keys. They are read by a
+// person, so they are translated, and they now live in each locale's
+// `nutrients.ts` under `src/lib/i18n/messages/` keyed by `NutrientKey`
+// (ADR-0011). No Convex function ever read them; three client components did.
 
 // JSON-LD nutrition values are free text in the wild: "250 kcal", "12,5 g"
 // (Dutch decimal comma), "1,200 kcal" (US thousands comma), "1046 kJ",

--- a/docs/adr/0011-the-ui-is-english-at-the-source-and-translations-are-typed-dictionaries.md
+++ b/docs/adr/0011-the-ui-is-english-at-the-source-and-translations-are-typed-dictionaries.md
@@ -104,15 +104,41 @@ Lid, Module, Pin. Ordinary UI words are lowercase as Dutch normally writes them.
 | Cheeses / Wines | Kazen / Wijnen |
 | Kitchen / Money / Home & life / Tasting | Keuken / Geld / Huis & leven / Proeven |
 
-## What is not done
+## Backend files do not hold display strings
 
-Only the shell is translated: navigation, the topbar, the Group switcher, Home,
-All, the placeholder pages, the not-found page and `/settings`. Recipes,
-Nutrition, Tasks, the Baby log, Foods and a Group's own settings are still
-English literals in their components, and each is extracted as its own change
-using the same recipe. Until then the app is honestly half-translated rather
-than dishonestly half-typed — the parity test proves what *is* in the tree is
-complete, and says nothing about what has not been put there yet.
+Four records of English lived in `convex/`, read only by client components:
+`NUTRIENT_LABELS`, `MEAL_LABELS`, `BABY_EVENT_LABELS`, and the baby-log option
+labels in `src/lib/babyEventFields.ts`. All four moved to the message tree,
+keyed by the union the schema already defines, so the key stays where the data
+is and the word goes where the reader is.
+
+`BABY_EVENT_LABELS` was the one with a server-side reader: `activity.ts` used
+it to title a baby-log entry. That was the backend choosing a display word, so
+it now sends the `BabyEventType` key and the client names it. This makes the
+`title` field of `GroupActivityEntry` mean two things by `kind`, which its
+comment now spells out: content for a recipe or a task, a type key for a baby
+event. That is the honest shape — a recipe's title is somebody's words, a
+temperature entry's is ours.
+
+Two smaller rules fell out of doing this at scale:
+
+- **A validator returns a key, not a sentence.** `buildEventInput` reports
+  `'enterVaccineName'`; the form that renders the complaint resolves it. The
+  validator never has to be handed a message tree to stay testable.
+- **A message read inside a `useEffect` makes the effect depend on the
+  locale.** Where that is wrong — the camera stream in `BarcodeScanner`, the
+  once-only OAuth callback — the *state* holds a key and the words are chosen at
+  render. Biome's `useExhaustiveDependencies` catches this, and adding the
+  dependency is usually the wrong fix.
+
+## What is not done
 
 `@appelent/auth`'s own strings — the sign-in forms, the account panel,
 `AppearanceSettings` — belong to that package and are out of gather's reach.
+Everything gather itself renders is translated.
+
+Dates and numbers go through `Intl` with the active locale, so a Dutch reader
+gets `di 4 aug, 13:30` and `1 minuut geleden` without a second dictionary.
+Durations inside a summary (`1h 15m`) are not yet localised; they are compact
+enough to read either way, and doing them properly means a duration formatter
+rather than a message.

--- a/docs/adr/0011-the-ui-is-english-at-the-source-and-translations-are-typed-dictionaries.md
+++ b/docs/adr/0011-the-ui-is-english-at-the-source-and-translations-are-typed-dictionaries.md
@@ -1,0 +1,118 @@
+# The UI is English at the source, and translations are typed dictionaries
+
+Status: accepted (2026-08-04)
+
+Gather's own words are written in English first, in `src/lib/i18n/messages/en/`,
+and every other locale is a file of the same shape that `satisfies` the English
+one. Content — anything a person or an external source wrote — is never
+translated. There is no i18n library; the engine is `@appelent/i18n`, and the
+dictionaries are ordinary TypeScript objects.
+
+## The line that actually matters: chrome, not content
+
+The hard part of translating an app this size is not the mechanism. It is
+knowing what to leave alone.
+
+**Chrome is Gather talking.** Navigation, buttons, headings, empty states,
+`aria-label`s, the sentence Home builds around an activity entry, a Module's
+name and its one-line description. All of it is translated.
+
+**Content is somebody else talking.** A Group's name, a Member's name, a recipe
+title, a task, a note, a child's name, a food from Open Food Facts, and every
+fixture in `convex/lib/seed/`. None of it is translated, ever — not by us and
+not by a translation layer. A recipe called "Boeuf bourguignon" stays that in
+English, and one called "Shepherd's pie" stays that in Dutch, because the person
+who typed it chose those words.
+
+Get this wrong in one direction and translations bleed into the database; get it
+wrong in the other and half the interface stays English. The seed fixtures are
+the case most likely to tempt somebody: they are ours, they are visible, and
+they are still content.
+
+## Why the strings left `lib/modules.ts`
+
+A Module's `label` and `description` used to sit in the registry beside its icon
+and scope. They are the most-rendered strings in the app — sidebar, dock, topbar
+title, All, the command palette, nine placeholder pages — and the registry is
+deliberately a plain data file that no React context may reach, because
+`appNavigation.ts`, `pins.ts` and `groupActivity.ts` all read it from outside a
+component.
+
+So they moved to `messages/<locale>/modules.ts`, keyed by Module id and typed
+`satisfies Record<ModuleId, …>` against the registry itself. Declaring a Module
+without naming it is now a `pnpm typecheck` failure rather than a page that
+renders `undefined`. `MODULE_GROUPS` became ids for the same reason: a heading
+is a translated string, a bucket key is not.
+
+The functions that used to read those fields take a messages object as a
+trailing parameter instead of importing the context — `navItems`,
+`jumpTargets`, `getRouteContext`, `activityModuleLabel`, `formatActivityTime`.
+They stay callable from a test with no React tree around them, which is most of
+why they were plain functions to begin with.
+
+## One thing the shared package cannot do for us
+
+`@appelent/i18n` exports a `createGetSsrLocale` factory that builds the SSR
+locale-resolution server function. Gather does not use it, and no app on
+TanStack Start can: the Vite plugin rewrites `createServerFn(...).handler(...)`
+calls it finds in **app source** into registered endpoints, and never looks
+inside a pre-bundled dependency. The factory's server fn is therefore never
+registered, and calling it returns `undefined` rather than running the handler —
+which is what it did here, silently, until SSR tried to destructure the result.
+
+`src/lib/i18n/server.ts` declares the server function itself and takes only the
+pure `resolveLocale` from the package. Do not "simplify" it back to the factory.
+
+## Why typed `.ts` and not react-i18next
+
+At two locales maintained by the developer editing the files directly, a typed
+object tree buys something a JSON catalog cannot: a missing key is a compile
+error, not a runtime fallback nobody notices. `assertMessageParity` covers what
+the type system cannot see — an empty string, and a `{placeholder}` one locale
+interpolates and another silently drops.
+
+This stops being the right trade at three or four locales, or the first time
+translations arrive from an external translator or a TMS rather than from a
+commit. The dictionary shape maps 1:1 onto JSON message catalogs, so that
+migration is mechanical.
+
+## Dutch glossary
+
+Dutch keeps the capitalised proper nouns CONTEXT.md sets for the domain: Groep,
+Lid, Module, Pin. Ordinary UI words are lowercase as Dutch normally writes them.
+
+| English | Dutch |
+| --- | --- |
+| Group / Member / Module | Groep / Lid / Module |
+| Pin (verb) / Unpin | Vastzetten / Losmaken |
+| Home | Start |
+| All modules | Alle modules |
+| Settings / Group settings | Instellingen / Groepsinstellingen |
+| Groups | Groepen |
+| Soon / Only you / Personal | Binnenkort / Alleen jij / Persoonlijk |
+| Recipes | Recepten |
+| Nutrition | Voeding |
+| Meal planner | Maaltijdplanner |
+| Groceries | Boodschappen |
+| Pantry | Voorraadkast |
+| Finances | Financiën |
+| Bills & subscriptions | Rekeningen & abonnementen |
+| Tasks | Taken |
+| Baby log | Babylogboek |
+| Calendar | Agenda |
+| Notes | Notities |
+| Cheeses / Wines | Kazen / Wijnen |
+| Kitchen / Money / Home & life / Tasting | Keuken / Geld / Huis & leven / Proeven |
+
+## What is not done
+
+Only the shell is translated: navigation, the topbar, the Group switcher, Home,
+All, the placeholder pages, the not-found page and `/settings`. Recipes,
+Nutrition, Tasks, the Baby log, Foods and a Group's own settings are still
+English literals in their components, and each is extracted as its own change
+using the same recipe. Until then the app is honestly half-translated rather
+than dishonestly half-typed — the parity test proves what *is* in the tree is
+complete, and says nothing about what has not been put there yet.
+
+`@appelent/auth`'s own strings — the sign-in forms, the account panel,
+`AppearanceSettings` — belong to that package and are out of gather's reach.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@appelent/auth": "^0.1.0",
+    "@appelent/i18n": "^0.1.0",
     "@clerk/clerk-react": "^5.61.3",
     "@cloudflare/vite-plugin": "^1.26.0",
     "@convex-dev/react-query": "0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@appelent/auth':
         specifier: ^0.1.0
         version: 0.1.0(@clerk/clerk-react@5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@appelent/i18n':
+        specifier: ^0.1.0
+        version: 0.1.0(@clerk/clerk-react@5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/react-start@1.168.34(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@28.1.0)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))
       '@clerk/clerk-react':
         specifier: ^5.61.3
         version: 5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -79,7 +82,7 @@ importers:
         version: 1.167.1(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.7))(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start':
         specifier: latest
-        version: 1.168.32(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 1.168.34(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
       '@tanstack/react-store':
         specifier: latest
         version: 0.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -338,6 +341,15 @@ packages:
       '@clerk/clerk-react': ^5.61.0
       react: ^19.0.0
       react-dom: ^19.0.0
+
+  '@appelent/i18n@0.1.0':
+    resolution: {integrity: sha512-5luhxfz0mREoAs9hvrgVdrjZgJn3KdCHJFBgyBZVbTXPSDRlB6X6sonANdHWJJrZMJ/lsLecnTgED7+ORjU9gg==, tarball: https://npm.pkg.github.com/download/@appelent/i18n/0.1.0/a8bc39d04dc799a659f81b9191fece66d83091be}
+    peerDependencies:
+      '@clerk/clerk-react': ^5.61.0
+      '@tanstack/react-start': ^1.0.0
+      react: ^19.0.0
+      react-dom: ^19.0.0
+      vitest: ^3.0.0 || ^4.0.0
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -3372,12 +3384,12 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start-rsc@0.1.31':
-    resolution: {integrity: sha512-WxjkXYflq550vTNJpdPyMaPC+Vyh88L5wOL+SiDTjPMGne9ad7FZmoJxqfCFEv1e7HVKMH/mMoE8619TsTNVzQ==}
+  '@tanstack/react-start-rsc@0.1.33':
+    resolution: {integrity: sha512-G4e1xwi/InoQmIGgNQSozcWASw68/o3NpbTz+exosdMGRZzLBeUDbj0swEAajxHm6jDEOQ/reSeIcDkcEfhMfw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rspack/core': '>=2.0.0-0'
-      '@vitejs/plugin-rsc': '>=0.5.20'
+      '@vitejs/plugin-rsc': '>=0.5.30'
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
       react-server-dom-rspack: '>=0.0.2'
@@ -3396,8 +3408,8 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
-  '@tanstack/react-start@1.168.32':
-    resolution: {integrity: sha512-y1WXHo+jPfHxiuuN1m+br06IcriiBQnEWryBdbKdEOS5vw2PmnOj+Cgf1/YcGOqtSougScWFeE2rL1FXWvsLLg==}
+  '@tanstack/react-start@1.168.34':
+    resolution: {integrity: sha512-W5MDbD4QlDZHtEXlqN6bJUz7SdsPv6tbNPCih1i72FZqgQlhaxN1BoeoB8H+nN8M4tXRkfJD7VW75FCdQyaQDw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -3524,8 +3536,8 @@ packages:
     resolution: {integrity: sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ==}
     engines: {node: '>=22.12.0'}
 
-  '@tanstack/start-plugin-core@1.171.24':
-    resolution: {integrity: sha512-l/tm+T0ntXHeIzr9kJDTJ2IDNZC0yFazjkvbEVeZsDOrJ8F+HiZmY+tXYqI5/nDYkwxY0DVQr+kGsTRVb6y2Jw==}
+  '@tanstack/start-plugin-core@1.171.25':
+    resolution: {integrity: sha512-YmMye36vohfxau/MaVpltjkpJlf+wfUBoZp3S6Ue53mpAnsHr6El3XQDmcp1wS4kicZmyX1SNcobJpVZc+2dOQ==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@rsbuild/core': ^2.0.0
@@ -8562,6 +8574,14 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       tailwind-merge: 3.6.0
 
+  '@appelent/i18n@0.1.0(@clerk/clerk-react@5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/react-start@1.168.34(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@28.1.0)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))':
+    dependencies:
+      '@clerk/clerk-react': 5.61.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-start': 1.168.34(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      vitest: 4.1.10(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@28.1.0)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
@@ -11688,14 +11708,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@tanstack/react-start-rsc@0.1.31(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.33(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-core': 1.171.15
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.14
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.25(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.17
       '@tanstack/start-storage-context': 1.167.17
       pathe: 2.0.3
@@ -11725,15 +11745,15 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.32(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.34(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start-client': 1.168.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/react-start-rsc': 0.1.31(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+      '@tanstack/react-start-rsc': 0.1.33(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.22(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.14
-      '@tanstack/start-plugin-core': 1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.25(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.17
       pathe: 2.0.3
       react: 19.2.7
@@ -11905,7 +11925,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.171.25(@tanstack/react-router@1.170.18(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react'
 import { getRouteContext } from '../../lib/appNavigation'
+import { useMessages } from '../../lib/i18n'
 import { CommandPalette } from './CommandPalette'
 import { GatherPanel } from './GatherPanel'
 import { IssueReporterModal } from './IssueReporterModal'
@@ -41,7 +42,8 @@ export function AppShell({ children }: { children: ReactNode }) {
 
 function AppShellBody({ children }: { children: ReactNode }) {
   const location = useLocation()
-  const context = getRouteContext(location.pathname)
+  const messages = useMessages()
+  const context = getRouteContext(location.pathname, messages)
   const { current: currentGroup } = useCurrentGroup()
   // The dock is only on screen when there is a navigation to put in it, and the
   // room reserved for it has to go when it does — asked of the same list the
@@ -142,14 +144,14 @@ function AppShellBody({ children }: { children: ReactNode }) {
             ref={navigationDrawerRef}
             role="dialog"
             aria-modal="true"
-            aria-label="Navigation"
+            aria-label={messages.shell.drawer.label}
             onKeyDown={handleDrawerKeyDown}
             onClick={(event) => event.stopPropagation()}
             className="min-h-full w-[min(22rem,92vw)] overflow-y-auto border-r border-[var(--app-border)] bg-[var(--app-surface)]"
           >
             <div className="flex justify-end p-3">
               <IconButton
-                label="Close navigation"
+                label={messages.shell.drawer.close}
                 onClick={() => setNavigationOpen(false)}
               >
                 <X className="h-4 w-4" aria-hidden="true" />

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -2,11 +2,13 @@ import { useLocation, useNavigate } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
 import { jumpTargets } from '../../lib/appNavigation'
 import { groupSlugOf } from '../../lib/groupPaths'
+import { useMessages } from '../../lib/i18n'
 
 export function CommandPalette() {
   const [open, setOpen] = useState(false)
   const [q, setQ] = useState('')
   const navigate = useNavigate()
+  const messages = useMessages()
   // Jumping from inside a Group keeps you in it, exactly as the sidebar and the
   // dock do — the palette is on screen under both route trees too.
   const groupSlug = groupSlugOf(useLocation().pathname)
@@ -24,7 +26,7 @@ export function CommandPalette() {
   }, [])
 
   if (!open) return null
-  const results = jumpTargets(groupSlug).filter((target) =>
+  const results = jumpTargets(groupSlug, messages).filter((target) =>
     target.label.toLowerCase().includes(q.toLowerCase()),
   )
 
@@ -41,7 +43,7 @@ export function CommandPalette() {
           autoFocus
           value={q}
           onChange={(e) => setQ(e.target.value)}
-          placeholder="Jump to…"
+          placeholder={messages.shell.palette.placeholder}
           className="w-full rounded-md border px-3 py-2 text-sm outline-none"
         />
         <ul className="mt-2 max-h-72 overflow-auto">

--- a/src/components/app/ConfirmAction.test.tsx
+++ b/src/components/app/ConfirmAction.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { ConvexError } from 'convex/values'
 import { describe, expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { useConfirmAction } from './ConfirmAction'
 
 /**
@@ -40,7 +41,7 @@ function Harness({ run }: { run: () => Promise<unknown> | unknown }) {
 describe('asking', () => {
   test('nothing runs until the question is answered', () => {
     const run = vi.fn()
-    render(<Harness run={run} />)
+    renderWithI18n(<Harness run={run} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
 
@@ -52,7 +53,7 @@ describe('asking', () => {
 
   test('cancelling closes the question and runs nothing', () => {
     const run = vi.fn()
-    render(<Harness run={run} />)
+    renderWithI18n(<Harness run={run} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
@@ -63,7 +64,7 @@ describe('asking', () => {
 
   test('Escape cancels too', () => {
     const run = vi.fn()
-    render(<Harness run={run} />)
+    renderWithI18n(<Harness run={run} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     fireEvent.keyDown(window, { key: 'Escape' })
@@ -76,7 +77,7 @@ describe('asking', () => {
 describe('answering', () => {
   test('confirming runs the work and closes', async () => {
     const run = vi.fn().mockResolvedValue(undefined)
-    render(<Harness run={run} />)
+    renderWithI18n(<Harness run={run} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     fireEvent.click(screen.getByRole('button', { name: 'Delete list' }))
@@ -87,7 +88,7 @@ describe('answering', () => {
 
   test('a refusal is shown, and the question stays open', async () => {
     const run = vi.fn().mockRejectedValue(new ConvexError('List not found'))
-    render(<Harness run={run} />)
+    renderWithI18n(<Harness run={run} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     fireEvent.click(screen.getByRole('button', { name: 'Delete list' }))
@@ -101,7 +102,7 @@ describe('answering', () => {
 
   test('a failure with nothing readable in it still says something', async () => {
     const run = vi.fn().mockRejectedValue({})
-    render(<Harness run={run} />)
+    renderWithI18n(<Harness run={run} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     fireEvent.click(screen.getByRole('button', { name: 'Delete list' }))

--- a/src/components/app/ConfirmAction.tsx
+++ b/src/components/app/ConfirmAction.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from 'react'
 import { errorMessage } from '../../lib/errorMessage'
+import { useMessages } from '../../lib/i18n'
 import { SurfaceCard } from './ShellPrimitives'
 
 /**
@@ -55,6 +56,7 @@ function ConfirmDialog({
 }: ConfirmDialogProps) {
   const confirmRef = useRef<HTMLButtonElement>(null)
   const openerRef = useRef<HTMLElement | null>(null)
+  const actions = useMessages().common.actions
 
   useEffect(() => {
     openerRef.current =
@@ -132,7 +134,7 @@ function ConfirmDialog({
                 onClick={onCancel}
                 className="inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold"
               >
-                Cancel
+                {actions.cancel}
               </button>
               <button
                 ref={confirmRef}
@@ -141,7 +143,9 @@ function ConfirmDialog({
                 onClick={onConfirm}
                 className="inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[color-mix(in_oklch,var(--app-danger)_45%,var(--app-border))] px-3 text-sm font-semibold text-[var(--app-danger)] disabled:opacity-60"
               >
-                {busy ? 'Working…' : (request.confirmLabel ?? 'Confirm')}
+                {busy
+                  ? actions.working
+                  : (request.confirmLabel ?? actions.confirm)}
               </button>
             </div>
           </div>
@@ -162,6 +166,7 @@ export function useConfirmAction() {
   const [request, setRequest] = useState<ConfirmRequest | null>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const didNotWork = useMessages().common.errors.didNotWork
 
   function confirm(next: ConfirmRequest) {
     setError(null)
@@ -183,12 +188,7 @@ export function useConfirmAction() {
       await request.run()
       setRequest(null)
     } catch (e) {
-      setError(
-        errorMessage(
-          e,
-          request.errorFallback ?? 'That did not work — try again.',
-        ),
-      )
+      setError(errorMessage(e, request.errorFallback ?? didNotWork))
     } finally {
       setBusy(false)
     }

--- a/src/components/app/GatherPanel.test.tsx
+++ b/src/components/app/GatherPanel.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { GatherPanel } from './GatherPanel'
 
 test('does not render when closed', () => {
-  render(
+  renderWithI18n(
     <GatherPanel
       open={false}
       activeGroupName="Jansen Household"
@@ -16,7 +17,7 @@ test('does not render when closed', () => {
 })
 
 test('renders non-automated placeholder prompts when open', () => {
-  render(
+  renderWithI18n(
     <GatherPanel
       open={true}
       activeGroupName="Jansen Household"
@@ -33,7 +34,7 @@ test('renders non-automated placeholder prompts when open', () => {
 })
 
 test('names no group off a group route, rather than inventing one', () => {
-  render(
+  renderWithI18n(
     <GatherPanel
       open={true}
       activeGroupName={null}
@@ -50,7 +51,7 @@ test('names no group off a group route, rather than inventing one', () => {
 
 test('calls onClose from close button and Escape', () => {
   const onClose = vi.fn()
-  render(
+  renderWithI18n(
     <GatherPanel
       open={true}
       activeGroupName="Jansen Household"
@@ -66,7 +67,7 @@ test('calls onClose from close button and Escape', () => {
 })
 
 test('moves focus into the panel and traps Tab navigation', () => {
-  render(
+  renderWithI18n(
     <GatherPanel
       open={true}
       activeGroupName="Oak House"
@@ -100,7 +101,7 @@ test('restores focus to the opener when it closes', () => {
       />
     </>
   )
-  const { rerender } = render(renderPanel(false))
+  const { rerender } = renderWithI18n(renderPanel(false))
   const opener = screen.getByRole('button', { name: 'Open Gather' })
 
   opener.focus()

--- a/src/components/app/GatherPanel.tsx
+++ b/src/components/app/GatherPanel.tsx
@@ -4,6 +4,7 @@ import {
   useEffect,
   useRef,
 } from 'react'
+import { fmt, useMessages } from '../../lib/i18n'
 import { IconButton, Pill, SectionHeader, SurfaceCard } from './ShellPrimitives'
 
 export interface GatherPanelProps {
@@ -14,11 +15,11 @@ export interface GatherPanelProps {
   onClose: () => void
 }
 
-const PROMPTS = [
-  'Show me what changed recently',
-  'Draft a plan for this group',
-  'Summarize this page',
-]
+/**
+ * Which suggestions to offer, and in what order. The words are in the message
+ * tree; this is only the running order, which is not a translator's decision.
+ */
+const PROMPT_KEYS = ['recent', 'plan', 'summarize'] as const
 
 const FOCUSABLE_SELECTOR =
   'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])'
@@ -35,6 +36,7 @@ export function GatherPanel({
 }: GatherPanelProps) {
   const panelRef = useRef<HTMLElement>(null)
   const openerRef = useRef<HTMLElement | null>(null)
+  const { gatherPanel, groupSwitcher } = useMessages().shell
 
   useEffect(() => {
     if (!open) {
@@ -97,7 +99,7 @@ export function GatherPanel({
         ref={panelRef}
         role="dialog"
         aria-modal="true"
-        aria-label="Ask Gather"
+        aria-label={gatherPanel.title}
         onKeyDown={handleKeyDown}
         className="fixed inset-x-0 bottom-0 max-h-[88svh] overflow-auto rounded-t-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-4 shadow-2xl md:inset-y-3 md:right-3 md:left-auto md:w-[360px] md:rounded-[var(--app-radius)]"
       >
@@ -107,14 +109,14 @@ export function GatherPanel({
                 the same answer the switcher gives rather than a guess at
                 which Group the question is about. */}
             <p className="mb-1 text-xs font-semibold uppercase text-[var(--app-muted)]">
-              {activeGroupName ?? 'No group'}
+              {activeGroupName ?? groupSwitcher.none}
             </p>
-            <h2 className="m-0 text-lg font-semibold">Ask Gather</h2>
+            <h2 className="m-0 text-lg font-semibold">{gatherPanel.title}</h2>
             <p className="mt-1 text-sm text-[var(--app-muted)]">
-              Context: {routeTitle}
+              {fmt(gatherPanel.context, { page: routeTitle })}
             </p>
           </div>
-          <IconButton label="Close Ask Gather" onClick={onClose}>
+          <IconButton label={gatherPanel.close} onClick={onClose}>
             <X className="h-4 w-4" aria-hidden="true" />
           </IconButton>
         </header>
@@ -122,34 +124,32 @@ export function GatherPanel({
         <SurfaceCard className="mb-3">
           <div className="mb-3 flex items-center gap-2">
             <Sparkles className="h-4 w-4 text-[var(--app-accent)]" />
-            <Pill tone="warning">Preview</Pill>
+            <Pill tone="warning">{gatherPanel.preview}</Pill>
           </div>
           <p className="m-0 text-sm leading-6 text-[var(--app-muted)]">
-            Automation is not connected yet. Use this panel as a command
-            scratchpad for the active group; real actions will arrive in a later
-            feature.
+            {gatherPanel.notConnected}
           </p>
         </SurfaceCard>
 
         <SurfaceCard>
-          <SectionHeader title="Try asking" />
+          <SectionHeader title={gatherPanel.tryAsking} />
           <div className="grid gap-2">
-            {PROMPTS.map((prompt) => (
+            {PROMPT_KEYS.map((key) => (
               <button
                 type="button"
-                key={prompt}
+                key={key}
                 className="rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface-muted)] px-3 py-2 text-left text-sm"
               >
-                {prompt}
+                {gatherPanel.prompts[key]}
               </button>
             ))}
           </div>
         </SurfaceCard>
 
         <label className="mt-3 block">
-          <span className="sr-only">Ask Gather</span>
+          <span className="sr-only">{gatherPanel.title}</span>
           <textarea
-            placeholder="Ask Gather to help with this group..."
+            placeholder={gatherPanel.placeholder}
             className="min-h-28 w-full resize-none rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)]"
           />
         </label>

--- a/src/components/app/GroupGate.tsx
+++ b/src/components/app/GroupGate.tsx
@@ -2,6 +2,7 @@ import { useQuery } from 'convex/react'
 import { createContext, type ReactNode, useContext, useMemo } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { fmt, useMessages } from '../../lib/i18n'
 
 /**
  * The Group a `/g/<slug>/…` page is being viewed in.
@@ -65,6 +66,8 @@ export interface GroupGateProps {
  */
 export function GroupGate({ slug, children }: GroupGateProps) {
   const result = useQuery(api.groups.bySlug, { slug })
+  const messages = useMessages()
+  const { groupGate } = messages.shell
 
   const group = useMemo<ActiveGroup | null>(
     () => (result?.ok ? { ...result.group, role: result.role } : null),
@@ -74,7 +77,7 @@ export function GroupGate({ slug, children }: GroupGateProps) {
   if (result === undefined) {
     return (
       <p className="py-16 text-center text-sm text-[var(--app-muted)]">
-        Loading…
+        {messages.common.errors.loading}
       </p>
     )
   }
@@ -83,8 +86,8 @@ export function GroupGate({ slug, children }: GroupGateProps) {
     if (result.reason === 'unknown-slug') {
       return (
         <GateMessage
-          title="No such group"
-          body={`Nothing here is called “${slug}”. Check the link, or pick a group from the sidebar.`}
+          title={groupGate.unknownTitle}
+          body={fmt(groupGate.unknownBody, { slug })}
         />
       )
     }
@@ -95,8 +98,8 @@ export function GroupGate({ slug, children }: GroupGateProps) {
     // group is not yours to see.
     return (
       <GateMessage
-        title="This group is not yours"
-        body="You are not a member of it. Ask an admin of the group for an invite."
+        title={groupGate.forbiddenTitle}
+        body={groupGate.forbiddenBody}
       />
     )
   }

--- a/src/components/app/GroupSwitcher.tsx
+++ b/src/components/app/GroupSwitcher.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from '@tanstack/react-router'
 import { useEffect, useRef, useState } from 'react'
 import { groupIndexSurfaceOf, groupLink } from '../../lib/groupPaths'
+import { useMessages } from '../../lib/i18n'
 import { Icon } from './Icon'
 import { useShellGroup } from './ShellGroup'
 import { Pill } from './ShellPrimitives'
@@ -33,6 +34,9 @@ export interface GroupSwitcherProps {
  */
 export function GroupSwitcher({ onNavigate }: GroupSwitcherProps) {
   const location = useLocation()
+  const messages = useMessages()
+  const { groupSwitcher } = messages.shell
+  const { loading } = messages.common.errors
   // The shell's Group rather than the URL's: on `/groups` or `/settings` this
   // keeps naming the Group you came from, which is the one the sidebar below is
   // still listing and the one you are most likely on your way back to.
@@ -73,7 +77,7 @@ export function GroupSwitcher({ onNavigate }: GroupSwitcherProps) {
         onClick={() => setOpen((wasOpen) => !wasOpen)}
         aria-expanded={open}
         aria-haspopup="menu"
-        aria-label="Switch group"
+        aria-label={groupSwitcher.label}
         className="grid w-full grid-cols-[32px_minmax(0,1fr)_auto] items-center gap-2 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-2 py-1.5 text-left"
       >
         <span className="grid h-8 w-8 place-items-center rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] text-sm font-bold text-[var(--app-fg)]">
@@ -83,7 +87,8 @@ export function GroupSwitcher({ onNavigate }: GroupSwitcherProps) {
           <strong className="block truncate text-sm text-[var(--app-fg)]">
             {/* Not "Gather": the app's name is the one thing on this screen
                 nobody needs telling. */}
-            {current?.name ?? (groups === undefined ? 'Loading…' : 'No group')}
+            {current?.name ??
+              (groups === undefined ? loading : groupSwitcher.none)}
           </strong>
           <span className="block truncate text-xs text-[var(--app-muted)]">
             {current
@@ -91,11 +96,11 @@ export function GroupSwitcher({ onNavigate }: GroupSwitcherProps) {
                 // you are, and the line that would otherwise describe the Group
                 // says so instead.
                 !addressed
-                ? 'Go back to it'
+                ? groupSwitcher.elsewhere
                 : current.isPersonal
-                  ? 'Your own group'
-                  : 'Shared group'
-              : 'Pick a group'}
+                  ? groupSwitcher.personal
+                  : groupSwitcher.shared
+              : groupSwitcher.pick}
           </span>
         </span>
         <Icon
@@ -118,7 +123,9 @@ export function GroupSwitcher({ onNavigate }: GroupSwitcherProps) {
               className="grid min-h-9 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-[7px] px-2 text-sm font-semibold text-[var(--app-fg)] no-underline aria-[current]:bg-[var(--app-surface-muted)]"
             >
               <span className="truncate">{group.name}</span>
-              {group.isPersonal ? <Pill>Personal</Pill> : null}
+              {group.isPersonal ? (
+                <Pill>{groupSwitcher.personalPill}</Pill>
+              ) : null}
             </Link>
           ))}
           <Link
@@ -129,7 +136,7 @@ export function GroupSwitcher({ onNavigate }: GroupSwitcherProps) {
             }}
             className="grid min-h-9 items-center rounded-[7px] border-t border-[var(--app-border)] px-2 text-sm text-[var(--app-muted)] no-underline"
           >
-            Manage groups
+            {groupSwitcher.manage}
           </Link>
         </div>
       ) : null}

--- a/src/components/app/ImageUploadField.tsx
+++ b/src/components/app/ImageUploadField.tsx
@@ -1,10 +1,12 @@
 import { useRef, useState } from 'react'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { useMessages } from '../../lib/i18n'
 
 interface ImageUploadFieldProps {
   imageUrl: string | null
   onChange: (imageId: Id<'_storage'> | undefined) => void
   generateUploadUrl: () => Promise<string>
+  /** Overrides the default "Photo" where a caller has a better word for it. */
   label?: string
   fieldId?: string
 }
@@ -13,9 +15,10 @@ export function ImageUploadField({
   imageUrl,
   onChange,
   generateUploadUrl,
-  label = 'Photo',
+  label,
   fieldId = 'image-upload',
 }: ImageUploadFieldProps) {
+  const image = useMessages().common.image
   const [uploading, setUploading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
@@ -39,7 +42,7 @@ export function ImageUploadField({
       })
       onChange(storageId)
     } catch {
-      setError('Could not upload that image')
+      setError(image.failed)
     } finally {
       setUploading(false)
     }
@@ -50,7 +53,7 @@ export function ImageUploadField({
   return (
     <div className="mx-auto mb-6 max-w-2xl rounded-xl border p-4">
       <label htmlFor={fieldId} className="mb-2 block text-sm font-medium">
-        {label}
+        {label ?? image.label}
       </label>
       <div className="flex items-center gap-3">
         {displayUrl ? (
@@ -75,7 +78,7 @@ export function ImageUploadField({
               if (file) handleFile(file)
             }}
           />
-          {uploading && <p className="text-xs opacity-60">Uploading…</p>}
+          {uploading && <p className="text-xs opacity-60">{image.uploading}</p>}
           {error && <p className="text-xs text-red-800">{error}</p>}
           {displayUrl && !uploading && (
             <button
@@ -90,7 +93,7 @@ export function ImageUploadField({
                 if (inputRef.current) inputRef.current.value = ''
               }}
             >
-              Remove photo
+              {image.remove}
             </button>
           )}
         </div>

--- a/src/components/app/IssueReporterModal.test.tsx
+++ b/src/components/app/IssueReporterModal.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { IssueReporterModal } from './IssueReporterModal'
 
 const reportIssueMock = vi.fn()
@@ -27,7 +28,7 @@ function openModal() {
 }
 
 test('is closed until the keyboard shortcut is pressed', () => {
-  render(<IssueReporterModal />)
+  renderWithI18n(<IssueReporterModal />)
   expect(screen.queryByText('Report an issue')).toBeNull()
   openModal()
   expect(screen.getByText('Report an issue')).toBeDefined()
@@ -38,7 +39,7 @@ test('submits the report with the current user and page url', async () => {
     ok: true,
     issueUrl: 'https://github.com/o/r/issues/1',
   })
-  render(<IssueReporterModal />)
+  renderWithI18n(<IssueReporterModal />)
   openModal()
 
   fireEvent.change(screen.getByPlaceholderText(/what happened/i), {
@@ -67,7 +68,7 @@ test('shows the server-reported error', async () => {
     ok: false,
     error: 'GitHub issue reporter is not configured.',
   })
-  render(<IssueReporterModal />)
+  renderWithI18n(<IssueReporterModal />)
   openModal()
 
   fireEvent.change(screen.getByPlaceholderText(/what happened/i), {

--- a/src/components/app/IssueReporterModal.tsx
+++ b/src/components/app/IssueReporterModal.tsx
@@ -1,17 +1,9 @@
 import { useUser } from '@clerk/clerk-react'
 import { useEffect, useState } from 'react'
-import {
-  ISSUE_REPORTER_TYPES,
-  type IssueReporterType,
-} from '../../lib/issueReporter'
+import { useMessages } from '../../lib/i18n'
+import type { IssueReporterType } from '../../lib/issueReporter'
+import { ISSUE_REPORTER_TYPES } from '../../lib/issueReporter'
 import { reportIssue } from '../../server/reportIssue'
-
-const TYPE_LABELS: Record<IssueReporterType, string> = {
-  bug: 'Bug',
-  enhancement: 'Enhancement',
-  docs: 'Docs',
-  question: 'Question',
-}
 
 type SubmitStatus =
   | { state: 'idle' }
@@ -25,6 +17,8 @@ export function IssueReporterModal() {
   const [text, setText] = useState('')
   const [status, setStatus] = useState<SubmitStatus>({ state: 'idle' })
   const { user } = useUser()
+  const messages = useMessages()
+  const { issueReporter } = messages.shell
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -66,7 +60,7 @@ export function IssueReporterModal() {
         setStatus({ state: 'error', error: result.error })
       }
     } catch {
-      setStatus({ state: 'error', error: 'Could not reach the server.' })
+      setStatus({ state: 'error', error: issueReporter.unreachable })
     }
   }
 
@@ -79,10 +73,10 @@ export function IssueReporterModal() {
         className="w-full max-w-md rounded-xl border bg-white p-4 shadow-lg dark:bg-neutral-900"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 className="mb-3 text-sm font-semibold">Report an issue</h2>
+        <h2 className="mb-3 text-sm font-semibold">{issueReporter.title}</h2>
         {status.state === 'success' ? (
           <div className="space-y-3 text-sm">
-            <p>Thanks — your report was filed.</p>
+            <p>{issueReporter.filed}</p>
             {status.issueUrl && (
               <a
                 href={status.issueUrl}
@@ -90,7 +84,7 @@ export function IssueReporterModal() {
                 rel="noreferrer"
                 className="block text-emerald-600 underline dark:text-emerald-400"
               >
-                View issue
+                {issueReporter.viewIssue}
               </a>
             )}
             <button
@@ -101,7 +95,7 @@ export function IssueReporterModal() {
                 setStatus({ state: 'idle' })
               }}
             >
-              Close
+              {messages.common.actions.close}
             </button>
           </div>
         ) : (
@@ -113,7 +107,7 @@ export function IssueReporterModal() {
             >
               {ISSUE_REPORTER_TYPES.map((t) => (
                 <option key={t} value={t}>
-                  {TYPE_LABELS[t]}
+                  {issueReporter.types[t]}
                 </option>
               ))}
             </select>
@@ -121,7 +115,7 @@ export function IssueReporterModal() {
               autoFocus
               value={text}
               onChange={(e) => setText(e.target.value)}
-              placeholder="What happened, or what would you like to see?"
+              placeholder={issueReporter.placeholder}
               rows={4}
               className="w-full rounded-md border bg-transparent px-3 py-2 text-sm outline-none"
             />
@@ -136,14 +130,16 @@ export function IssueReporterModal() {
                 className="rounded-md border px-3 py-1.5 text-sm"
                 onClick={() => setOpen(false)}
               >
-                Cancel
+                {messages.common.actions.cancel}
               </button>
               <button
                 type="submit"
                 disabled={status.state === 'submitting' || !text.trim()}
                 className="rounded-md border bg-black px-3 py-1.5 text-sm text-white disabled:opacity-50 dark:bg-white dark:text-black"
               >
-                {status.state === 'submitting' ? 'Sending…' : 'Send'}
+                {status.state === 'submitting'
+                  ? issueReporter.sending
+                  : issueReporter.send}
               </button>
             </div>
           </form>

--- a/src/components/app/LanguageToggle.tsx
+++ b/src/components/app/LanguageToggle.tsx
@@ -1,0 +1,35 @@
+import { fmt, type Locale, useI18n } from '../../lib/i18n'
+import { IconButton } from './ShellPrimitives'
+
+/**
+ * Flip the language, from the topbar.
+ *
+ * Two locales, so this is a switch rather than a menu: the button shows the
+ * language you are in and says, when asked, the one it would take you to. A
+ * third locale turns this into a list, and that is the moment to write one —
+ * not before.
+ *
+ * `IconButton` rather than a bespoke button: it already sets `aria-label` and
+ * `title` from a single label, which is exactly what a two-character control
+ * needs, and it keeps this the same size and shape as the three controls it
+ * sits beside.
+ */
+const NEXT_LOCALE: Record<Locale, Locale> = { en: 'nl', nl: 'en' }
+
+export function LanguageToggle() {
+  const { locale, messages, setLocale } = useI18n()
+  const next = NEXT_LOCALE[locale]
+  const label = fmt(messages.shell.topbar.switchLanguage, {
+    language: messages.settings.language.names[next],
+  })
+
+  return (
+    <IconButton
+      label={label}
+      onClick={() => setLocale(next)}
+      className="text-xs font-semibold"
+    >
+      {locale.toUpperCase()}
+    </IconButton>
+  )
+}

--- a/src/components/app/MobileDock.tsx
+++ b/src/components/app/MobileDock.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import { dockNavItems, NAV_ACTIVE_OPTIONS } from '../../lib/appNavigation'
+import { useMessages } from '../../lib/i18n'
 import { Icon } from './Icon'
 import { useNavigation } from './useNavigation'
 
@@ -20,6 +21,7 @@ import { useNavigation } from './useNavigation'
  * do not depend on a Group.
  */
 export function MobileDock() {
+  const { dock } = useMessages().shell
   const { items, activeId } = useNavigation()
   const shown = dockNavItems(items, activeId)
 
@@ -27,7 +29,7 @@ export function MobileDock() {
 
   return (
     <nav
-      aria-label="Mobile navigation"
+      aria-label={dock.label}
       className="fixed inset-x-2 bottom-2 z-30 grid gap-1 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-1 md:hidden"
       // Someone who has pinned nothing gets two items, not four empty columns.
       style={{

--- a/src/components/app/ModulePlaceholder.test.tsx
+++ b/src/components/app/ModulePlaceholder.test.tsx
@@ -1,15 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { expect, test } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { ModulePlaceholder } from './ModulePlaceholder'
 
 test('renders an operational placeholder page for a module', () => {
-  render(
-    <ModulePlaceholder
-      label="Groceries"
-      description="A shared shopping list you both check off."
-      icon="ShoppingCart"
-    />,
-  )
+  renderWithI18n(<ModulePlaceholder moduleId="groceries" />)
   expect(screen.getByRole('heading', { name: 'Groceries' })).toBeDefined()
   expect(
     screen.getByText('A shared shopping list you both check off.'),
@@ -18,4 +13,12 @@ test('renders an operational placeholder page for a module', () => {
   expect(
     screen.getByText(/this module is listed in every group already/i),
   ).toBeDefined()
+})
+
+// The whole point of taking an id rather than three strings: the page names
+// the Module in the reader's language without any caller having to know.
+test('names the module in the reader’s language', () => {
+  renderWithI18n(<ModulePlaceholder moduleId="groceries" />, { locale: 'nl' })
+  expect(screen.getByRole('heading', { name: 'Boodschappen' })).toBeDefined()
+  expect(screen.getByText('Module gepland')).toBeDefined()
 })

--- a/src/components/app/ModulePlaceholder.tsx
+++ b/src/components/app/ModulePlaceholder.tsx
@@ -1,15 +1,22 @@
+import { useMessages } from '../../lib/i18n'
+import type { ModuleId } from '../../lib/modules'
+import { moduleById } from '../../lib/modules'
 import { Icon } from './Icon'
 import { Pill, SurfaceCard } from './ShellPrimitives'
 
-export function ModulePlaceholder({
-  label,
-  description,
-  icon,
-}: {
-  label: string
-  description: string
-  icon: string
-}) {
+/**
+ * Takes the Module's id and looks the rest up, rather than being handed a
+ * label, a description and an icon by each of the nine routes that render it.
+ * Three props every caller filled from the same registry row were three chances
+ * to fill one from a different one — and now that two of the three are
+ * translated, three chances to leave a page half in English.
+ */
+export function ModulePlaceholder({ moduleId }: { moduleId: ModuleId }) {
+  const messages = useMessages()
+  const { label, description } = messages.modules.byId[moduleId]
+  const { placeholder } = messages.shell
+  const icon = moduleById(moduleId)?.icon ?? 'Circle'
+
   return (
     <div className="mx-auto grid max-w-4xl gap-4">
       <SurfaceCard>
@@ -20,7 +27,7 @@ export function ModulePlaceholder({
           <div className="min-w-0">
             <div className="mb-2 flex flex-wrap items-center gap-2">
               <h1 className="m-0 text-2xl font-semibold">{label}</h1>
-              <Pill>Module planned</Pill>
+              <Pill>{placeholder.planned}</Pill>
             </div>
             <p className="m-0 max-w-2xl text-sm leading-6 text-[var(--app-muted)]">
               {description}
@@ -30,11 +37,11 @@ export function ModulePlaceholder({
       </SurfaceCard>
 
       <SurfaceCard>
-        <h2 className="m-0 text-sm font-semibold">What will live here</h2>
+        <h2 className="m-0 text-sm font-semibold">
+          {placeholder.whatWillLiveHere}
+        </h2>
         <p className="mt-2 text-sm leading-6 text-[var(--app-muted)]">
-          This module is listed in every group already, so navigation, sharing,
-          and the mobile layout are ready before the full workflow is
-          implemented.
+          {placeholder.body}
         </p>
       </SurfaceCard>
     </div>

--- a/src/components/app/PublicPageFrame.test.tsx
+++ b/src/components/app/PublicPageFrame.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { PublicPageFrame } from './PublicPageFrame'
 
 vi.mock('@tanstack/react-router', () => ({
@@ -19,7 +20,7 @@ vi.mock('@tanstack/react-router', () => ({
 }))
 
 test('renders public pages in the app visual system', () => {
-  render(
+  renderWithI18n(
     <PublicPageFrame eyebrow="Public" title="Welcome back" subtitle="Sign in.">
       <form aria-label="Auth form" />
     </PublicPageFrame>,

--- a/src/components/app/PublicPageFrame.tsx
+++ b/src/components/app/PublicPageFrame.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import type { ReactNode } from 'react'
+import { useMessages } from '../../lib/i18n'
 
 interface PublicPageFrameProps {
   eyebrow: string
@@ -16,6 +17,8 @@ export function PublicPageFrame({
   children,
   actions,
 }: PublicPageFrameProps) {
+  const { publicFrame } = useMessages().shell
+
   return (
     <main className="app-shell grid min-h-svh grid-rows-[auto_1fr] bg-[var(--app-bg)] text-[var(--app-fg)]">
       <header className="border-b border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_88%,transparent)]">
@@ -28,9 +31,11 @@ export function PublicPageFrame({
               G
             </span>
             <span className="min-w-0">
-              <strong className="block truncate text-sm">Gather</strong>
+              <strong className="block truncate text-sm">
+                {publicFrame.brand}
+              </strong>
               <span className="block truncate text-xs text-[var(--app-muted)]">
-                Household plans, shared
+                {publicFrame.tagline}
               </span>
             </span>
           </Link>

--- a/src/components/app/Sidebar.test.tsx
+++ b/src/components/app/Sidebar.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { MobileDock } from './MobileDock'
 import { ShellGroupProvider } from './ShellGroup'
 import { Sidebar } from './Sidebar'
@@ -99,14 +100,14 @@ beforeEach(() => {
 
 describe('the sidebar off any Group route', () => {
   test('says why the modules are missing instead of listing none', () => {
-    render(<Sidebar />)
+    renderWithI18n(<Sidebar />)
 
     expect(screen.getByText(/pick a group to see its modules/i)).toBeDefined()
     expect(screen.queryByRole('navigation', { name: 'Primary' })).toBeNull()
   })
 
   test('still reaches the pages that do not need a Group', () => {
-    render(<Sidebar variant="drawer" />)
+    renderWithI18n(<Sidebar variant="drawer" />)
 
     expect(screen.getByRole('link', { name: 'Groups' })).toBeDefined()
     expect(screen.getByRole('link', { name: 'Settings' })).toBeDefined()
@@ -123,26 +124,41 @@ describe('the sidebar off any Group route', () => {
    * decision, and a deleted test would not notice it being undone.
    */
   test('offers no Group settings link, in or out of a Group', () => {
-    render(<Sidebar />)
+    renderWithI18n(<Sidebar />)
     expect(screen.queryByRole('link', { name: 'Group settings' })).toBeNull()
 
     location.pathname = '/g/me-alice/recipes'
-    render(<Sidebar />)
+    renderWithI18n(<Sidebar />)
     expect(screen.queryByRole('link', { name: 'Group settings' })).toBeNull()
   })
 
   test('lists the modules again as soon as the address names a Group', () => {
     location.pathname = '/g/me-alice/recipes'
-    render(<Sidebar />)
+    renderWithI18n(<Sidebar />)
 
     const nav = screen.getByRole('navigation', { name: 'Primary' })
     expect(nav).toBeDefined()
     expect(screen.getByRole('link', { name: /home/i })).toBeDefined()
   })
 
+  /**
+   * A Module's name reaches the sidebar through `navItems` and `moduleText`,
+   * neither of which is a component, so nothing else here would notice if the
+   * registry started handing back English again.
+   */
+  test('names the modules in the reader’s language', () => {
+    location.pathname = '/g/me-alice/recipes'
+    renderWithI18n(<Sidebar />, { locale: 'nl' })
+
+    const nav = screen.getByRole('navigation', { name: 'Hoofdnavigatie' })
+    expect(within(nav).getByRole('link', { name: 'Recepten' })).toBeDefined()
+    expect(within(nav).getByRole('link', { name: 'Taken' })).toBeDefined()
+    expect(screen.getByRole('link', { name: 'Instellingen' })).toBeDefined()
+  })
+
   test('and Settings still means yours, wherever you are standing', () => {
     location.pathname = '/g/me-alice/recipes'
-    render(<Sidebar />)
+    renderWithI18n(<Sidebar />)
 
     expect(
       screen.getByRole('link', { name: 'Settings' }).getAttribute('href'),
@@ -151,7 +167,7 @@ describe('the sidebar off any Group route', () => {
 
   test('says nothing about preview data any more', () => {
     location.pathname = '/g/me-alice/recipes'
-    const { container } = render(<Sidebar />)
+    const { container } = renderWithI18n(<Sidebar />)
 
     // The footer used to be a card headed "Preview group" promising that group
     // and member details would appear once connected. Home keeps that promise
@@ -173,7 +189,7 @@ describe('the sidebar off any Group route', () => {
 describe('which item claims to be the page you are on', () => {
   test('the dock lights the Module, not Home above it', () => {
     location.pathname = '/g/me-alice/tasks'
-    render(<MobileDock />)
+    renderWithI18n(<MobileDock />)
 
     const current = screen.getAllByRole('link', { current: 'page' })
     expect(current.map((el) => el.textContent)).toEqual(['Tasks'])
@@ -181,7 +197,7 @@ describe('which item claims to be the page you are on', () => {
 
   test('the sidebar agrees, attribute and all', () => {
     location.pathname = '/g/me-alice/tasks'
-    render(<Sidebar />)
+    renderWithI18n(<Sidebar />)
 
     const current = screen.getAllByRole('link', { current: 'page' })
     expect(current.map((el) => el.textContent)).toEqual(['Tasks'])
@@ -191,7 +207,7 @@ describe('which item claims to be the page you are on', () => {
     // `/recipes/<id>` is Recipes, which only `activeNavItemId` knows — the
     // router sees a link to `/recipes` that is not this page.
     location.pathname = '/g/me-alice/recipes/rec_1'
-    render(<MobileDock />)
+    renderWithI18n(<MobileDock />)
 
     const current = screen.getAllByRole('link', { current: 'page' })
     expect(current.map((el) => el.textContent)).toEqual(['Recipes'])
@@ -199,7 +215,7 @@ describe('which item claims to be the page you are on', () => {
 
   test('Home is lit on Home, and only there', () => {
     location.pathname = '/g/me-alice'
-    render(<MobileDock />)
+    renderWithI18n(<MobileDock />)
 
     const current = screen.getAllByRole('link', { current: 'page' })
     expect(current.map((el) => el.textContent)).toEqual(['Home'])
@@ -208,14 +224,14 @@ describe('which item claims to be the page you are on', () => {
 
 describe('the mobile dock with no Group ever visited', () => {
   test('is not there at all, rather than an empty bar', () => {
-    const { container } = render(<MobileDock />)
+    const { container } = renderWithI18n(<MobileDock />)
 
     expect(container.firstChild).toBeNull()
   })
 
   test('comes back inside a Group', () => {
     location.pathname = '/g/me-alice/recipes'
-    render(<MobileDock />)
+    renderWithI18n(<MobileDock />)
 
     expect(
       screen.getByRole('navigation', { name: 'Mobile navigation' }),
@@ -239,7 +255,7 @@ describe('stepping out of a Group and back', () => {
     // Standing in a Group first is what gives the shell something to remember;
     // the rerender is the navigation to a slugless route.
     location.pathname = '/g/me-alice/recipes'
-    const view = render(<ShellGroupProvider>{ui()}</ShellGroupProvider>)
+    const view = renderWithI18n(<ShellGroupProvider>{ui()}</ShellGroupProvider>)
     location.pathname = '/groups'
     view.rerender(<ShellGroupProvider>{ui()}</ShellGroupProvider>)
     return view

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import { NAV_ACTIVE_OPTIONS } from '../../lib/appNavigation'
+import { useMessages } from '../../lib/i18n'
 import { GroupSwitcher } from './GroupSwitcher'
 import { Icon } from './Icon'
 import { Pill } from './ShellPrimitives'
@@ -33,6 +34,7 @@ const FOOTER_LINK =
  */
 export function Sidebar({ variant = 'desktop', onNavigate }: SidebarProps) {
   const isDrawer = variant === 'drawer'
+  const { sidebar, marks, nav } = useMessages().shell
   const { items, activeId } = useNavigation()
 
   return (
@@ -42,16 +44,16 @@ export function Sidebar({ variant = 'desktop', onNavigate }: SidebarProps) {
           ? 'flex min-h-full flex-col gap-6 overflow-y-auto p-4'
           : 'hidden h-svh w-66 shrink-0 flex-col gap-6 overflow-y-auto border-r border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-surface)_86%,transparent)] p-4 md:flex'
       }
-      aria-label="Gather navigation"
+      aria-label={sidebar.label}
     >
       <GroupSwitcher onNavigate={onNavigate} />
 
       {items.length === 0 ? (
         <p className="m-0 px-2 text-sm leading-6 text-[var(--app-muted)]">
-          Pick a group to see its modules.
+          {sidebar.noGroup}
         </p>
       ) : (
-        <nav className="grid gap-1" aria-label="Primary">
+        <nav className="grid gap-1" aria-label={sidebar.primary}>
           {items.map((item) => (
             <Link
               key={item.id}
@@ -75,10 +77,10 @@ export function Sidebar({ variant = 'desktop', onNavigate }: SidebarProps) {
               </span>
               <span className="truncate">{item.label}</span>
               <span className="flex shrink-0 items-center gap-1">
-                {item.placeholder ? <Pill>Soon</Pill> : null}
+                {item.placeholder ? <Pill>{marks.soon}</Pill> : null}
                 {item.personal ? (
-                  <span title="Only you can see this. It is the same in every group.">
-                    <Pill>Only you</Pill>
+                  <span title={marks.onlyYouExplained}>
+                    <Pill>{marks.onlyYou}</Pill>
                   </span>
                 ) : null}
               </span>
@@ -98,12 +100,12 @@ export function Sidebar({ variant = 'desktop', onNavigate }: SidebarProps) {
           one that never does and is called almost the same word, is two
           meanings of "settings" in the same two inches. The Group's settings
           hang off the Group instead: clicking it on Groups opens them. */}
-      <nav className="mt-auto grid gap-1" aria-label="Settings and groups">
+      <nav className="mt-auto grid gap-1" aria-label={sidebar.footer}>
         <Link to="/groups" onClick={onNavigate} className={FOOTER_LINK}>
-          Groups
+          {nav.groups}
         </Link>
         <Link to="/settings" onClick={onNavigate} className={FOOTER_LINK}>
-          Settings
+          {nav.settings}
         </Link>
       </nav>
     </aside>

--- a/src/components/app/Topbar.tsx
+++ b/src/components/app/Topbar.tsx
@@ -1,6 +1,8 @@
 import { HeaderUser } from '@appelent/auth'
 import { Bug, Menu, MessageSquare, Search } from 'lucide-react'
 import type { RouteContext } from '../../lib/appNavigation'
+import { useMessages } from '../../lib/i18n'
+import { LanguageToggle } from './LanguageToggle'
 import { IconButton } from './ShellPrimitives'
 
 export interface TopbarProps {
@@ -17,11 +19,13 @@ export function Topbar({
   onOpenNavigation,
   onOpenGather,
 }: TopbarProps) {
+  const { topbar } = useMessages().shell
+
   return (
     <header className="sticky top-0 z-20 flex min-h-16 items-center justify-between gap-3 border-b border-[var(--app-border)] bg-[color-mix(in_oklch,var(--app-bg)_86%,transparent)] px-3 backdrop-blur md:min-h-[72px] md:px-5">
       <div className="flex min-w-0 items-center gap-3">
         <IconButton
-          label="Open navigation"
+          label={topbar.openNavigation}
           onClick={onOpenNavigation}
           className="md:hidden"
         >
@@ -45,7 +49,7 @@ export function Topbar({
 
       <div className="flex shrink-0 items-center gap-2">
         <IconButton
-          label="Jump to"
+          label={topbar.jumpTo}
           onClick={() => {
             window.dispatchEvent(
               new KeyboardEvent('keydown', { key: 'k', metaKey: true }),
@@ -54,11 +58,11 @@ export function Topbar({
         >
           <Search className="h-4 w-4" aria-hidden="true" />
         </IconButton>
-        <IconButton label="Ask Gather" onClick={onOpenGather}>
+        <IconButton label={topbar.askGather} onClick={onOpenGather}>
           <MessageSquare className="h-4 w-4" aria-hidden="true" />
         </IconButton>
         <IconButton
-          label="Report an issue"
+          label={topbar.reportIssue}
           onClick={() => {
             window.dispatchEvent(
               new KeyboardEvent('keydown', {
@@ -71,6 +75,7 @@ export function Topbar({
         >
           <Bug className="h-4 w-4" aria-hidden="true" />
         </IconButton>
+        <LanguageToggle />
         <HeaderUser />
       </div>
     </header>

--- a/src/components/app/useNavigation.ts
+++ b/src/components/app/useNavigation.ts
@@ -3,6 +3,7 @@ import { useQuery } from 'convex/react'
 import { api } from '../../../convex/_generated/api'
 import type { NavItem } from '../../lib/appNavigation'
 import { activeNavItemId, navItems } from '../../lib/appNavigation'
+import { useMessages } from '../../lib/i18n'
 import { useShellGroup } from './ShellGroup'
 
 /**
@@ -26,12 +27,13 @@ export function useNavigation(): {
   activeId: string | null
 } {
   const location = useLocation()
+  const messages = useMessages()
   const { slug } = useShellGroup()
   // Pins belong to a person *in a Group* (ADR-0005), so there is nothing to ask
   // for until there is a Group to ask about — and `navItems` renders nothing
   // without one either.
   const pins = useQuery(api.users.myPins, slug ? { groupSlug: slug } : 'skip')
-  const items = navItems(pins ?? undefined, slug)
+  const items = navItems(pins ?? undefined, slug, messages)
 
   return { items, activeId: activeNavItemId(location.pathname, items) }
 }

--- a/src/components/baby/BabyChecklistCard.tsx
+++ b/src/components/baby/BabyChecklistCard.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { fmt, useMessages } from '../../lib/i18n'
 import { SurfaceCard } from '../app/ShellPrimitives'
 import { TaskRow } from '../tasks/TaskRow'
 
@@ -30,6 +31,7 @@ export function BabyChecklistCard({
   placeholder,
   collapsible = false,
 }: BabyChecklistCardProps) {
+  const { child } = useMessages().baby.log
   const [open, setOpen] = useState(!collapsible)
   const tasks = useQuery(api.tasks.listByList, {
     listId: taskListId,
@@ -84,12 +86,12 @@ export function BabyChecklistCard({
               value={text}
               onChange={(e) => setText(e.target.value)}
               placeholder={placeholder}
-              aria-label={`Add to ${title}`}
+              aria-label={fmt(child.addTo, { list: title })}
               className="min-h-9 flex-1 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-transparent px-3 text-sm"
             />
             <button
               type="submit"
-              aria-label={`Add to ${title}`}
+              aria-label={fmt(child.addTo, { list: title })}
               className="inline-flex min-h-9 min-w-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3"
             >
               <Plus className="h-4 w-4" aria-hidden="true" />
@@ -97,7 +99,7 @@ export function BabyChecklistCard({
           </form>
           {tasks !== undefined && openItems.length === 0 ? (
             <p className="m-0 text-sm text-[var(--app-muted)]">
-              Nothing here — nice.
+              {child.checklistEmpty}
             </p>
           ) : (
             openItems.map((t) => (
@@ -108,7 +110,7 @@ export function BabyChecklistCard({
                 actions={
                   <button
                     type="button"
-                    aria-label={`Delete ${t.title}`}
+                    aria-label={fmt(child.deleteTask, { task: t.title })}
                     className="grid min-h-9 min-w-9 shrink-0 place-items-center rounded-[var(--app-radius)] text-[var(--app-muted)]"
                     onClick={() =>
                       void removeTask({ taskId: t._id, groupSlug })

--- a/src/components/baby/BabyDetailPage.tsx
+++ b/src/components/baby/BabyDetailPage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import { formatAge } from '../../lib/babyDate'
+import { useI18n } from '../../lib/i18n'
 import { SurfaceCard } from '../app/ShellPrimitives'
 import { BabyChecklistCard } from './BabyChecklistCard'
 import { BabySwitcher } from './BabySwitcher'
@@ -47,6 +48,8 @@ export function BabyDetailPage({
   )
   const ensureTodoList = useMutation(api.babies.ensureTodoList)
   const ensureQuestionsList = useMutation(api.babies.ensureQuestionsList)
+  const { locale, messages } = useI18n()
+  const { child } = messages.baby.log
 
   useEffect(() => {
     if (baby && !baby.taskListId)
@@ -82,9 +85,12 @@ export function BabyDetailPage({
     [events],
   )
 
-  if (baby === undefined) return <p className="text-sm opacity-60">Loading…</p>
+  if (baby === undefined)
+    return (
+      <p className="text-sm opacity-60">{messages.common.errors.loading}</p>
+    )
   if (baby === null)
-    return <p className="text-sm opacity-60">Child not found.</p>
+    return <p className="text-sm opacity-60">{child.notFound}</p>
 
   return (
     <div className="mx-auto grid max-w-5xl gap-4">
@@ -92,16 +98,16 @@ export function BabyDetailPage({
         <BabyChecklistCard
           taskListId={baby.taskListId}
           groupSlug={groupSlug}
-          title="To-do"
-          placeholder="Buy diapers, call pediatrician…"
+          title={child.todo}
+          placeholder={child.todoPlaceholder}
         />
       )}
       {baby.questionsListId && (
         <BabyChecklistCard
           taskListId={baby.questionsListId}
           groupSlug={groupSlug}
-          title="Questions"
-          placeholder="Ask about sleep regression…"
+          title={child.questions}
+          placeholder={child.questionsPlaceholder}
           collapsible
         />
       )}
@@ -122,7 +128,7 @@ export function BabyDetailPage({
           <div>
             <h1 className="m-0 text-2xl font-semibold">{baby.name}</h1>
             <p className="m-0 text-sm text-[var(--app-muted)]">
-              {formatAge(baby.birthDate)}
+              {formatAge(baby.birthDate, child.age, locale)}
             </p>
           </div>
         </div>
@@ -132,7 +138,7 @@ export function BabyDetailPage({
             {...nav.edit(id)}
             className="inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold no-underline"
           >
-            Edit
+            {messages.common.actions.edit}
           </Link>
         </div>
       </div>
@@ -154,14 +160,16 @@ export function BabyDetailPage({
           {temperaturePoints.length > 0 && (
             <SurfaceCard>
               <h2 className="m-0 mb-2 text-sm font-semibold">
-                Temperature trend
+                {child.temperatureTrend}
               </h2>
               <TrendChart points={temperaturePoints} unit="°C" />
             </SurfaceCard>
           )}
           {weightPoints.length > 0 && (
             <SurfaceCard>
-              <h2 className="m-0 mb-2 text-sm font-semibold">Weight trend</h2>
+              <h2 className="m-0 mb-2 text-sm font-semibold">
+                {child.weightTrend}
+              </h2>
               <TrendChart points={weightPoints} unit="kg" />
             </SurfaceCard>
           )}

--- a/src/components/baby/BabyForm.tsx
+++ b/src/components/baby/BabyForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useMessages } from '../../lib/i18n'
 
 const inputClass =
   'w-full rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)] disabled:cursor-not-allowed disabled:opacity-60'
@@ -16,6 +17,9 @@ interface BabyFormProps {
 }
 
 export function BabyForm({ initial, submitting, onSubmit }: BabyFormProps) {
+  const messages = useMessages()
+  const { form } = messages.baby.log
+
   const [name, setName] = useState(initial?.name ?? '')
   const [birthDate, setBirthDate] = useState(initial?.birthDate ?? '')
   const [sex, setSex] = useState(initial?.sex ?? 'unspecified')
@@ -29,7 +33,7 @@ export function BabyForm({ initial, submitting, onSubmit }: BabyFormProps) {
       }}
     >
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Name</span>
+        <span className="mb-1 block font-medium">{form.name}</span>
         <input
           className={inputClass}
           value={name}
@@ -38,7 +42,7 @@ export function BabyForm({ initial, submitting, onSubmit }: BabyFormProps) {
         />
       </label>
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Birth date</span>
+        <span className="mb-1 block font-medium">{form.birthDate}</span>
         <input
           type="date"
           className={inputClass}
@@ -48,7 +52,7 @@ export function BabyForm({ initial, submitting, onSubmit }: BabyFormProps) {
         />
       </label>
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Sex</span>
+        <span className="mb-1 block font-medium">{form.sex}</span>
         <select
           className={inputClass}
           value={sex}
@@ -56,9 +60,9 @@ export function BabyForm({ initial, submitting, onSubmit }: BabyFormProps) {
             setSex(e.target.value as NonNullable<BabyFormValues['sex']>)
           }
         >
-          <option value="unspecified">Prefer not to say</option>
-          <option value="female">Female</option>
-          <option value="male">Male</option>
+          <option value="unspecified">{form.sexUnspecified}</option>
+          <option value="female">{form.sexFemale}</option>
+          <option value="male">{form.sexMale}</option>
         </select>
       </label>
       <button
@@ -66,7 +70,9 @@ export function BabyForm({ initial, submitting, onSubmit }: BabyFormProps) {
         disabled={submitting}
         className="w-fit rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-4 py-2 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
       >
-        {submitting ? 'Saving…' : 'Save'}
+        {submitting
+          ? messages.common.actions.saving
+          : messages.common.actions.save}
       </button>
     </form>
   )

--- a/src/components/baby/BabyListPage.tsx
+++ b/src/components/baby/BabyListPage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from 'convex/react'
 import { Plus } from 'lucide-react'
 import { api } from '../../../convex/_generated/api'
 import { formatAge } from '../../lib/babyDate'
+import { useI18n } from '../../lib/i18n'
 import { SurfaceCard } from '../app/ShellPrimitives'
 import type { BabyNav } from './babyNav'
 
@@ -21,15 +22,18 @@ export interface BabyListPageProps {
  */
 export function BabyListPage({ groupSlug, nav }: BabyListPageProps) {
   const babies = useQuery(api.babies.list, { groupSlug })
+  const { locale, messages } = useI18n()
+  const { child, list } = messages.baby.log
 
   return (
     <div className="mx-auto grid max-w-5xl gap-4">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <h2 className="m-0 text-2xl font-semibold">Baby log</h2>
+          <h2 className="m-0 text-2xl font-semibold">
+            {messages.modules.byId['baby-log'].label}
+          </h2>
           <p className="mt-1 text-sm text-[var(--app-muted)]">
-            Temperature, feeding, sleep, growth and more — shared with the
-            group.
+            {list.subtitle}
           </p>
         </div>
         <Link
@@ -37,7 +41,7 @@ export function BabyListPage({ groupSlug, nav }: BabyListPageProps) {
           className="inline-flex min-h-9 items-center gap-2 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 text-sm font-semibold text-[var(--app-fg)] no-underline"
         >
           <Plus className="h-4 w-4" aria-hidden="true" />
-          Add child
+          {list.addChild}
         </Link>
       </div>
 
@@ -53,15 +57,15 @@ export function BabyListPage({ groupSlug, nav }: BabyListPageProps) {
       ) : babies.length === 0 ? (
         <SurfaceCard>
           <div className="grid gap-3 text-center">
-            <h3 className="m-0 text-base font-semibold">No children yet</h3>
+            <h3 className="m-0 text-base font-semibold">{list.emptyTitle}</h3>
             <p className="m-0 text-sm text-[var(--app-muted)]">
-              Add a child to start logging temperature, feeding, sleep and more.
+              {list.emptyBody}
             </p>
             <Link
               {...nav.create}
               className="mx-auto inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold no-underline"
             >
-              Add your first child
+              {list.emptyAction}
             </Link>
           </div>
         </SurfaceCard>
@@ -89,7 +93,7 @@ export function BabyListPage({ groupSlug, nav }: BabyListPageProps) {
                       {b.name}
                     </h3>
                     <p className="m-0 text-sm text-[var(--app-muted)]">
-                      {formatAge(b.birthDate)}
+                      {formatAge(b.birthDate, child.age, locale)}
                     </p>
                   </div>
                 </div>

--- a/src/components/baby/BabySwitcher.tsx
+++ b/src/components/baby/BabySwitcher.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { useMessages } from '../../lib/i18n'
 import type { BabyNav } from './babyNav'
 
 interface BabySwitcherProps {
@@ -9,10 +10,12 @@ interface BabySwitcherProps {
 }
 
 export function BabySwitcher({ babies, activeId, nav }: BabySwitcherProps) {
+  const { child } = useMessages().baby.log
+
   if (babies.length < 2) return null
 
   return (
-    <nav className="flex flex-wrap gap-2" aria-label="Switch child">
+    <nav className="flex flex-wrap gap-2" aria-label={child.switch}>
       {babies.map((b) => (
         <Link
           key={b._id}

--- a/src/components/baby/EditBabyPage.tsx
+++ b/src/components/baby/EditBabyPage.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery } from 'convex/react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Doc, Id } from '../../../convex/_generated/dataModel'
+import { fmt, useMessages } from '../../lib/i18n'
 import { useConfirmAction } from '../app/ConfirmAction'
 import { ImageUploadField } from '../app/ImageUploadField'
 import { BabyForm } from './BabyForm'
@@ -21,10 +22,16 @@ export interface EditBabyPageProps {
 export function EditBabyPage({ babyId, groupSlug, nav }: EditBabyPageProps) {
   const id = babyId as Id<'babies'>
   const baby = useQuery(api.babies.get, { id, groupSlug })
+  const messages = useMessages()
 
-  if (baby === undefined) return <p className="text-sm opacity-60">Loading…</p>
+  if (baby === undefined)
+    return (
+      <p className="text-sm opacity-60">{messages.common.errors.loading}</p>
+    )
   if (baby === null)
-    return <p className="text-sm opacity-60">Child not found.</p>
+    return (
+      <p className="text-sm opacity-60">{messages.baby.log.child.notFound}</p>
+    )
 
   return (
     <EditBabyForm key={baby._id} baby={baby} groupSlug={groupSlug} nav={nav} />
@@ -51,20 +58,24 @@ function EditBabyForm({
     baby.photoId,
   )
   const [photoUrl, setPhotoUrl] = useState<string | null>(baby.photoUrl)
+  const messages = useMessages()
+  const { form } = messages.baby.log
 
   return (
     <div className="mx-auto max-w-2xl">
       <div className="mb-6 flex items-center justify-between">
-        <h1 className="m-0 text-2xl font-semibold">Edit {baby.name}</h1>
+        <h1 className="m-0 text-2xl font-semibold">
+          {fmt(form.editTitle, { name: baby.name })}
+        </h1>
         <button
           type="button"
           className="rounded border px-3 py-1.5 text-sm"
           onClick={() =>
             confirm({
-              title: `Delete ${baby.name}?`,
-              body: 'Every entry logged for them goes too, for everyone in this group.',
-              confirmLabel: `Delete ${baby.name}`,
-              errorFallback: 'Could not delete that child.',
+              title: fmt(form.deleteTitle, { name: baby.name }),
+              body: form.deleteBody,
+              confirmLabel: fmt(form.deleteConfirm, { name: baby.name }),
+              errorFallback: form.deleteFailed,
               run: async () => {
                 await remove({ id: baby._id, groupSlug })
                 navigate(nav.list)
@@ -72,7 +83,7 @@ function EditBabyForm({
             })
           }
         >
-          Delete
+          {messages.common.actions.delete}
         </button>
       </div>
 
@@ -112,9 +123,7 @@ function EditBabyForm({
             })
             navigate(nav.detail(baby._id))
           } catch (err) {
-            setError(
-              err instanceof Error ? err.message : 'Could not save that child',
-            )
+            setError(err instanceof Error ? err.message : form.saveFailed)
             setSubmitting(false)
           }
         }}

--- a/src/components/baby/EventForm.tsx
+++ b/src/components/baby/EventForm.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Doc, Id } from '../../../convex/_generated/dataModel'
 import type { BabyEventType } from '../../../convex/lib/babyEvents'
-import { BABY_EVENT_LABELS } from '../../../convex/lib/babyEvents'
 import {
   combineDateTime,
   toDateInputValue,
@@ -17,6 +16,7 @@ import {
   rememberEventChoices,
 } from '../../lib/babyEventFormValues'
 import { errorMessage } from '../../lib/errorMessage'
+import { fmt, useMessages } from '../../lib/i18n'
 import { EventTypeFields } from './EventTypeFields'
 
 type BabyEventDoc = Doc<'babyEvents'>
@@ -49,12 +49,15 @@ export function EventForm({
   const [notes, setNotes] = useState(event?.notes ?? '')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const messages = useMessages()
+  const { entry, validation } = messages.baby.log
+  const typeName = messages.baby.eventTypes[type]
 
   async function submit(e: React.FormEvent) {
     e.preventDefault()
     const built = buildEventInput(type, values, timestampMs)
     if (built.error) {
-      setError(built.error)
+      setError(validation[built.error])
       return
     }
     rememberEventChoices(type, values)
@@ -83,7 +86,7 @@ export function EventForm({
       }
       onDone()
     } catch (err) {
-      setError(errorMessage(err, 'Could not save this entry'))
+      setError(errorMessage(err, entry.saveFailed))
       setSubmitting(false)
     }
   }
@@ -91,12 +94,15 @@ export function EventForm({
   return (
     <form onSubmit={submit} className="grid gap-3">
       <h3 className="m-0 text-sm font-semibold">
-        {event ? 'Edit' : 'Log'} {BABY_EVENT_LABELS[type].toLowerCase()}
+        {/* The name is not lowercased on the way in: English put the type
+            after "Log " and could take a lowercase word, Dutch puts it first
+            and cannot. Each locale's template decides its own capitalisation. */}
+        {fmt(event ? entry.editTitle : entry.logTitle, { type: typeName })}
       </h3>
 
       <div className="min-w-0 sm:max-w-sm">
         <span className="mb-1 block text-sm font-medium">
-          {type === 'sleep' ? 'Start' : 'When'}
+          {type === 'sleep' ? entry.start : entry.when}
         </span>
         <div className="flex gap-2">
           <input
@@ -132,7 +138,7 @@ export function EventForm({
       />
 
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Notes</span>
+        <span className="mb-1 block font-medium">{entry.notes}</span>
         <textarea
           className={inputClass}
           value={notes}
@@ -149,14 +155,16 @@ export function EventForm({
           disabled={submitting}
           className="min-h-9 rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-3 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {submitting ? 'Saving…' : 'Save'}
+          {submitting
+            ? messages.common.actions.saving
+            : messages.common.actions.save}
         </button>
         <button
           type="button"
           onClick={onCancel}
           className="min-h-9 px-2 text-sm text-[var(--app-muted)]"
         >
-          Cancel
+          {messages.common.actions.cancel}
         </button>
       </div>
     </form>

--- a/src/components/baby/EventTypeFields.tsx
+++ b/src/components/baby/EventTypeFields.tsx
@@ -5,13 +5,14 @@ import {
   toTimeInputValue,
 } from '../../lib/babyDate'
 import {
-  DIAPER_KIND_LABELS,
-  FEEDING_METHOD_LABELS,
+  DIAPER_KINDS,
+  FEEDING_METHODS,
   BABY_INPUT_CLASS as inputClass,
-  TEMPERATURE_METHOD_LABELS,
+  TEMPERATURE_METHODS,
   TEMPERATURE_OPTIONS,
 } from '../../lib/babyEventFields'
 import type { EventValues } from '../../lib/babyEventFormValues'
+import { useMessages } from '../../lib/i18n'
 
 interface EventTypeFieldsProps {
   type: BabyEventType
@@ -29,6 +30,7 @@ export function EventTypeFields({
   timestampMs,
   onChange,
 }: EventTypeFieldsProps) {
+  const { fields, options: labels } = useMessages().baby.log
   const str = (key: string) =>
     typeof values[key] === 'string' ? (values[key] as string) : ''
 
@@ -50,7 +52,7 @@ export function EventTypeFields({
 
   const endFields = (
     <div className="min-w-0">
-      <span className="mb-1 block text-sm font-medium">End (optional)</span>
+      <span className="mb-1 block text-sm font-medium">{fields.end}</span>
       <div className="flex gap-2">
         <input
           type="date"
@@ -78,7 +80,7 @@ export function EventTypeFields({
       return (
         <div className="grid gap-3 sm:grid-cols-2">
           <label className="block text-sm">
-            <span className="mb-1 block font-medium">Temperature (°C)</span>
+            <span className="mb-1 block font-medium">{fields.temperature}</span>
             <select
               className={inputClass}
               value={celsius}
@@ -92,16 +94,16 @@ export function EventTypeFields({
             </select>
           </label>
           <label className="block text-sm">
-            <span className="mb-1 block font-medium">Method</span>
+            <span className="mb-1 block font-medium">{fields.method}</span>
             <select
               className={inputClass}
               value={str('method')}
               onChange={(e) => onChange({ method: e.target.value })}
             >
-              <option value="">Not specified</option>
-              {Object.entries(TEMPERATURE_METHOD_LABELS).map(([k, l]) => (
+              <option value="">{fields.notSpecified}</option>
+              {TEMPERATURE_METHODS.map((k) => (
                 <option key={k} value={k}>
-                  {l}
+                  {labels.temperatureMethod[k]}
                 </option>
               ))}
             </select>
@@ -115,15 +117,15 @@ export function EventTypeFields({
       return (
         <div className="grid gap-3 sm:grid-cols-2">
           <label className="block text-sm">
-            <span className="mb-1 block font-medium">Method</span>
+            <span className="mb-1 block font-medium">{fields.method}</span>
             <select
               className={inputClass}
               value={method}
               onChange={(e) => onChange({ method: e.target.value })}
             >
-              {Object.entries(FEEDING_METHOD_LABELS).map(([k, l]) => (
+              {FEEDING_METHODS.map((k) => (
                 <option key={k} value={k}>
-                  {l}
+                  {labels.feedingMethod[k]}
                 </option>
               ))}
             </select>
@@ -131,7 +133,7 @@ export function EventTypeFields({
           {method === 'breast' ? (
             <div className="grid grid-cols-2 gap-3">
               <label className="block text-sm">
-                <span className="mb-1 block font-medium">Left (min)</span>
+                <span className="mb-1 block font-medium">{fields.leftMin}</span>
                 <input
                   type="number"
                   min="0"
@@ -142,7 +144,9 @@ export function EventTypeFields({
                 />
               </label>
               <label className="block text-sm">
-                <span className="mb-1 block font-medium">Right (min)</span>
+                <span className="mb-1 block font-medium">
+                  {fields.rightMin}
+                </span>
                 <input
                   type="number"
                   min="0"
@@ -155,7 +159,7 @@ export function EventTypeFields({
             </div>
           ) : (
             <label className="block text-sm">
-              <span className="mb-1 block font-medium">Amount (ml)</span>
+              <span className="mb-1 block font-medium">{fields.amountMl}</span>
               <input
                 type="number"
                 inputMode="numeric"
@@ -175,15 +179,15 @@ export function EventTypeFields({
     case 'diaper':
       return (
         <label className="block text-sm">
-          <span className="mb-1 block font-medium">Kind</span>
+          <span className="mb-1 block font-medium">{fields.kind}</span>
           <select
             className={inputClass}
             value={str('kind')}
             onChange={(e) => onChange({ kind: e.target.value })}
           >
-            {Object.entries(DIAPER_KIND_LABELS).map(([k, l]) => (
+            {DIAPER_KINDS.map((k) => (
               <option key={k} value={k}>
-                {l}
+                {labels.diaperKind[k]}
               </option>
             ))}
           </select>
@@ -197,7 +201,7 @@ export function EventTypeFields({
       return (
         <div className="grid gap-3 sm:grid-cols-3">
           <label className="block text-sm">
-            <span className="mb-1 block font-medium">Weight (kg)</span>
+            <span className="mb-1 block font-medium">{fields.weightKg}</span>
             <input
               type="number"
               step="0.01"
@@ -208,7 +212,7 @@ export function EventTypeFields({
             />
           </label>
           <label className="block text-sm">
-            <span className="mb-1 block font-medium">Height (cm)</span>
+            <span className="mb-1 block font-medium">{fields.heightCm}</span>
             <input
               type="number"
               step="0.1"
@@ -219,7 +223,7 @@ export function EventTypeFields({
             />
           </label>
           <label className="block text-sm">
-            <span className="mb-1 block font-medium">Head circ. (cm)</span>
+            <span className="mb-1 block font-medium">{fields.headCm}</span>
             <input
               type="number"
               step="0.1"
@@ -238,7 +242,9 @@ export function EventTypeFields({
       return (
         <div className="grid gap-3 sm:grid-cols-3">
           <label className="block text-sm sm:col-span-1">
-            <span className="mb-1 block font-medium">Name</span>
+            <span className="mb-1 block font-medium">
+              {fields.medicationName}
+            </span>
             <input
               className={inputClass}
               value={str('name')}
@@ -247,7 +253,7 @@ export function EventTypeFields({
             />
           </label>
           <label className="block text-sm">
-            <span className="mb-1 block font-medium">Dose amount</span>
+            <span className="mb-1 block font-medium">{fields.doseAmount}</span>
             <input
               type="number"
               step="0.01"
@@ -258,10 +264,10 @@ export function EventTypeFields({
             />
           </label>
           <label className="block text-sm">
-            <span className="mb-1 block font-medium">Dose unit</span>
+            <span className="mb-1 block font-medium">{fields.doseUnit}</span>
             <input
               className={inputClass}
-              placeholder="ml, mg…"
+              placeholder={fields.doseUnitPlaceholder}
               value={str('doseUnit')}
               onChange={(e) => onChange({ doseUnit: e.target.value })}
             />
@@ -272,7 +278,7 @@ export function EventTypeFields({
     case 'vaccination':
       return (
         <label className="block text-sm">
-          <span className="mb-1 block font-medium">Vaccine name</span>
+          <span className="mb-1 block font-medium">{fields.vaccineName}</span>
           <input
             className={inputClass}
             value={str('name')}
@@ -290,7 +296,7 @@ export function EventTypeFields({
             checked={values.milestone === true}
             onChange={(e) => onChange({ milestone: e.target.checked })}
           />
-          <span className="font-medium">Mark as a milestone</span>
+          <span className="font-medium">{fields.milestone}</span>
         </label>
       )
   }

--- a/src/components/baby/ExportPdfButton.tsx
+++ b/src/components/baby/ExportPdfButton.tsx
@@ -1,3 +1,5 @@
+import { useMessages } from '../../lib/i18n'
+
 interface ExportPdfButtonProps {
   onClick: () => void
 }
@@ -7,13 +9,15 @@ interface ExportPdfButtonProps {
  * nesting a full form inside this button's flex row squeezed it into a
  * shrink-to-fit width instead of the page width. */
 export function ExportPdfButton({ onClick }: ExportPdfButtonProps) {
+  const { export: exportText } = useMessages().baby.log
+
   return (
     <button
       type="button"
       onClick={onClick}
       className="inline-flex min-h-9 items-center gap-2 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 text-sm font-semibold"
     >
-      Export PDF
+      {exportText.button}
     </button>
   )
 }

--- a/src/components/baby/ExportPdfPanel.tsx
+++ b/src/components/baby/ExportPdfPanel.tsx
@@ -3,16 +3,14 @@ import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import type { BabyEventType } from '../../../convex/lib/babyEvents'
-import {
-  BABY_EVENT_LABELS,
-  BABY_EVENT_TYPES,
-} from '../../../convex/lib/babyEvents'
+import { BABY_EVENT_TYPES } from '../../../convex/lib/babyEvents'
 import {
   combineDateTime,
   toDateInputValue,
   toTimeInputValue,
 } from '../../lib/babyDate'
 import type { BabyPdfLayout } from '../../lib/babyPdfExport'
+import { useI18n } from '../../lib/i18n'
 import { SurfaceCard } from '../app/ShellPrimitives'
 
 const inputClass =
@@ -46,6 +44,8 @@ export function ExportPdfPanel({
   const [layout, setLayout] = useState<BabyPdfLayout>('category')
   const [exporting, setExporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const { locale, messages } = useI18n()
+  const { export: exportText } = messages.baby.log
 
   function toggleType(t: BabyEventType) {
     setTypes((prev) =>
@@ -68,6 +68,9 @@ export function ExportPdfPanel({
       })
       exportBabyLogPdf({
         baby: { name: babyName, birthDate: babyBirthDate },
+        messages: messages.baby.log,
+        eventTypes: messages.baby.eventTypes,
+        locale,
         events,
         from: fromMs,
         to: toMs,
@@ -76,7 +79,7 @@ export function ExportPdfPanel({
       })
       onClose()
     } catch {
-      setError('Could not generate the PDF')
+      setError(exportText.failed)
     } finally {
       setExporting(false)
     }
@@ -84,10 +87,12 @@ export function ExportPdfPanel({
 
   return (
     <SurfaceCard>
-      <h2 className="m-0 mb-3 text-sm font-semibold">Export PDF</h2>
+      <h2 className="m-0 mb-3 text-sm font-semibold">{exportText.title}</h2>
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="min-w-0">
-          <span className="mb-1 block text-sm font-medium">From</span>
+          <span className="mb-1 block text-sm font-medium">
+            {exportText.from}
+          </span>
           <div className="flex gap-2">
             <input
               type="date"
@@ -112,7 +117,9 @@ export function ExportPdfPanel({
           </div>
         </div>
         <div className="min-w-0">
-          <span className="mb-1 block text-sm font-medium">To</span>
+          <span className="mb-1 block text-sm font-medium">
+            {exportText.to}
+          </span>
           <div className="flex gap-2">
             <input
               type="date"
@@ -135,7 +142,9 @@ export function ExportPdfPanel({
       </div>
 
       <fieldset className="mt-3">
-        <legend className="mb-1 text-sm font-medium">Layout</legend>
+        <legend className="mb-1 text-sm font-medium">
+          {exportText.layout}
+        </legend>
         <div className="grid gap-1 sm:grid-cols-2">
           <label className="flex items-center gap-1.5 text-sm">
             <input
@@ -144,7 +153,7 @@ export function ExportPdfPanel({
               checked={layout === 'category'}
               onChange={() => setLayout('category')}
             />
-            By category
+            {exportText.byCategory}
           </label>
           <label className="flex items-center gap-1.5 text-sm">
             <input
@@ -153,13 +162,15 @@ export function ExportPdfPanel({
               checked={layout === 'chronological'}
               onChange={() => setLayout('chronological')}
             />
-            Chronological
+            {exportText.chronological}
           </label>
         </div>
       </fieldset>
 
       <fieldset className="mt-3">
-        <legend className="mb-1 text-sm font-medium">Include</legend>
+        <legend className="mb-1 text-sm font-medium">
+          {exportText.include}
+        </legend>
         <div className="grid grid-cols-2 gap-1 sm:grid-cols-4">
           {BABY_EVENT_TYPES.map((t) => (
             <label key={t} className="flex items-center gap-1.5 text-sm">
@@ -168,7 +179,7 @@ export function ExportPdfPanel({
                 checked={types.includes(t)}
                 onChange={() => toggleType(t)}
               />
-              {BABY_EVENT_LABELS[t]}
+              {messages.baby.eventTypes[t]}
             </label>
           ))}
         </div>
@@ -183,14 +194,14 @@ export function ExportPdfPanel({
           onClick={runExport}
           className="min-h-9 rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-3 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {exporting ? 'Generating…' : 'Download PDF'}
+          {exporting ? exportText.generating : exportText.download}
         </button>
         <button
           type="button"
           onClick={onClose}
           className="min-h-9 px-2 text-sm text-[var(--app-muted)]"
         >
-          Cancel
+          {messages.common.actions.cancel}
         </button>
       </div>
     </SurfaceCard>

--- a/src/components/baby/MultiEventForm.test.tsx
+++ b/src/components/baby/MultiEventForm.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { beforeEach, expect, test, vi } from 'vitest'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { MultiEventForm } from './MultiEventForm'
 
 const add = vi.fn()
@@ -18,7 +19,7 @@ beforeEach(() => {
 })
 
 function renderForm(onDone = vi.fn()) {
-  return render(
+  return renderWithI18n(
     <MultiEventForm
       babyId={babyId}
       groupSlug="jansen-household"

--- a/src/components/baby/MultiEventForm.tsx
+++ b/src/components/baby/MultiEventForm.tsx
@@ -3,10 +3,7 @@ import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import type { BabyEventType } from '../../../convex/lib/babyEvents'
-import {
-  BABY_EVENT_LABELS,
-  BABY_EVENT_TYPES,
-} from '../../../convex/lib/babyEvents'
+import { BABY_EVENT_TYPES } from '../../../convex/lib/babyEvents'
 import {
   combineDateTime,
   toDateInputValue,
@@ -20,6 +17,7 @@ import {
   rememberEventChoices,
 } from '../../lib/babyEventFormValues'
 import { errorMessage } from '../../lib/errorMessage'
+import { fmt, plural, useI18n } from '../../lib/i18n'
 import { readLastUsed, writeLastUsed } from '../../lib/lastUsed'
 import { EventIcon } from './EventIcon'
 import { EventTypeFields } from './EventTypeFields'
@@ -77,6 +75,9 @@ export function MultiEventForm({
   >({})
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+  const { locale, messages } = useI18n()
+  const { multi, validation } = messages.baby.log
+  const eventTypes = messages.baby.eventTypes
 
   function toggleType(type: BabyEventType) {
     setSelected((prev) =>
@@ -97,10 +98,11 @@ export function MultiEventForm({
 
     const inputs: { type: BabyEventType; values: EventValues }[] = []
     const errors: Partial<Record<BabyEventType, string>> = {}
+    // Keys in, sentences out: the validator does not know the language.
     for (const type of activeTypes) {
       const values = valuesByType[type] ?? initialEventValues(type)
       const built = buildEventInput(type, values, timestampMs)
-      if (built.error) errors[type] = built.error
+      if (built.error) errors[type] = validation[built.error]
       else inputs.push({ type, values })
     }
     setFieldErrors(errors)
@@ -129,10 +131,14 @@ export function MultiEventForm({
       // Keep only what still needs saving on screen, so a retry doesn't
       // duplicate the entries that already went through.
       setSelected((prev) => prev.filter((t) => !saved.includes(t)))
-      const detail = errorMessage(err, 'Could not save this entry')
+      const detail = errorMessage(err, messages.baby.log.entry.saveFailed)
       setError(
         saved.length > 0
-          ? `Saved ${saved.length} of ${inputs.length} entries — ${detail}`
+          ? fmt(multi.partial, {
+              saved: saved.length,
+              total: inputs.length,
+              detail,
+            })
           : detail,
       )
       setSubmitting(false)
@@ -141,10 +147,10 @@ export function MultiEventForm({
 
   return (
     <form onSubmit={submit} className="grid gap-3">
-      <h3 className="m-0 text-sm font-semibold">Log several entries</h3>
+      <h3 className="m-0 text-sm font-semibold">{multi.heading}</h3>
 
       <div className="min-w-0 sm:max-w-sm">
-        <span className="mb-1 block text-sm font-medium">When</span>
+        <span className="mb-1 block text-sm font-medium">{multi.when}</span>
         <div className="flex gap-2">
           <input
             type="date"
@@ -172,7 +178,7 @@ export function MultiEventForm({
       </div>
 
       <fieldset className="m-0 border-0 p-0">
-        <legend className="mb-1 text-sm font-medium">Include</legend>
+        <legend className="mb-1 text-sm font-medium">{multi.include}</legend>
         <div className="grid grid-cols-2 gap-1 sm:grid-cols-4">
           {BABY_EVENT_TYPES.map((type) => (
             <label key={type} className="flex items-center gap-1.5 text-sm">
@@ -181,7 +187,7 @@ export function MultiEventForm({
                 checked={selected.includes(type)}
                 onChange={() => toggleType(type)}
               />
-              {BABY_EVENT_LABELS[type]}
+              {eventTypes[type]}
             </label>
           ))}
         </div>
@@ -194,7 +200,7 @@ export function MultiEventForm({
         >
           <p className="m-0 flex items-center gap-2 text-sm font-semibold">
             <EventIcon type={type} />
-            {BABY_EVENT_LABELS[type]}
+            {eventTypes[type]}
           </p>
           <EventTypeFields
             type={type}
@@ -211,7 +217,9 @@ export function MultiEventForm({
             }
           />
           <label className="block text-sm">
-            <span className="mb-1 block font-medium">Notes</span>
+            <span className="mb-1 block font-medium">
+              {messages.baby.log.entry.notes}
+            </span>
             <input
               className={inputClass}
               value={notesByType[type] ?? ''}
@@ -227,9 +235,7 @@ export function MultiEventForm({
       ))}
 
       {activeTypes.length === 0 && (
-        <p className="m-0 text-sm text-[var(--app-muted)]">
-          Pick at least one thing to log.
-        </p>
+        <p className="m-0 text-sm text-[var(--app-muted)]">{multi.pickOne}</p>
       )}
 
       {error && <p className="m-0 text-sm text-red-800">{error}</p>}
@@ -241,17 +247,15 @@ export function MultiEventForm({
           className="min-h-9 rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-3 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
         >
           {submitting
-            ? 'Saving…'
-            : `Save ${activeTypes.length || ''} ${
-                activeTypes.length === 1 ? 'entry' : 'entries'
-              }`.trim()}
+            ? messages.common.actions.saving
+            : plural(locale, activeTypes.length, multi.save)}
         </button>
         <button
           type="button"
           onClick={onCancel}
           className="min-h-9 px-2 text-sm text-[var(--app-muted)]"
         >
-          Cancel
+          {messages.common.actions.cancel}
         </button>
       </div>
     </form>

--- a/src/components/baby/NewBabyPage.tsx
+++ b/src/components/baby/NewBabyPage.tsx
@@ -4,6 +4,7 @@ import { ConvexError } from 'convex/values'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { useMessages } from '../../lib/i18n'
 import { ImageUploadField } from '../app/ImageUploadField'
 import { BabyForm, type BabyFormValues } from './BabyForm'
 import type { BabyNav } from './babyNav'
@@ -28,10 +29,11 @@ export function NewBabyPage({ groupSlug, nav }: NewBabyPageProps) {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [photoId, setPhotoId] = useState<Id<'_storage'> | undefined>()
+  const { form } = useMessages().baby.log
 
   return (
     <div className="mx-auto max-w-2xl">
-      <h1 className="mb-6 text-2xl font-semibold">Add a child</h1>
+      <h1 className="mb-6 text-2xl font-semibold">{form.createTitle}</h1>
 
       {error && (
         <p className="mb-4 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800">
@@ -59,10 +61,10 @@ export function NewBabyPage({ groupSlug, nav }: NewBabyPageProps) {
               err instanceof ConvexError
                 ? typeof err.data === 'string'
                   ? err.data
-                  : 'Could not save that child'
+                  : form.saveFailed
                 : err instanceof Error
                   ? err.message
-                  : 'Could not save that child',
+                  : form.saveFailed,
             )
             setSubmitting(false)
           }

--- a/src/components/baby/QuickLogButtons.tsx
+++ b/src/components/baby/QuickLogButtons.tsx
@@ -2,10 +2,8 @@ import { Layers } from 'lucide-react'
 import { useState } from 'react'
 import type { Id } from '../../../convex/_generated/dataModel'
 import type { BabyEventType } from '../../../convex/lib/babyEvents'
-import {
-  BABY_EVENT_LABELS,
-  BABY_EVENT_TYPES,
-} from '../../../convex/lib/babyEvents'
+import { BABY_EVENT_TYPES } from '../../../convex/lib/babyEvents'
+import { useMessages } from '../../lib/i18n'
 import { SurfaceCard } from '../app/ShellPrimitives'
 import { EventForm } from './EventForm'
 import { EventIcon } from './EventIcon'
@@ -19,19 +17,21 @@ interface QuickLogButtonsProps {
 
 export function QuickLogButtons({ babyId, groupSlug }: QuickLogButtonsProps) {
   const [active, setActive] = useState<BabyEventType | 'multi' | null>(null)
+  const messages = useMessages()
+  const { quickLog } = messages.baby.log
 
   return (
     <SurfaceCard>
       {active === null && (
         <div className="mb-3 flex items-center justify-between gap-3">
-          <h2 className="m-0 text-sm font-semibold">Log an entry</h2>
+          <h2 className="m-0 text-sm font-semibold">{quickLog.heading}</h2>
           <button
             type="button"
             onClick={() => setActive('multi')}
             className="inline-flex min-h-9 items-center gap-1.5 rounded-[var(--app-radius)] border border-[var(--app-border)] px-2.5 text-sm font-semibold"
           >
             <Layers className="h-4 w-4" aria-hidden="true" />
-            Log several
+            {quickLog.several}
           </button>
         </div>
       )}
@@ -60,7 +60,7 @@ export function QuickLogButtons({ babyId, groupSlug }: QuickLogButtonsProps) {
               className="flex min-h-16 flex-col items-center justify-center gap-1 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] text-xs font-semibold"
             >
               <EventIcon type={type} className="h-5 w-5" />
-              {BABY_EVENT_LABELS[type]}
+              {messages.baby.eventTypes[type]}
             </button>
           ))}
         </div>

--- a/src/components/baby/Timeline.tsx
+++ b/src/components/baby/Timeline.tsx
@@ -3,13 +3,13 @@ import { ChevronRight, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Doc, Id } from '../../../convex/_generated/dataModel'
-import { BABY_EVENT_LABELS } from '../../../convex/lib/babyEvents'
 import {
   dayKey,
   formatEventDateHeading,
   formatEventTimestamp,
 } from '../../lib/babyDate'
 import { summarizeEvent } from '../../lib/babyEventSummary'
+import { fmt, useI18n, useMessages } from '../../lib/i18n'
 import { useConfirmAction } from '../app/ConfirmAction'
 import { SurfaceCard } from '../app/ShellPrimitives'
 import { EventForm } from './EventForm'
@@ -26,12 +26,16 @@ export function Timeline({ babyId, groupSlug, events }: TimelineProps) {
   const remove = useMutation(api.babyEvents.remove)
   const { confirm, dialog } = useConfirmAction()
   const [editingId, setEditingId] = useState<Id<'babyEvents'> | null>(null)
+  const messages = useMessages()
+  const log = messages.baby.log
+  const eventTypes = messages.baby.eventTypes
+  const { locale } = useI18n()
 
   if (events.length === 0) {
     return (
       <SurfaceCard>
         <p className="m-0 text-sm text-[var(--app-muted)]">
-          No entries yet — log the first one above.
+          {log.timeline.empty}
         </p>
       </SurfaceCard>
     )
@@ -50,7 +54,7 @@ export function Timeline({ babyId, groupSlug, events }: TimelineProps) {
       {Array.from(groups.entries()).map(([key, dayEvents]) => (
         <div key={key}>
           <p className="m-0 mb-2 text-xs font-semibold uppercase text-[var(--app-muted)]">
-            {formatEventDateHeading(dayEvents[0].timestamp)}
+            {formatEventDateHeading(dayEvents[0].timestamp, locale)}
           </p>
           <SurfaceCard>
             <ul className="m-0 list-none divide-y divide-[var(--app-border)] p-0">
@@ -79,13 +83,15 @@ export function Timeline({ babyId, groupSlug, events }: TimelineProps) {
                       <div className="min-w-0 flex-1">
                         <div className="flex flex-wrap items-baseline gap-2">
                           <span className="font-semibold">
-                            {BABY_EVENT_LABELS[event.type]}
+                            {eventTypes[event.type]}
                           </span>
                           <span className="text-xs text-[var(--app-muted)]">
-                            {formatEventTimestamp(event.timestamp)}
+                            {formatEventTimestamp(event.timestamp, locale)}
                           </span>
                         </div>
-                        <p className="m-0 mt-0.5">{summarizeEvent(event)}</p>
+                        <p className="m-0 mt-0.5">
+                          {summarizeEvent(event, log)}
+                        </p>
                         {event.notes && (
                           <p className="m-0 mt-0.5 text-[var(--app-muted)]">
                             {event.notes}
@@ -99,14 +105,16 @@ export function Timeline({ babyId, groupSlug, events }: TimelineProps) {
                     </button>
                     <button
                       type="button"
-                      aria-label={`Delete ${BABY_EVENT_LABELS[event.type]} entry`}
+                      aria-label={fmt(log.timeline.deleteEntry, {
+                        type: eventTypes[event.type],
+                      })}
                       className="grid min-h-9 min-w-9 shrink-0 place-items-center self-center rounded-[var(--app-radius)] text-red-800"
                       onClick={() =>
                         confirm({
-                          title: 'Delete this entry?',
-                          body: `${BABY_EVENT_LABELS[event.type]} — ${formatEventTimestamp(event.timestamp)}`,
-                          confirmLabel: 'Delete entry',
-                          errorFallback: 'Could not delete that entry.',
+                          title: log.timeline.deleteTitle,
+                          body: `${eventTypes[event.type]} — ${formatEventTimestamp(event.timestamp, locale)}`,
+                          confirmLabel: log.timeline.deleteConfirm,
+                          errorFallback: log.timeline.deleteFailed,
                           run: () => remove({ eventId: event._id, groupSlug }),
                         })
                       }

--- a/src/components/baby/TrendChart.tsx
+++ b/src/components/baby/TrendChart.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { fmt, useMessages } from '../../lib/i18n'
 
 interface TrendChartProps {
   points: { x: number; y: number }[]
@@ -9,6 +10,8 @@ interface TrendChartProps {
 /** Minimal hand-rolled SVG line chart — no charting dependency, just enough
  * for temperature/growth trend lines over time. */
 export function TrendChart({ points, unit, height = 160 }: TrendChartProps) {
+  const { child } = useMessages().baby.log
+
   const containerRef = useRef<HTMLDivElement>(null)
   // The viewBox width must track the *actual* rendered pixel width, not a
   // fixed desktop-sized number — an SVG's font-size/stroke-width are in
@@ -31,9 +34,7 @@ export function TrendChart({ points, unit, height = 160 }: TrendChartProps) {
 
   if (points.length < 2) {
     return (
-      <p className="m-0 text-sm text-[var(--app-muted)]">
-        Log at least two entries to see a trend line.
-      </p>
+      <p className="m-0 text-sm text-[var(--app-muted)]">{child.trendEmpty}</p>
     )
   }
 
@@ -68,7 +69,10 @@ export function TrendChart({ points, unit, height = 160 }: TrendChartProps) {
         viewBox={`0 0 ${width} ${height}`}
         className="w-full"
         role="img"
-        aria-label={`Trend chart, ${unit}, ${sorted.length} points`}
+        aria-label={fmt(child.trendChart, {
+          unit,
+          count: sorted.length,
+        })}
       >
         <line
           x1={padding.left}

--- a/src/components/foods/BarcodeScanner.test.tsx
+++ b/src/components/foods/BarcodeScanner.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { BarcodeScanner } from './BarcodeScanner'
 
 // jsdom does not implement navigator.mediaDevices at all (it's `undefined`,
@@ -21,7 +22,7 @@ afterEach(() => {
 
 test('manual entry keeps only digits and calls onDetected on Look up', () => {
   const onDetected = vi.fn()
-  render(<BarcodeScanner onDetected={onDetected} />)
+  renderWithI18n(<BarcodeScanner onDetected={onDetected} />)
 
   const input = screen.getByLabelText('Or enter the barcode number')
   fireEvent.change(input, { target: { value: '87a10-398b16000 5' } })
@@ -32,7 +33,7 @@ test('manual entry keeps only digits and calls onDetected on Look up', () => {
 })
 
 test('the Look up button is disabled until at least 8 digits are entered', () => {
-  render(<BarcodeScanner onDetected={vi.fn()} />)
+  renderWithI18n(<BarcodeScanner onDetected={vi.fn()} />)
   const lookUp = screen.getByRole('button', { name: /look up/i })
   const input = screen.getByLabelText('Or enter the barcode number')
 
@@ -47,7 +48,7 @@ test('shows a fallback message when camera access is denied', async () => {
   vi.spyOn(navigator.mediaDevices, 'getUserMedia').mockRejectedValue(
     new DOMException('Permission denied', 'NotAllowedError'),
   )
-  render(<BarcodeScanner onDetected={vi.fn()} />)
+  renderWithI18n(<BarcodeScanner onDetected={vi.fn()} />)
 
   fireEvent.click(screen.getByRole('button', { name: /scan barcode/i }))
   await waitFor(() =>

--- a/src/components/foods/BarcodeScanner.tsx
+++ b/src/components/foods/BarcodeScanner.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { readBarcodes } from 'zxing-wasm/reader'
+import { useMessages } from '../../lib/i18n'
 import { inputClass } from '../nutrition/nutrientInputs'
 
 interface Props {
@@ -20,8 +21,12 @@ export function BarcodeScanner({ onDetected }: Props) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [manualEntry, setManualEntry] = useState('')
-  const [cameraError, setCameraError] = useState<string | null>(null)
+  // A flag rather than the sentence: the sentence depends on the locale, and
+  // reading it inside the camera effect would tear the stream down and restart
+  // it every time somebody switched language mid-scan.
+  const [cameraDenied, setCameraDenied] = useState(false)
   const [scanning, setScanning] = useState(false)
+  const { scanner } = useMessages().foods
 
   // Read via a ref inside the scan loop below instead of depending on
   // `onDetected` directly — an inline arrow function passed by the caller
@@ -45,9 +50,7 @@ export function BarcodeScanner({ onDetected }: Props) {
           video: { facingMode: 'environment' },
         })
       } catch {
-        setCameraError(
-          'Camera access was denied or unavailable — enter the barcode number instead.',
-        )
+        setCameraDenied(true)
         setScanning(false)
         return
       }
@@ -123,14 +126,14 @@ export function BarcodeScanner({ onDetected }: Props) {
 
   return (
     <div className="grid gap-3">
-      {!cameraError && (
+      {!cameraDenied && (
         <div>
           <button
             type="button"
             onClick={() => setScanning((s) => !s)}
             className="rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 py-1.5 text-sm"
           >
-            {scanning ? 'Stop camera' : 'Scan barcode'}
+            {scanning ? scanner.stop : scanner.scan}
           </button>
           {scanning && (
             <div className="relative mt-2 max-w-sm">
@@ -145,18 +148,18 @@ export function BarcodeScanner({ onDetected }: Props) {
           )}
         </div>
       )}
-      {cameraError && <p className="text-sm text-red-800">{cameraError}</p>}
+      {cameraDenied && (
+        <p className="text-sm text-red-800">{scanner.cameraDenied}</p>
+      )}
       <label className="block max-w-xs text-sm">
-        <span className="mb-1 block font-medium">
-          Or enter the barcode number
-        </span>
+        <span className="mb-1 block font-medium">{scanner.manualLabel}</span>
         <div className="flex gap-2">
           <input
             inputMode="numeric"
             className={inputClass}
             value={manualEntry}
             onChange={(e) => setManualEntry(e.target.value.replace(/\D/g, ''))}
-            placeholder="8710398160005"
+            placeholder={scanner.manualPlaceholder}
           />
           <button
             type="button"
@@ -164,7 +167,7 @@ export function BarcodeScanner({ onDetected }: Props) {
             className="whitespace-nowrap rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-60"
             onClick={() => onDetected(manualEntry)}
           >
-            Look up
+            {scanner.lookUp}
           </button>
         </div>
       </label>

--- a/src/components/foods/EditFoodPage.tsx
+++ b/src/components/foods/EditFoodPage.tsx
@@ -4,6 +4,7 @@ import { ConvexError } from 'convex/values'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { useMessages } from '../../lib/i18n'
 import { FoodForm } from './FoodForm'
 import type { FoodNav } from './foodNav'
 
@@ -19,10 +20,15 @@ export function EditFoodPage({ foodId, nav }: EditFoodPageProps) {
   const navigate = useNavigate()
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const messages = useMessages()
+  const { detail, edit, form } = messages.foods
 
-  if (food === undefined) return <p className="text-sm opacity-60">Loading…</p>
+  if (food === undefined)
+    return (
+      <p className="text-sm opacity-60">{messages.common.errors.loading}</p>
+    )
   if (food === null)
-    return <p className="text-sm opacity-60">Food not found.</p>
+    return <p className="text-sm opacity-60">{detail.notFound}</p>
 
   // Reachable by typing the URL even though the detail page hides the link.
   // `foods.update` refuses too — this only avoids offering a form that is
@@ -32,14 +38,14 @@ export function EditFoodPage({ foodId, nav }: EditFoodPageProps) {
       <div className="mx-auto max-w-2xl">
         <h1 className="mb-4 text-2xl font-semibold">{food.name}</h1>
         <p className="text-sm opacity-60">
-          This is part of gather's built-in food catalog and can't be edited.{' '}
+          {edit.builtInBefore}{' '}
           {/* Through the Group in the address rather than the flat `/foods/new`
               this arrived as: that route is gone (ADR-0002), and linking to it
               would drop the reader out of the Group they were browsing. */}
           <Link {...nav.create()} className="underline">
-            Create your own food
+            {detail.createYourOwn}
           </Link>{' '}
-          if you need a different version.
+          {edit.builtInAfter}
         </p>
       </div>
     )
@@ -47,7 +53,7 @@ export function EditFoodPage({ foodId, nav }: EditFoodPageProps) {
 
   return (
     <div className="mx-auto max-w-2xl">
-      <h1 className="mb-6 text-2xl font-semibold">Edit food</h1>
+      <h1 className="mb-6 text-2xl font-semibold">{edit.title}</h1>
       {error && (
         <p className="mb-4 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800">
           {error}
@@ -76,10 +82,10 @@ export function EditFoodPage({ foodId, nav }: EditFoodPageProps) {
               err instanceof ConvexError
                 ? typeof err.data === 'string'
                   ? err.data
-                  : 'Could not save food'
+                  : form.saveFailed
                 : err instanceof Error
                   ? err.message
-                  : 'Could not save food',
+                  : form.saveFailed,
             )
             setSubmitting(false)
           }

--- a/src/components/foods/FoodDetailPage.tsx
+++ b/src/components/foods/FoodDetailPage.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router'
 import { useAction, useQuery } from 'convex/react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { fmt, useMessages } from '../../lib/i18n'
 import { useConfirmAction } from '../app/ConfirmAction'
 import { NutritionPanel } from '../recipes/NutritionPanel'
 import type { FoodNav } from './foodNav'
@@ -16,10 +17,15 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
   const food = useQuery(api.foods.get, { id: foodId as Id<'foods'> })
   const refreshFromOff = useAction(api.foodsLookup.refreshFromOff)
   const { confirm, dialog } = useConfirmAction()
+  const messages = useMessages()
+  const { detail } = messages.foods
 
-  if (food === undefined) return <p className="text-sm opacity-60">Loading…</p>
+  if (food === undefined)
+    return (
+      <p className="text-sm opacity-60">{messages.common.errors.loading}</p>
+    )
   if (food === null)
-    return <p className="text-sm opacity-60">Food not found.</p>
+    return <p className="text-sm opacity-60">{detail.notFound}</p>
 
   return (
     <article className="mx-auto max-w-2xl">
@@ -38,23 +44,22 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
             {...nav.edit(foodId)}
             className="rounded border px-3 py-1.5 text-sm no-underline"
           >
-            Edit
+            {messages.common.actions.edit}
           </Link>
         ) : (
           <span className="rounded border border-dashed px-3 py-1.5 text-sm opacity-60">
-            Built-in
+            {detail.builtIn}
           </span>
         )}
       </div>
 
       {food.seedKey !== undefined && (
         <p className="mb-4 text-sm opacity-60">
-          Part of gather's built-in food catalog, so it can't be edited. Need a
-          different version?{' '}
+          {detail.builtInNote}{' '}
           {/* Through the Group in the address; the flat `/foods/new` this
               arrived as is gone (ADR-0002). */}
           <Link {...nav.create()} className="underline">
-            Create your own food
+            {detail.createYourOwn}
           </Link>
           .
         </p>
@@ -69,7 +74,7 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
       */}
       <NutritionPanel
         nutrition={food.nutritionPer100}
-        unitLabel={`per 100 ${food.baseUnit}`}
+        unitLabel={fmt(detail.per100, { unit: food.baseUnit })}
         source={
           food.source === 'seed'
             ? // Neither "Imported" nor "Manual" is true of a Catalog entry,
@@ -82,20 +87,22 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
         }
       />
       {food.servingLabel && (
-        <p className="mb-4 text-sm opacity-60">Serving: {food.servingLabel}</p>
+        <p className="mb-4 text-sm opacity-60">
+          {fmt(detail.serving, { label: food.servingLabel })}
+        </p>
       )}
       {food.source === 'openfoodfacts' && (
         <p className="mb-4 text-xs opacity-60">
-          Nutrition data from{' '}
+          {detail.dataFrom}{' '}
           <a
             href="https://world.openfoodfacts.org"
             target="_blank"
             rel="noreferrer"
             className="underline"
           >
-            Open Food Facts
+            {detail.openFoodFacts}
           </a>{' '}
-          (ODbL).
+          {detail.odbl}
         </p>
       )}
       {food.barcode && (
@@ -104,15 +111,15 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
           className="rounded border px-3 py-1.5 text-sm"
           onClick={() =>
             confirm({
-              title: 'Refresh from Open Food Facts?',
-              body: 'This food is overwritten with the latest data there. Any local edits are replaced.',
-              confirmLabel: 'Refresh',
-              errorFallback: 'Could not refresh from Open Food Facts.',
+              title: detail.refreshTitle,
+              body: detail.refreshBody,
+              confirmLabel: detail.refreshConfirm,
+              errorFallback: detail.refreshFailed,
               run: () => refreshFromOff({ id: food._id }),
             })
           }
         >
-          Refresh from Open Food Facts
+          {detail.refresh}
         </button>
       )}
 

--- a/src/components/foods/FoodForm.test.tsx
+++ b/src/components/foods/FoodForm.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { FoodForm } from './FoodForm'
 
 test('submits name, brand, base unit, and per-100 nutrition', () => {
   const onSubmit = vi.fn()
-  render(<FoodForm onSubmit={onSubmit} submitting={false} />)
+  renderWithI18n(<FoodForm onSubmit={onSubmit} submitting={false} />)
 
   fireEvent.change(screen.getByLabelText('Name'), {
     target: { value: 'Hagelslag' },
@@ -30,7 +31,7 @@ test('submits name, brand, base unit, and per-100 nutrition', () => {
 
 test('defaults to grams and omits optional fields when left blank', () => {
   const onSubmit = vi.fn()
-  render(<FoodForm onSubmit={onSubmit} submitting={false} />)
+  renderWithI18n(<FoodForm onSubmit={onSubmit} submitting={false} />)
   fireEvent.change(screen.getByLabelText('Name'), {
     target: { value: 'Water' },
   })
@@ -50,7 +51,7 @@ test('defaults to grams and omits optional fields when left blank', () => {
 
 test('prefills from initial values, shows a read-only barcode and source note', () => {
   const onSubmit = vi.fn()
-  render(
+  renderWithI18n(
     <FoodForm
       onSubmit={onSubmit}
       submitting={false}

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { NutritionFacts } from '../../../convex/lib/nutrition'
+import { fmt, useMessages } from '../../lib/i18n'
 import { NutrientInputGrid } from '../nutrition/NutrientInputGrid'
 import {
   inputClass,
@@ -40,6 +41,8 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
     initial?.servingSize !== undefined ? String(initial.servingSize) : '',
   )
   const [servingLabel, setServingLabel] = useState(initial?.servingLabel ?? '')
+  const messages = useMessages()
+  const { form } = messages.foods
 
   return (
     <form
@@ -63,9 +66,11 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
           {sourceNote}
         </p>
       )}
-      {barcode && <p className="text-xs opacity-60">Barcode: {barcode}</p>}
+      {barcode && (
+        <p className="text-xs opacity-60">{fmt(form.barcode, { barcode })}</p>
+      )}
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Name</span>
+        <span className="mb-1 block font-medium">{form.name}</span>
         <input
           className={inputClass}
           value={name}
@@ -74,7 +79,7 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
         />
       </label>
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Brand</span>
+        <span className="mb-1 block font-medium">{form.brand}</span>
         <input
           className={inputClass}
           value={brand}
@@ -82,7 +87,7 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
         />
       </label>
       <fieldset className="rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">
-        <legend className="px-1 text-sm font-medium">Base unit</legend>
+        <legend className="px-1 text-sm font-medium">{form.baseUnit}</legend>
         <div className="flex gap-4 text-sm">
           <label className="flex items-center gap-1">
             <input
@@ -91,7 +96,7 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
               checked={baseUnit === 'g'}
               onChange={() => setBaseUnit('g')}
             />
-            grams
+            {form.grams}
           </label>
           <label className="flex items-center gap-1">
             <input
@@ -100,13 +105,13 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
               checked={baseUnit === 'ml'}
               onChange={() => setBaseUnit('ml')}
             />
-            milliliters
+            {form.milliliters}
           </label>
         </div>
       </fieldset>
       <fieldset className="rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">
         <legend className="px-1 text-sm font-medium">
-          Nutrition per 100 {baseUnit}
+          {fmt(form.nutritionLegend, { unit: baseUnit })}
         </legend>
         <NutrientInputGrid
           values={nutritionInputs}
@@ -117,7 +122,7 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
       </fieldset>
       <label className="block max-w-32 text-sm">
         <span className="mb-1 block font-medium">
-          Serving size ({baseUnit})
+          {fmt(form.servingSize, { unit: baseUnit })}
         </span>
         <input
           inputMode="decimal"
@@ -127,12 +132,12 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
         />
       </label>
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Serving label</span>
+        <span className="mb-1 block font-medium">{form.servingLabel}</span>
         <input
           className={inputClass}
           value={servingLabel}
           onChange={(e) => setServingLabel(e.target.value)}
-          placeholder='e.g. "1 slice (30 g)"'
+          placeholder={form.servingLabelPlaceholder}
         />
       </label>
       <button
@@ -140,7 +145,7 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
         disabled={submitting}
         className="w-fit rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-4 py-2 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
       >
-        {submitting ? 'Saving…' : 'Save food'}
+        {submitting ? messages.common.actions.saving : form.save}
       </button>
     </form>
   )

--- a/src/components/foods/FoodsPage.tsx
+++ b/src/components/foods/FoodsPage.tsx
@@ -2,6 +2,7 @@ import { Link, useNavigate } from '@tanstack/react-router'
 import { useQuery } from 'convex/react'
 import { useEffect, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
+import { fmt, useMessages } from '../../lib/i18n'
 import { BarcodeScanner } from './BarcodeScanner'
 import type { FoodNav } from './foodNav'
 
@@ -22,25 +23,26 @@ export function FoodsPage({ nav }: { nav: FoodNav }) {
   }, [term])
   const results = useQuery(api.foods.search, { term: debouncedTerm })
   const navigate = useNavigate()
+  const { list } = useMessages().foods
 
   return (
     <div className="mx-auto max-w-2xl">
-      <h1 className="mb-6 text-2xl font-semibold">Foods</h1>
+      <h1 className="mb-6 text-2xl font-semibold">{list.title}</h1>
 
       <div className="mb-6 rounded-xl border p-4">
-        <p className="mb-2 text-sm font-medium">Scan a barcode</p>
+        <p className="mb-2 text-sm font-medium">{list.scanHeading}</p>
         <BarcodeScanner
           onDetected={(barcode) => navigate(nav.create(barcode))}
         />
       </div>
 
       <label className="mb-4 block text-sm">
-        <span className="mb-1 block font-medium">Search foods</span>
+        <span className="mb-1 block font-medium">{list.search}</span>
         <input
           className="w-full rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 py-2 text-sm outline-none focus:border-[var(--app-accent)]"
           value={term}
           onChange={(e) => setTerm(e.target.value)}
-          placeholder="e.g. hagelslag"
+          placeholder={list.searchPlaceholder}
         />
       </label>
 
@@ -48,11 +50,11 @@ export function FoodsPage({ nav }: { nav: FoodNav }) {
         {...nav.create()}
         className="mb-4 inline-block rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 py-1.5 text-sm no-underline"
       >
-        Add manually
+        {list.addManually}
       </Link>
 
       {results === undefined && debouncedTerm.trim() && (
-        <p className="text-sm opacity-60">Searching…</p>
+        <p className="text-sm opacity-60">{list.searching}</p>
       )}
       <ul className="divide-y divide-[var(--app-border)]">
         {results?.map((food) => (
@@ -68,7 +70,7 @@ export function FoodsPage({ nav }: { nav: FoodNav }) {
       </ul>
       {results?.length === 0 && debouncedTerm.trim() && (
         <p className="text-sm opacity-60">
-          No foods found for "{debouncedTerm}".
+          {fmt(list.noResults, { term: debouncedTerm })}
         </p>
       )}
     </div>

--- a/src/components/foods/NewFoodPage.tsx
+++ b/src/components/foods/NewFoodPage.tsx
@@ -3,6 +3,7 @@ import { useAction, useConvex, useMutation } from 'convex/react'
 import { ConvexError } from 'convex/values'
 import { useEffect, useRef, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
+import { useMessages } from '../../lib/i18n'
 import { FoodForm, type FoodFormValues } from './FoodForm'
 import type { FoodNav } from './foodNav'
 
@@ -44,6 +45,7 @@ export function NewFoodPage({ barcode, nav }: NewFoodPageProps) {
   const lookupBarcode = useAction(api.foodsLookup.lookupBarcode)
   const create = useMutation(api.foods.create)
   const upsertFromOff = useMutation(api.foods.upsertFromOff)
+  const { create: createText, form } = useMessages().foods
 
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -87,16 +89,14 @@ export function NewFoodPage({ barcode, nav }: NewFoodPageProps) {
             },
             version: Date.now(),
           })
-          setSourceNote('From Open Food Facts — review before saving.')
+          setSourceNote(createText.fromOff)
         }
       } catch {
         // A failed OFF lookup (timeout, network error, thrown ConvexError)
         // leaves the form a blank manual entry prefilled with the barcode —
         // never blocks manual entry — but the user still gets a non-blocking
         // heads-up about why nothing was prefilled (spec §6).
-        setLookupNotice(
-          "Couldn't reach Open Food Facts — fill in the details yourself.",
-        )
+        setLookupNotice(createText.offUnreachable)
       } finally {
         setLooking(false)
       }
@@ -104,12 +104,12 @@ export function NewFoodPage({ barcode, nav }: NewFoodPageProps) {
   }, [])
 
   if (looking) {
-    return <p className="text-sm opacity-60">Looking up barcode…</p>
+    return <p className="text-sm opacity-60">{createText.lookingUp}</p>
   }
 
   return (
     <div className="mx-auto max-w-2xl">
-      <h1 className="mb-6 text-2xl font-semibold">Add food</h1>
+      <h1 className="mb-6 text-2xl font-semibold">{createText.title}</h1>
       {error && (
         <p className="mb-4 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800">
           {error}
@@ -141,10 +141,10 @@ export function NewFoodPage({ barcode, nav }: NewFoodPageProps) {
               err instanceof ConvexError
                 ? typeof err.data === 'string'
                   ? err.data
-                  : 'Could not save food'
+                  : form.saveFailed
                 : err instanceof Error
                   ? err.message
-                  : 'Could not save food',
+                  : form.saveFailed,
             )
             setSubmitting(false)
           }

--- a/src/components/home/GroupHome.test.tsx
+++ b/src/components/home/GroupHome.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, within } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { GroupActivityEntry } from '../../../convex/activity'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { GroupHome } from './GroupHome'
 
 /**
@@ -87,7 +88,7 @@ beforeEach(() => {
 
 describe('the very first visit, before anything has happened', () => {
   test('names the Group, says who is in it, and says what to do next', () => {
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     // The Group. Named as a heading, not buried in a sentence.
     expect(
@@ -112,7 +113,7 @@ describe('the very first visit, before anything has happened', () => {
   })
 
   test('the starters point into this Group and not at a bare module path', () => {
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     const recipes = screen.getByRole('link', { name: 'Recipes' })
     expect(recipes.getAttribute('href')).toBe('/g/jansen-household/recipes')
@@ -120,7 +121,7 @@ describe('the very first visit, before anything has happened', () => {
 
   test('a Personal group says it is private, and points at Groups to share', () => {
     members.value = [{ userId: 'u_alice', name: 'Alice', role: 'admin' }]
-    render(
+    renderWithI18n(
       <GroupHome
         groupSlug="me-alice"
         groupName="Alice's things"
@@ -141,7 +142,7 @@ describe('the very first visit, before anything has happened', () => {
   })
 
   test('a shared group says everyone here sees everything', () => {
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     const who = screen.getByRole('region', { name: 'Who is here' })
     expect(
@@ -152,7 +153,7 @@ describe('the very first visit, before anything has happened', () => {
 
   test('the Members are shown whether or not anything has happened', () => {
     activity.value = [entry()]
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     const who = screen.getByRole('region', { name: 'Who is here' })
     expect(within(who).getByText('Alice')).toBeDefined()
@@ -162,7 +163,7 @@ describe('the very first visit, before anything has happened', () => {
 
 describe('the stream', () => {
   test('asks for this Group and no other', () => {
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     expect(queryArgs.value).toContainEqual({
       name: 'activity:forGroup',
@@ -176,7 +177,7 @@ describe('the stream', () => {
 
   test('says who did what, and in which module', () => {
     activity.value = [entry()]
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     const card = screen.getByRole('region', { name: 'Recent activity' })
     expect(within(card).getByText('Bob')).toBeDefined()
@@ -189,7 +190,7 @@ describe('the stream', () => {
 
   test('links a recipe to its page inside this Group', () => {
     activity.value = [entry()]
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     expect(
       screen.getByRole('link', { name: 'Roast chicken' }).getAttribute('href'),
@@ -207,7 +208,7 @@ describe('the stream', () => {
         byName: 'Alice',
       }),
     ]
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     expect(
       screen.getByRole('link', { name: 'Feeding' }).getAttribute('href'),
@@ -226,7 +227,7 @@ describe('the stream', () => {
         targetId: null,
       }),
     ]
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     expect(
       screen.getByRole('link', { name: 'Buy nappies' }).getAttribute('href'),
@@ -236,7 +237,7 @@ describe('the stream', () => {
 
   test('an entry whose person has gone still says what happened', () => {
     activity.value = [entry({ byName: null })]
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     expect(screen.getByText('Someone')).toBeDefined()
     expect(screen.getByRole('link', { name: 'Roast chicken' })).toBeDefined()
@@ -247,7 +248,7 @@ describe('the stream', () => {
       entry({ id: 'r2', title: 'Newest' }),
       entry({ id: 'r1', title: 'Oldest' }),
     ]
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     const items = screen
       .getByRole('region', { name: 'Recent activity' })
@@ -259,7 +260,7 @@ describe('the stream', () => {
 
   test('says it is still loading rather than that nothing has happened', () => {
     activity.value = undefined
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     expect(screen.queryByText(/nothing has happened/i)).toBeNull()
   })
@@ -268,7 +269,7 @@ describe('the stream', () => {
 describe('nothing is stored per person, and nothing is editable', () => {
   test('there is no layout editor on the page', () => {
     activity.value = [entry()]
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     // A configurable Home would need at least one control to configure it
     // with. There is none: Home is one owned surface, the same for everybody
@@ -280,7 +281,7 @@ describe('nothing is stored per person, and nothing is editable', () => {
 
   test('nothing about the page is written back', () => {
     activity.value = [entry()]
-    render(<GroupHome {...HOUSEHOLD} />)
+    renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     // `useMutation` is not even imported — the mock would throw if it were
     // called, and this asserts the page only ever reads.
@@ -309,7 +310,7 @@ describe('what a phone has to survive', () => {
         role: 'admin',
       },
     ]
-    render(
+    renderWithI18n(
       <GroupHome
         groupSlug="jansen-household"
         groupName="Vandenbergenhuishoudenoverdewintermaanden"
@@ -344,7 +345,7 @@ describe('what a phone has to survive', () => {
 
   test('the page never lays anything out in a table', () => {
     activity.value = [entry(), entry({ id: 'r2', title: 'Second' })]
-    const { container } = render(<GroupHome {...HOUSEHOLD} />)
+    const { container } = renderWithI18n(<GroupHome {...HOUSEHOLD} />)
 
     // A table is the one layout that cannot be made to shrink below the sum of
     // its columns, which is how a page starts scrolling sideways on a phone.

--- a/src/components/home/GroupHome.tsx
+++ b/src/components/home/GroupHome.tsx
@@ -2,14 +2,15 @@ import { Link } from '@tanstack/react-router'
 import { useQuery } from 'convex/react'
 import { api } from '../../../convex/_generated/api'
 import type { GroupActivityEntry } from '../../../convex/activity'
+import { moduleText } from '../../lib/appNavigation'
 import {
-  ACTIVITY_PHRASES,
   activityModuleIcon,
   activityModuleLabel,
+  activityPhrase,
   formatActivityTime,
-  UNKNOWN_ACTOR,
 } from '../../lib/groupActivity'
 import { groupLink, moduleLink } from '../../lib/groupPaths'
+import { fmt, useI18n, useMessages } from '../../lib/i18n'
 import { MODULES } from '../../lib/modules'
 import { Icon } from '../app/Icon'
 import { Pill, SurfaceCard } from '../app/ShellPrimitives'
@@ -47,12 +48,17 @@ const STARTERS = MODULES.filter(
 
 function MemberList({ groupSlug, groupName, isPersonal }: GroupHomeProps) {
   const members = useQuery(api.groups.members, { slug: groupSlug })
+  const messages = useMessages()
+  const { home } = messages.shell
+  const note = isPersonal ? home.personalNote : home.sharedNote
 
   return (
-    <SurfaceCard ariaLabel="Who is here">
-      <h2 className="m-0 mb-2 text-sm font-semibold">Who is here</h2>
+    <SurfaceCard ariaLabel={home.whoIsHere}>
+      <h2 className="m-0 mb-2 text-sm font-semibold">{home.whoIsHere}</h2>
       {members === undefined ? (
-        <p className="m-0 text-sm text-[var(--app-muted)]">Loading…</p>
+        <p className="m-0 text-sm text-[var(--app-muted)]">
+          {messages.common.errors.loading}
+        </p>
       ) : (
         <ul className="m-0 flex list-none flex-wrap gap-2 p-0">
           {members.map((member) => (
@@ -66,25 +72,19 @@ function MemberList({ groupSlug, groupName, isPersonal }: GroupHomeProps) {
               {/* The pill never wraps, so it has to be the part that keeps its
                   width while the name beside it gives way. */}
               {member.role === 'admin' ? (
-                <Pill className="shrink-0">Admin</Pill>
+                <Pill className="shrink-0">{home.admin}</Pill>
               ) : null}
             </li>
           ))}
         </ul>
       )}
+      {/* Split around the link rather than assembled from one string: neither
+          half carries markup, so a translation is free to word the sentence
+          its own way without having to reproduce a `<Link>`. */}
       <p className="mt-3 mb-0 text-sm leading-6 text-[var(--app-muted)]">
-        {isPersonal ? (
-          <>
-            {groupName} is yours alone — nothing kept here is visible to anybody
-            else. To share something with other people, start a group with them
-            in <Link to="/groups">Groups</Link>.
-          </>
-        ) : (
-          <>
-            Everyone here sees everything in {groupName}. To invite somebody
-            else, or to leave, go to <Link to="/groups">Groups</Link>.
-          </>
-        )}
+        {fmt(note.before, { group: groupName })}{' '}
+        <Link to="/groups">{note.link}</Link>
+        {note.after}
       </p>
     </SurfaceCard>
   )
@@ -141,7 +141,8 @@ function ActivityRow({
   entry: GroupActivityEntry
   groupSlug: string
 }) {
-  const phrase = ACTIVITY_PHRASES[entry.kind]
+  const { locale, messages } = useI18n()
+  const phrase = activityPhrase(entry.kind, messages)
 
   return (
     <li className="grid grid-cols-[28px_minmax(0,1fr)] gap-2 border-t border-[var(--app-border)] py-2 first:border-t-0 first:pt-0">
@@ -155,16 +156,18 @@ function ActivityRow({
             needed — the track has to be allowed to shrink, and the word has to
             be willing to break. */}
         <p className="m-0 text-sm leading-6 wrap-anywhere">
-          <span className="font-semibold">{entry.byName ?? UNKNOWN_ACTOR}</span>{' '}
+          <span className="font-semibold">
+            {entry.byName ?? messages.shell.activity.unknownActor}
+          </span>{' '}
           {phrase.verb} <EntryTitle entry={entry} groupSlug={groupSlug} />
           {entry.context && phrase.connector
             ? ` ${phrase.connector} ${entry.context}`
             : null}
         </p>
         <p className="m-0 flex flex-wrap gap-x-2 text-xs text-[var(--app-muted)]">
-          <span>{activityModuleLabel(entry.kind)}</span>
+          <span>{activityModuleLabel(entry.kind, messages)}</span>
           <time dateTime={new Date(entry.at).toISOString()}>
-            {formatActivityTime(entry.at)}
+            {formatActivityTime(entry.at, messages, locale)}
           </time>
         </p>
       </div>
@@ -180,13 +183,14 @@ function ActivityRow({
  * making even for a household that has just been created.
  */
 function NothingYet({ groupSlug, groupName, isPersonal }: GroupHomeProps) {
+  const messages = useMessages()
+  const { home } = messages.shell
+
   return (
     <div className="grid gap-3">
       <p className="m-0 text-sm leading-6 text-[var(--app-muted)]">
-        Nothing has happened in {groupName} yet.{' '}
-        {isPersonal
-          ? 'Whatever you add here appears in this list, and only you will ever see it.'
-          : 'Whatever anybody here adds appears in this list, with their name on it.'}
+        {fmt(home.nothingYet, { group: groupName })}{' '}
+        {isPersonal ? home.nothingYetPersonal : home.nothingYetShared}
       </p>
       <div className="flex flex-wrap gap-2">
         {STARTERS.map((module) => (
@@ -196,7 +200,9 @@ function NothingYet({ groupSlug, groupName, isPersonal }: GroupHomeProps) {
             className="inline-flex min-h-9 max-w-full items-center gap-2 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 text-sm font-semibold text-[var(--app-fg)] no-underline"
           >
             <Icon name={module.icon} className="h-4 w-4" />
-            <span className="truncate">{module.label}</span>
+            <span className="truncate">
+              {moduleText(module, messages).label}
+            </span>
           </Link>
         ))}
       </div>
@@ -210,6 +216,8 @@ export function GroupHome({
   isPersonal,
 }: GroupHomeProps) {
   const activity = useQuery(api.activity.forGroup, { groupSlug })
+  const messages = useMessages()
+  const { home } = messages.shell
 
   return (
     // `grid-cols-[minmax(0,1fr)]` rather than a bare `grid`: an implicit track
@@ -228,9 +236,7 @@ export function GroupHome({
           {groupName}
         </h1>
         <p className="mt-1 mb-0 text-sm leading-6 text-[var(--app-muted)]">
-          {isPersonal
-            ? 'Your own group. Anything kept here is private to you.'
-            : 'What everyone in this group has been up to.'}
+          {isPersonal ? home.personalSubtitle : home.sharedSubtitle}
         </p>
       </header>
 
@@ -240,10 +246,14 @@ export function GroupHome({
         isPersonal={isPersonal}
       />
 
-      <SurfaceCard ariaLabel="Recent activity">
-        <h2 className="m-0 mb-2 text-sm font-semibold">Recent activity</h2>
+      <SurfaceCard ariaLabel={home.recentActivity}>
+        <h2 className="m-0 mb-2 text-sm font-semibold">
+          {home.recentActivity}
+        </h2>
         {activity === undefined ? (
-          <p className="m-0 text-sm text-[var(--app-muted)]">Loading…</p>
+          <p className="m-0 text-sm text-[var(--app-muted)]">
+            {messages.common.errors.loading}
+          </p>
         ) : activity.length === 0 ? (
           <NothingYet
             groupSlug={groupSlug}

--- a/src/components/nutrition/AddEntryModal.tsx
+++ b/src/components/nutrition/AddEntryModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { MealName } from '../../../convex/lib/consumption'
-import { MEAL_LABELS } from '../../../convex/lib/consumption'
+import { fmt, useMessages } from '../../lib/i18n'
 import { FoodAddTab } from './FoodAddTab'
 import type { NutritionNav } from './nutritionNav'
 import { QuickAddTab } from './QuickAddTab'
@@ -8,11 +8,8 @@ import { RecipeAddTab } from './RecipeAddTab'
 
 type Tab = 'recipes' | 'foods' | 'quick'
 
-const TABS: Array<[Tab, string]> = [
-  ['recipes', 'Recipes'],
-  ['foods', 'Foods'],
-  ['quick', 'Quick add'],
-]
+/** Which tabs there are and in what order — the words are in the message tree. */
+const TABS = ['recipes', 'foods', 'quick'] as const satisfies readonly Tab[]
 
 interface Props {
   date: string
@@ -23,6 +20,8 @@ interface Props {
 
 export function AddEntryModal({ date, meal, nav, onClose }: Props) {
   const [tab, setTab] = useState<Tab>('recipes')
+  const { diary, meals } = useMessages().nutrition
+  const { add } = diary
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -42,7 +41,9 @@ export function AddEntryModal({ date, meal, nav, onClose }: Props) {
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-semibold">Add to {MEAL_LABELS[meal]}</h2>
+          <h2 className="text-sm font-semibold">
+            {fmt(add.title, { meal: meals[meal] })}
+          </h2>
           <button
             type="button"
             onClick={onClose}
@@ -52,7 +53,7 @@ export function AddEntryModal({ date, meal, nav, onClose }: Props) {
           </button>
         </div>
         <div className="mb-3 flex gap-2 border-b border-[var(--app-border)]">
-          {TABS.map(([id, label]) => (
+          {TABS.map((id) => (
             <button
               key={id}
               type="button"
@@ -63,7 +64,7 @@ export function AddEntryModal({ date, meal, nav, onClose }: Props) {
                   : 'border-transparent opacity-60'
               }`}
             >
-              {label}
+              {add.tabs[id]}
             </button>
           ))}
         </div>

--- a/src/components/nutrition/ConsumptionEntryRow.test.tsx
+++ b/src/components/nutrition/ConsumptionEntryRow.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { ConsumptionEntryRow } from './ConsumptionEntryRow'
 import { groupNutritionNav } from './nutritionNav'
 
@@ -46,7 +47,7 @@ const entry = {
 }
 
 test('renders label, quantity, unit, and calories', () => {
-  render(
+  renderWithI18n(
     <ConsumptionEntryRow
       nav={nav}
       entry={entry}
@@ -61,7 +62,7 @@ test('renders label, quantity, unit, and calories', () => {
 
 test('clicking Delete calls onDelete', () => {
   const onDelete = vi.fn()
-  render(
+  renderWithI18n(
     <ConsumptionEntryRow
       nav={nav}
       entry={entry}
@@ -74,7 +75,7 @@ test('clicking Delete calls onDelete', () => {
 })
 
 test('shows no source link for a quick-add entry (no recipeId or foodId)', () => {
-  render(
+  renderWithI18n(
     <ConsumptionEntryRow
       nav={nav}
       entry={entry}
@@ -87,7 +88,7 @@ test('shows no source link for a quick-add entry (no recipeId or foodId)', () =>
 })
 
 test('shows a View recipe link when recipeId is set', () => {
-  render(
+  renderWithI18n(
     <ConsumptionEntryRow
       nav={nav}
       entry={{ ...entry, recipeId: 'recipe1' }}
@@ -103,7 +104,7 @@ test('shows a View recipe link when recipeId is set', () => {
 })
 
 test('shows a View food link when foodId is set', () => {
-  render(
+  renderWithI18n(
     <ConsumptionEntryRow
       nav={nav}
       entry={{ ...entry, foodId: 'food1' }}
@@ -120,7 +121,7 @@ test('shows a View food link when foodId is set', () => {
 
 test('editing quantity and saving calls onUpdate with the new quantity, current meal and date', async () => {
   const onUpdate = vi.fn().mockResolvedValue(undefined)
-  render(
+  renderWithI18n(
     <ConsumptionEntryRow
       nav={nav}
       entry={entry}
@@ -142,7 +143,7 @@ test('editing quantity and saving calls onUpdate with the new quantity, current 
 
 test('a failed save keeps the row in edit mode and shows an error', async () => {
   const onUpdate = vi.fn().mockRejectedValue(new Error('Network error'))
-  render(
+  renderWithI18n(
     <ConsumptionEntryRow
       nav={nav}
       entry={entry}
@@ -158,7 +159,7 @@ test('a failed save keeps the row in edit mode and shows an error', async () => 
 
 test('an invalid quantity does not call onUpdate', () => {
   const onUpdate = vi.fn()
-  render(
+  renderWithI18n(
     <ConsumptionEntryRow
       nav={nav}
       entry={entry}

--- a/src/components/nutrition/ConsumptionEntryRow.tsx
+++ b/src/components/nutrition/ConsumptionEntryRow.tsx
@@ -1,8 +1,9 @@
 import { Link } from '@tanstack/react-router'
 import { useState } from 'react'
 import type { MealName } from '../../../convex/lib/consumption'
-import { MEAL_LABELS, MEAL_NAMES } from '../../../convex/lib/consumption'
+import { MEAL_NAMES } from '../../../convex/lib/consumption'
 import type { NutritionFacts } from '../../../convex/lib/nutrition'
+import { useMessages } from '../../lib/i18n'
 import type { NutritionNav } from './nutritionNav'
 
 export interface ConsumptionEntryData {
@@ -35,6 +36,8 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
   const [date, setDate] = useState(entry.date)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const messages = useMessages()
+  const { diary, meals, units } = messages.nutrition
 
   return (
     <li className="py-2 text-sm">
@@ -42,7 +45,7 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
         <div>
           <span className="font-medium">{entry.label}</span>
           <span className="ml-2 opacity-60">
-            {entry.quantity} {entry.quantityUnit}
+            {entry.quantity} {units[entry.quantityUnit]}
             {entry.nutrition.calories !== undefined &&
               ` · ${entry.nutrition.calories} kcal`}
           </span>
@@ -51,7 +54,7 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
               {...nav.recipe(entry.recipeId)}
               className="ml-2 text-xs underline"
             >
-              View recipe
+              {diary.entry.viewRecipe}
             </Link>
           )}
           {entry.foodId && (
@@ -59,7 +62,7 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
               {...nav.food(entry.foodId)}
               className="ml-2 text-xs underline"
             >
-              View food
+              {diary.entry.viewFood}
             </Link>
           )}
         </div>
@@ -69,21 +72,23 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
             onClick={() => setEditing((e) => !e)}
             className="text-xs underline"
           >
-            {editing ? 'Close' : 'Edit'}
+            {editing
+              ? messages.common.actions.close
+              : messages.common.actions.edit}
           </button>
           <button
             type="button"
             onClick={onDelete}
             className="text-xs text-red-700"
           >
-            Delete
+            {messages.common.actions.delete}
           </button>
         </div>
       </div>
       {editing && (
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <label className="text-xs">
-            Qty
+            {diary.entry.quantity}
             <input
               inputMode="decimal"
               value={quantityInput}
@@ -93,7 +98,7 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
             />
           </label>
           <label className="text-xs">
-            Meal
+            {diary.entry.meal}
             <select
               value={meal}
               onChange={(e) => setMeal(e.target.value as MealName)}
@@ -102,13 +107,13 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
             >
               {MEAL_NAMES.map((m) => (
                 <option key={m} value={m}>
-                  {MEAL_LABELS[m]}
+                  {meals[m]}
                 </option>
               ))}
             </select>
           </label>
           <label className="text-xs">
-            Date
+            {diary.entry.date}
             <input
               type="date"
               value={date}
@@ -130,7 +135,7 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
                 setEditing(false)
               } catch (err) {
                 setError(
-                  err instanceof Error ? err.message : 'Could not save changes',
+                  err instanceof Error ? err.message : diary.entry.saveFailed,
                 )
               } finally {
                 setSaving(false)
@@ -138,7 +143,9 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
             }}
             className="rounded border border-[var(--app-fg)] bg-[var(--app-fg)] px-2 py-0.5 text-xs font-semibold text-[var(--app-surface)] disabled:opacity-60"
           >
-            {saving ? 'Saving…' : 'Save'}
+            {saving
+              ? messages.common.actions.saving
+              : messages.common.actions.save}
           </button>
           {error && (
             <p className="w-full rounded-md border border-red-300 bg-red-50 px-2 py-1 text-xs text-red-800">

--- a/src/components/nutrition/DayTotals.test.tsx
+++ b/src/components/nutrition/DayTotals.test.tsx
@@ -1,26 +1,31 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { expect, test } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { DayTotals } from './DayTotals'
 
 test('renders a total with a target as "value / target"', () => {
-  render(<DayTotals totals={{ calories: 1500 }} targets={{ calories: 2000 }} />)
+  renderWithI18n(
+    <DayTotals totals={{ calories: 1500 }} targets={{ calories: 2000 }} />,
+  )
   expect(screen.getByText('Calories (kcal)')).toBeDefined()
   expect(screen.getByText('1500 / 2000')).toBeDefined()
 })
 
 test('renders a total without a target as a plain value', () => {
-  render(<DayTotals totals={{ protein: 50 }} />)
+  renderWithI18n(<DayTotals totals={{ protein: 50 }} />)
   expect(screen.getByText('Protein (g)')).toBeDefined()
   expect(screen.getByText('50')).toBeDefined()
 })
 
 test('renders nothing when totals and targets are both empty', () => {
-  const { container } = render(<DayTotals totals={{}} />)
+  const { container } = renderWithI18n(<DayTotals totals={{}} />)
   expect(container.innerHTML).toBe('')
 })
 
 test('renders a custom heading when provided', () => {
-  render(<DayTotals totals={{ calories: 100 }} heading="Totals — 2026-07-17" />)
+  renderWithI18n(
+    <DayTotals totals={{ calories: 100 }} heading="Totals — 2026-07-17" />,
+  )
   expect(screen.getByText('Totals — 2026-07-17')).toBeDefined()
   expect(screen.queryByText("Today's totals")).toBeNull()
 })

--- a/src/components/nutrition/DayTotals.tsx
+++ b/src/components/nutrition/DayTotals.tsx
@@ -1,27 +1,28 @@
 import {
   NUTRIENT_KEYS,
-  NUTRIENT_LABELS,
   type NutritionFacts,
 } from '../../../convex/lib/nutrition'
+import { useMessages } from '../../lib/i18n'
 
 interface Props {
   totals: NutritionFacts
   targets?: NutritionFacts
+  /** Defaults to the "today" wording; callers pass a dated one for other days. */
   heading?: string
 }
 
-export function DayTotals({
-  totals,
-  targets,
-  heading = "Today's totals",
-}: Props) {
+export function DayTotals({ totals, targets, heading }: Props) {
+  const messages = useMessages()
+  const labels = messages.nutrients.labels
   const present = NUTRIENT_KEYS.filter(
     (key) => totals[key] !== undefined || targets?.[key] !== undefined,
   )
   if (present.length === 0) return null
   return (
     <section className="mb-6 rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">
-      <h2 className="mb-2 font-medium">{heading}</h2>
+      <h2 className="mb-2 font-medium">
+        {heading ?? messages.nutrition.diary.totalsToday}
+      </h2>
       <dl className="grid gap-2">
         {present.map((key) => {
           const value = totals[key] ?? 0
@@ -33,7 +34,7 @@ export function DayTotals({
           return (
             <div key={key}>
               <div className="flex justify-between text-sm">
-                <dt className="opacity-60">{NUTRIENT_LABELS[key]}</dt>
+                <dt className="opacity-60">{labels[key]}</dt>
                 <dd className="font-medium">
                   {target !== undefined ? `${value} / ${target}` : value}
                 </dd>

--- a/src/components/nutrition/FoodAddTab.tsx
+++ b/src/components/nutrition/FoodAddTab.tsx
@@ -12,6 +12,7 @@ import type {
   OffMappedFood,
   OffSearchResult,
 } from '../../../convex/lib/offMapping'
+import { fmt, useMessages } from '../../lib/i18n'
 import { BarcodeScanner } from '../foods/BarcodeScanner'
 import type { NutritionNav } from './nutritionNav'
 
@@ -56,7 +57,11 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
   const [lookupError, setLookupError] = useState<string | null>(null)
   const [offResults, setOffResults] = useState<OffSearchResult[] | null>(null)
   const [offSearching, setOffSearching] = useState(false)
-  const [offSearchError, setOffSearchError] = useState<string | null>(null)
+  // Keys, not sentences — see BarcodeScanner: a message read inside the search
+  // effect would make the effect depend on the locale.
+  const [offSearchError, setOffSearchError] = useState<
+    'searchFailed' | 'addFailed' | null
+  >(null)
   const offSearchedTermRef = useRef<string | null>(null)
   // Cache each term's OFF results for the component's lifetime (retyping the
   // same term costs nothing) and never fire two OFF calls closer together
@@ -75,6 +80,8 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
   const searchByName = useAction(api.foodsLookup.searchByName)
   const upsertFromOff = useMutation(api.foods.upsertFromOff)
   const createEntry = useMutation(api.consumption.create)
+  const messages = useMessages()
+  const { foodAdd } = messages.nutrition.diary
 
   // A name-search hit's barcode may already have a local row that the name
   // search itself didn't surface (searched by brand, an alternate-language
@@ -123,7 +130,7 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
       }
       await saveOffMatch(mapped, barcode)
     } catch {
-      setLookupError("Couldn't look up that barcode — try again.")
+      setLookupError(foodAdd.barcodeFailed)
     } finally {
       setResolving(false)
     }
@@ -134,7 +141,7 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
     try {
       await saveOffMatch(result, result.barcode)
     } catch {
-      setOffSearchError("Couldn't add that item — try again.")
+      setOffSearchError('addFailed')
     }
   }
 
@@ -176,7 +183,7 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
         })
         .catch(() => {
           if (offSearchedTermRef.current !== term) return
-          setOffSearchError("Couldn't search Open Food Facts.")
+          setOffSearchError('searchFailed')
         })
         .finally(() => {
           if (offSearchedTermRef.current !== term) return
@@ -217,8 +224,10 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
             <option value={selected.baseUnit}>{selected.baseUnit}</option>
             {selected.servingSize !== undefined && (
               <option value="piece">
-                piece ({selected.servingSize}
-                {selected.baseUnit})
+                {fmt(foodAdd.pieceOf, {
+                  size: selected.servingSize,
+                  unit: selected.baseUnit,
+                })}
               </option>
             )}
           </select>
@@ -234,7 +243,7 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
             onClick={() => setSelected(null)}
             className="rounded border px-2 py-1 text-xs"
           >
-            Back
+            {messages.common.actions.back}
           </button>
           <button
             type="button"
@@ -261,9 +270,7 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
                 onAdded()
               } catch (err) {
                 setSubmitError(
-                  err instanceof Error
-                    ? err.message
-                    : 'Could not log this food',
+                  err instanceof Error ? err.message : foodAdd.logFailed,
                 )
               } finally {
                 setSubmitting(false)
@@ -271,7 +278,7 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
             }}
             className="rounded border border-[var(--app-fg)] bg-[var(--app-fg)] px-3 py-1 text-xs font-semibold text-[var(--app-surface)] disabled:opacity-60"
           >
-            Add
+            {messages.common.actions.add}
           </button>
         </div>
       </div>
@@ -281,22 +288,22 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
   return (
     <div className="grid gap-3">
       <BarcodeScanner onDetected={handleDetected} />
-      {resolving && <p className="text-xs opacity-60">Looking up…</p>}
+      {resolving && <p className="text-xs opacity-60">{foodAdd.lookingUp}</p>}
       {lookupError && <p className="text-xs text-red-700">{lookupError}</p>}
       {notFoundBarcode && (
         <p className="text-xs opacity-60">
-          Not found.{' '}
+          {foodAdd.notFound}{' '}
           <Link {...nav.createFood(notFoundBarcode)} className="underline">
-            Add it to the foods library
+            {foodAdd.addToLibrary}
           </Link>{' '}
-          first.
+          {foodAdd.addToLibraryAfter}
         </p>
       )}
       <input
         className="w-full rounded border border-[var(--app-border)] px-2 py-1 text-sm"
         value={term}
         onChange={(e) => setTerm(e.target.value)}
-        placeholder="Search foods…"
+        placeholder={foodAdd.searchPlaceholder}
       />
       <ul className="max-h-48 divide-y divide-[var(--app-border)] overflow-y-auto">
         {results?.map((food) => (
@@ -318,14 +325,14 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
         ))}
       </ul>
       {offSearching && (
-        <p className="text-xs opacity-60">Searching Open Food Facts…</p>
+        <p className="text-xs opacity-60">{foodAdd.searching}</p>
       )}
       {offSearchError && (
-        <p className="text-xs text-red-700">{offSearchError}</p>
+        <p className="text-xs text-red-700">{foodAdd[offSearchError]}</p>
       )}
       {offResults && offResults.length > 0 && (
         <div className="grid gap-1">
-          <p className="text-xs font-medium opacity-60">From Open Food Facts</p>
+          <p className="text-xs font-medium opacity-60">{foodAdd.fromOff}</p>
           <ul className="max-h-48 divide-y divide-[var(--app-border)] overflow-y-auto">
             {offResults.map((result) => (
               <li key={result.barcode}>
@@ -342,7 +349,9 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
                   </span>
                   {result.nutritionPer100.calories !== undefined && (
                     <span className="shrink-0 text-xs opacity-60">
-                      {Math.round(result.nutritionPer100.calories)} kcal/100g
+                      {fmt(foodAdd.perHundred, {
+                        calories: Math.round(result.nutritionPer100.calories),
+                      })}
                     </span>
                   )}
                 </button>
@@ -350,16 +359,16 @@ export function FoodAddTab({ date, meal, nav, onAdded }: Props) {
             ))}
           </ul>
           <p className="text-xs opacity-60">
-            Data from{' '}
+            {messages.foods.detail.dataFrom}{' '}
             <a
               href="https://world.openfoodfacts.org"
               target="_blank"
               rel="noreferrer"
               className="underline"
             >
-              Open Food Facts
+              {messages.foods.detail.openFoodFacts}
             </a>{' '}
-            (ODbL).
+            {messages.foods.detail.odbl}
           </p>
         </div>
       )}

--- a/src/components/nutrition/MealSlot.test.tsx
+++ b/src/components/nutrition/MealSlot.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { MealSlot } from './MealSlot'
 import { groupNutritionNav } from './nutritionNav'
 
@@ -18,7 +19,7 @@ const entries = [
 ]
 
 test('shows a placeholder when there are no entries', () => {
-  render(
+  renderWithI18n(
     <MealSlot
       nav={nav}
       label="Breakfast"
@@ -33,7 +34,7 @@ test('shows a placeholder when there are no entries', () => {
 
 test('renders entries and clicking + Add calls onAdd', () => {
   const onAdd = vi.fn()
-  render(
+  renderWithI18n(
     <MealSlot
       nav={nav}
       label="Breakfast"
@@ -50,7 +51,7 @@ test('renders entries and clicking + Add calls onAdd', () => {
 
 test('deleting an entry calls onDeleteEntry with its id', () => {
   const onDeleteEntry = vi.fn()
-  render(
+  renderWithI18n(
     <MealSlot
       nav={nav}
       label="Breakfast"

--- a/src/components/nutrition/MealSlot.tsx
+++ b/src/components/nutrition/MealSlot.tsx
@@ -1,4 +1,5 @@
 import type { MealName } from '../../../convex/lib/consumption'
+import { useMessages } from '../../lib/i18n'
 import type { ConsumptionEntryData } from './ConsumptionEntryRow'
 import { ConsumptionEntryRow } from './ConsumptionEntryRow'
 import type { NutritionNav } from './nutritionNav'
@@ -23,16 +24,18 @@ export function MealSlot({
   onUpdateEntry,
   onDeleteEntry,
 }: Props) {
+  const { slot } = useMessages().nutrition.diary
+
   return (
     <section className="mb-4 rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">
       <div className="mb-2 flex items-center justify-between">
         <h2 className="font-medium">{label}</h2>
         <button type="button" onClick={onAdd} className="text-sm underline">
-          + Add
+          {slot.add}
         </button>
       </div>
       {entries.length === 0 ? (
-        <p className="text-sm opacity-60">Nothing logged yet.</p>
+        <p className="text-sm opacity-60">{slot.empty}</p>
       ) : (
         <ul className="divide-y divide-[var(--app-border)]">
           {entries.map((entry) => (

--- a/src/components/nutrition/NutrientInputGrid.test.tsx
+++ b/src/components/nutrition/NutrientInputGrid.test.tsx
@@ -1,11 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { NutrientInputGrid } from './NutrientInputGrid'
 import { toNutrientInputs } from './nutrientInputs'
 
 test('renders a labeled input per nutrient and calls onChange with the key', () => {
   const onChange = vi.fn()
-  render(
+  renderWithI18n(
     <NutrientInputGrid
       values={toNutrientInputs(undefined)}
       onChange={onChange}
@@ -18,7 +19,7 @@ test('renders a labeled input per nutrient and calls onChange with the key', () 
 })
 
 test('disables every input when disabled is true', () => {
-  render(
+  renderWithI18n(
     <NutrientInputGrid
       values={toNutrientInputs(undefined)}
       onChange={vi.fn()}

--- a/src/components/nutrition/NutrientInputGrid.tsx
+++ b/src/components/nutrition/NutrientInputGrid.tsx
@@ -1,8 +1,5 @@
-import {
-  NUTRIENT_KEYS,
-  NUTRIENT_LABELS,
-  type NutrientKey,
-} from '../../../convex/lib/nutrition'
+import { NUTRIENT_KEYS, type NutrientKey } from '../../../convex/lib/nutrition'
+import { useMessages } from '../../lib/i18n'
 import { inputClass } from './nutrientInputs'
 
 interface Props {
@@ -12,11 +9,13 @@ interface Props {
 }
 
 export function NutrientInputGrid({ values, onChange, disabled }: Props) {
+  const labels = useMessages().nutrients.labels
+
   return (
     <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
       {NUTRIENT_KEYS.map((key) => (
         <label key={key} className="block text-sm">
-          <span className="mb-1 block font-medium">{NUTRIENT_LABELS[key]}</span>
+          <span className="mb-1 block font-medium">{labels[key]}</span>
           <input
             inputMode="decimal"
             className={inputClass}

--- a/src/components/nutrition/NutritionPage.tsx
+++ b/src/components/nutrition/NutritionPage.tsx
@@ -3,11 +3,11 @@ import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import {
-  MEAL_LABELS,
   MEAL_NAMES,
   type MealName,
   sumFacts,
 } from '../../../convex/lib/consumption'
+import { fmt, useMessages } from '../../lib/i18n'
 import { moduleById } from '../../lib/modules'
 import { AddEntryModal } from './AddEntryModal'
 import { DayTotals } from './DayTotals'
@@ -85,16 +85,19 @@ export function NutritionPage({
   const [addingMeal, setAddingMeal] = useState<MealName | null>(null)
   const [savingTargets, setSavingTargets] = useState(false)
   const [targetsError, setTargetsError] = useState<string | null>(null)
+  const messages = useMessages()
+  const { diary, meals } = messages.nutrition
 
   const totals = sumFacts((entries ?? []).map((e) => e.nutrition))
 
   return (
     <div className="mx-auto max-w-2xl">
-      <h1 className="mb-1 text-2xl font-semibold">Nutrition</h1>
+      <h1 className="mb-1 text-2xl font-semibold">
+        {messages.modules.byId.nutrition.label}
+      </h1>
       {moduleById('nutrition')?.scope === 'personal' && (
         <p className="mb-4 text-sm text-[var(--app-muted)]">
-          Yours alone. Nobody else in the group can see it, and it looks the
-          same whichever group you are in.
+          {diary.personalNote}
         </p>
       )}
 
@@ -104,7 +107,7 @@ export function NutritionPage({
           onClick={() => onDateChange(shiftDate(date, -1))}
           className="rounded border px-2 py-1 text-sm"
         >
-          ← Prev
+          {diary.prevDay}
         </button>
         <input
           type="date"
@@ -117,7 +120,7 @@ export function NutritionPage({
           onClick={() => onDateChange(shiftDate(date, 1))}
           className="rounded border px-2 py-1 text-sm"
         >
-          Next →
+          {diary.nextDay}
         </button>
       </div>
 
@@ -136,7 +139,7 @@ export function NutritionPage({
             await setTargets({ targets })
           } catch (err) {
             setTargetsError(
-              err instanceof Error ? err.message : 'Could not save targets',
+              err instanceof Error ? err.message : diary.targets.saveFailed,
             )
           } finally {
             setSavingTargets(false)
@@ -147,13 +150,17 @@ export function NutritionPage({
       <DayTotals
         totals={totals}
         targets={me?.nutritionTargets}
-        heading={date === todayLocal() ? "Today's totals" : `Totals — ${date}`}
+        heading={
+          date === todayLocal()
+            ? diary.totalsToday
+            : fmt(diary.totalsOn, { date })
+        }
       />
 
       {MEAL_NAMES.map((meal) => (
         <MealSlot
           key={meal}
-          label={MEAL_LABELS[meal]}
+          label={meals[meal]}
           entries={(entries ?? []).filter((e) => e.meal === meal)}
           nav={nav}
           onAdd={() => setAddingMeal(meal)}

--- a/src/components/nutrition/QuickAddTab.tsx
+++ b/src/components/nutrition/QuickAddTab.tsx
@@ -2,6 +2,7 @@ import { useMutation } from 'convex/react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { MealName } from '../../../convex/lib/consumption'
+import { useMessages } from '../../lib/i18n'
 import { NutrientInputGrid } from './NutrientInputGrid'
 import {
   inputClass,
@@ -21,6 +22,8 @@ export function QuickAddTab({ date, meal, onAdded }: Props) {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const create = useMutation(api.consumption.create)
+  const messages = useMessages()
+  const { quickAdd } = messages.nutrition.diary
 
   return (
     <form
@@ -41,7 +44,7 @@ export function QuickAddTab({ date, meal, onAdded }: Props) {
           })
           onAdded()
         } catch (err) {
-          setError(err instanceof Error ? err.message : 'Could not log this')
+          setError(err instanceof Error ? err.message : quickAdd.failed)
         } finally {
           setSubmitting(false)
         }
@@ -53,12 +56,12 @@ export function QuickAddTab({ date, meal, onAdded }: Props) {
         </p>
       )}
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Label</span>
+        <span className="mb-1 block font-medium">{quickAdd.label}</span>
         <input
           className={inputClass}
           value={label}
           onChange={(e) => setLabel(e.target.value)}
-          placeholder='e.g. "Restaurant meal"'
+          placeholder={quickAdd.placeholder}
           required
         />
       </label>
@@ -73,7 +76,7 @@ export function QuickAddTab({ date, meal, onAdded }: Props) {
         disabled={submitting}
         className="w-fit rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-4 py-2 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
       >
-        {submitting ? 'Adding…' : 'Add'}
+        {submitting ? quickAdd.adding : messages.common.actions.add}
       </button>
     </form>
   )

--- a/src/components/nutrition/RecipeAddTab.tsx
+++ b/src/components/nutrition/RecipeAddTab.tsx
@@ -6,6 +6,7 @@ import {
   computeRecipeEntryNutrition,
   type MealName,
 } from '../../../convex/lib/consumption'
+import { useMessages } from '../../lib/i18n'
 import type { NutritionNav } from './nutritionNav'
 
 interface Props {
@@ -27,9 +28,13 @@ export function RecipeAddTab({ date, meal, nav, onAdded }: Props) {
   const [quantities, setQuantities] = useState<Record<string, string>>({})
   const [submittingId, setSubmittingId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const messages = useMessages()
+  const { recipeAdd } = messages.nutrition.diary
 
   if (recipes === undefined)
-    return <p className="text-sm opacity-60">Loading…</p>
+    return (
+      <p className="text-sm opacity-60">{messages.common.errors.loading}</p>
+    )
 
   const withNutrition = recipes.filter((r) => r.nutrition)
   const withoutNutrition = recipes.filter((r) => !r.nutrition)
@@ -42,9 +47,7 @@ export function RecipeAddTab({ date, meal, nav, onAdded }: Props) {
         </p>
       )}
       {withNutrition.length === 0 && (
-        <p className="text-sm opacity-60">
-          No recipes with nutrition data yet.
-        </p>
+        <p className="text-sm opacity-60">{recipeAdd.none}</p>
       )}
       {withNutrition.map((recipe) => {
         const quantityInput = quantities[recipe._id] ?? '1'
@@ -66,7 +69,7 @@ export function RecipeAddTab({ date, meal, nav, onAdded }: Props) {
                 }
                 className="w-14 rounded border border-[var(--app-border)] px-1 py-0.5"
               />
-              <span className="opacity-60">servings</span>
+              <span className="opacity-60">{recipeAdd.servings}</span>
               <button
                 type="button"
                 disabled={submittingId === recipe._id}
@@ -96,9 +99,7 @@ export function RecipeAddTab({ date, meal, nav, onAdded }: Props) {
                     onAdded()
                   } catch (err) {
                     setError(
-                      err instanceof Error
-                        ? err.message
-                        : 'Could not log this recipe',
+                      err instanceof Error ? err.message : recipeAdd.failed,
                     )
                   } finally {
                     setSubmittingId(null)
@@ -106,7 +107,7 @@ export function RecipeAddTab({ date, meal, nav, onAdded }: Props) {
                 }}
                 className="rounded border border-[var(--app-fg)] bg-[var(--app-fg)] px-2 py-0.5 text-xs font-semibold text-[var(--app-surface)] disabled:opacity-60"
               >
-                Add
+                {messages.common.actions.add}
               </button>
             </div>
           </div>
@@ -115,7 +116,7 @@ export function RecipeAddTab({ date, meal, nav, onAdded }: Props) {
       {withoutNutrition.length > 0 && (
         <div className="mt-2 border-t border-[var(--app-border)] pt-2">
           <p className="mb-1 text-xs opacity-60">
-            These recipes have no nutrition data yet:
+            {recipeAdd.withoutNutrition}
           </p>
           {withoutNutrition.map((recipe) => (
             <Link

--- a/src/components/nutrition/TargetsPanel.test.tsx
+++ b/src/components/nutrition/TargetsPanel.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { TargetsPanel } from './TargetsPanel'
 
 test('starts collapsed and expands to show the nutrient grid', () => {
-  render(<TargetsPanel saving={false} onSave={vi.fn()} />)
+  renderWithI18n(<TargetsPanel saving={false} onSave={vi.fn()} />)
   expect(screen.queryByText('Calories (kcal)')).toBeNull()
   fireEvent.click(screen.getByText('Daily targets'))
   expect(screen.getByText('Calories (kcal)')).toBeDefined()
@@ -11,7 +12,7 @@ test('starts collapsed and expands to show the nutrient grid', () => {
 
 test('prefills from targets and calls onSave with parsed values', () => {
   const onSave = vi.fn()
-  render(
+  renderWithI18n(
     <TargetsPanel
       targets={{ calories: 2000 }}
       saving={false}
@@ -28,7 +29,9 @@ test('prefills from targets and calls onSave with parsed values', () => {
 })
 
 test('syncs the form when targets arrives after mount (e.g. the parent query was still loading)', () => {
-  const { rerender } = render(<TargetsPanel saving={false} onSave={vi.fn()} />)
+  const { rerender } = renderWithI18n(
+    <TargetsPanel saving={false} onSave={vi.fn()} />,
+  )
   fireEvent.click(screen.getByText('Daily targets'))
   expect(screen.getByLabelText('Calories (kcal)')).toHaveValue('')
   rerender(

--- a/src/components/nutrition/TargetsPanel.tsx
+++ b/src/components/nutrition/TargetsPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { NutritionFacts } from '../../../convex/lib/nutrition'
+import { useMessages } from '../../lib/i18n'
 import { NutrientInputGrid } from './NutrientInputGrid'
 import { nutrientInputsToFacts, toNutrientInputs } from './nutrientInputs'
 
@@ -11,6 +12,8 @@ interface Props {
 
 export function TargetsPanel({ targets, saving, onSave }: Props) {
   const [open, setOpen] = useState(false)
+  const messages = useMessages()
+  const { targets: targetsText } = messages.nutrition.diary
   const [inputs, setInputs] = useState(() => toNutrientInputs(targets))
 
   // `targets` starts undefined while the caller's `users.me` query is still
@@ -31,7 +34,7 @@ export function TargetsPanel({ targets, saving, onSave }: Props) {
         onClick={() => setOpen((o) => !o)}
         className="flex w-full items-center justify-between text-sm font-medium"
       >
-        Daily targets
+        {targetsText.title}
         <span className="opacity-60">{open ? '▾' : '▸'}</span>
       </button>
       {open && (
@@ -49,7 +52,7 @@ export function TargetsPanel({ targets, saving, onSave }: Props) {
             className="mt-3 rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-3 py-1.5 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
             onClick={() => onSave(nutrientInputsToFacts(inputs))}
           >
-            {saving ? 'Saving…' : 'Save targets'}
+            {saving ? messages.common.actions.saving : targetsText.save}
           </button>
         </div>
       )}

--- a/src/components/recipes/EditRecipePage.tsx
+++ b/src/components/recipes/EditRecipePage.tsx
@@ -3,6 +3,7 @@ import { useAction, useMutation, useQuery } from 'convex/react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Doc, Id } from '../../../convex/_generated/dataModel'
+import { useMessages } from '../../lib/i18n'
 import { ImageUploadField } from '../app/ImageUploadField'
 import { RecipeForm } from './RecipeForm'
 import type { RecipeNav } from './recipeNav'
@@ -31,11 +32,16 @@ export function EditRecipePage({
     id: recipeId as Id<'recipes'>,
     groupSlug,
   })
+  const messages = useMessages()
 
   if (recipe === undefined)
-    return <p className="text-sm opacity-60">Loading…</p>
+    return (
+      <p className="text-sm opacity-60">{messages.common.errors.loading}</p>
+    )
   if (recipe === null)
-    return <p className="text-sm opacity-60">Recipe not found.</p>
+    return (
+      <p className="text-sm opacity-60">{messages.recipes.detail.notFound}</p>
+    )
 
   return <EditRecipeForm key={recipe._id} recipe={recipe} nav={nav} />
 }
@@ -52,6 +58,7 @@ function EditRecipeForm({
   const aiConfigured = useQuery(api.recipes.aiConfigured)
   const estimateNutrition = useAction(api.recipeNutrition.estimateNutrition)
   const navigate = useNavigate()
+  const { edit, form } = useMessages().recipes
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [imageId, setImageId] = useState<Id<'_storage'> | undefined>(
@@ -61,7 +68,7 @@ function EditRecipeForm({
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-semibold">Edit recipe</h1>
+      <h1 className="mb-6 text-2xl font-semibold">{edit.title}</h1>
       {error && (
         <p className="mb-4 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800">
           {error}
@@ -108,9 +115,7 @@ function EditRecipeForm({
             })
             navigate(nav.detail(recipe._id))
           } catch (err) {
-            setError(
-              err instanceof Error ? err.message : 'Could not save recipe',
-            )
+            setError(err instanceof Error ? err.message : form.saveFailed)
             setSubmitting(false)
           }
         }}

--- a/src/components/recipes/NewRecipePage.tsx
+++ b/src/components/recipes/NewRecipePage.tsx
@@ -4,6 +4,7 @@ import { ConvexError } from 'convex/values'
 import { useEffect, useRef, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { useMessages } from '../../lib/i18n'
 import { ImageUploadField } from '../app/ImageUploadField'
 import { RecipeDestinationNotice } from './RecipeDestinationNotice'
 import { RecipeForm, type RecipeFormValues } from './RecipeForm'
@@ -49,6 +50,7 @@ export function NewRecipePage({
   const aiConfigured = useQuery(api.recipes.aiConfigured)
   const estimateNutrition = useAction(api.recipeNutrition.estimateNutrition)
   const navigate = useNavigate()
+  const { create: createText, form } = useMessages().recipes
 
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -102,10 +104,10 @@ export function NewRecipePage({
         err instanceof ConvexError
           ? typeof err.data === 'string'
             ? err.data
-            : 'Could not import that recipe'
+            : createText.importFailed
           : err instanceof Error
             ? err.message
-            : 'Could not import that recipe',
+            : createText.importFailed,
       )
     } finally {
       setImporting(false)
@@ -124,17 +126,19 @@ export function NewRecipePage({
 
   return (
     <div>
-      <h1 className="mb-6 text-2xl font-semibold">New recipe</h1>
+      <h1 className="mb-6 text-2xl font-semibold">{createText.title}</h1>
 
       <div className="mx-auto mb-6 max-w-2xl rounded-xl border p-4">
         <label className="block text-sm">
-          <span className="mb-1 block font-medium">Import from URL</span>
+          <span className="mb-1 block font-medium">
+            {createText.importLabel}
+          </span>
           <div className="flex gap-2">
             <input
               className="w-full rounded border px-2 py-1"
               value={importUrl}
               onChange={(e) => setImportUrl(e.target.value)}
-              placeholder="https://example.com/some-recipe"
+              placeholder={createText.importPlaceholder}
             />
             <button
               type="button"
@@ -142,7 +146,7 @@ export function NewRecipePage({
               onClick={() => runImport(importUrl)}
               className="whitespace-nowrap rounded-md border px-3 py-1.5 text-sm"
             >
-              {importing ? 'Importing…' : 'Import'}
+              {importing ? createText.importing : createText.import}
             </button>
           </div>
         </label>
@@ -153,9 +157,7 @@ export function NewRecipePage({
           <p className="mt-2 text-sm text-red-800">{importError}</p>
         )}
         {imported && !importing && !importError && (
-          <p className="mt-2 text-sm text-green-700">
-            Imported — review the details below, then save.
-          </p>
+          <p className="mt-2 text-sm text-green-700">{createText.imported}</p>
         )}
       </div>
 
@@ -199,10 +201,10 @@ export function NewRecipePage({
               err instanceof ConvexError
                 ? typeof err.data === 'string'
                   ? err.data
-                  : 'Could not save recipe'
+                  : form.saveFailed
                 : err instanceof Error
                   ? err.message
-                  : 'Could not save recipe',
+                  : form.saveFailed,
             )
             setSubmitting(false)
           }

--- a/src/components/recipes/NutritionPanel.test.tsx
+++ b/src/components/recipes/NutritionPanel.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { expect, test } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { NutritionPanel } from './NutritionPanel'
 
 test('renders present nutrients with labels, unit label, and the source badge', () => {
-  render(
+  renderWithI18n(
     <NutritionPanel
       nutrition={{ calories: 520, protein: 18.5 }}
       unitLabel="per serving · 4 servings"
@@ -19,13 +20,13 @@ test('renders present nutrients with labels, unit label, and the source badge', 
 })
 
 test('hides absent nutrients and badge when source/unitLabel are missing', () => {
-  render(<NutritionPanel nutrition={{ fat: 10 }} />)
+  renderWithI18n(<NutritionPanel nutrition={{ fat: 10 }} />)
   expect(screen.queryByText('Calories (kcal)')).toBeNull()
   expect(screen.queryByText('Imported')).toBeNull()
   expect(screen.getByText('Fat (g)')).toBeDefined()
 })
 
 test('renders nothing for empty nutrition', () => {
-  const { container } = render(<NutritionPanel nutrition={{}} />)
+  const { container } = renderWithI18n(<NutritionPanel nutrition={{}} />)
   expect(container.innerHTML).toBe('')
 })

--- a/src/components/recipes/NutritionPanel.tsx
+++ b/src/components/recipes/NutritionPanel.tsx
@@ -1,15 +1,9 @@
 import {
   NUTRIENT_KEYS,
-  NUTRIENT_LABELS,
   type NutritionFacts,
   type NutritionSource,
 } from '../../../convex/lib/nutrition'
-
-const SOURCE_LABELS: Record<NutritionSource, string> = {
-  imported: 'Imported',
-  ai: 'AI estimate',
-  manual: 'Manual',
-}
+import { useMessages } from '../../lib/i18n'
 
 interface Props {
   nutrition: NutritionFacts
@@ -19,27 +13,29 @@ interface Props {
 }
 
 export function NutritionPanel({ nutrition, unitLabel, source }: Props) {
+  const messages = useMessages()
+  const nutrients = messages.nutrients
   const present = NUTRIENT_KEYS.filter((key) => nutrition[key] !== undefined)
   if (present.length === 0) return null
   return (
     <section className="mb-4 rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">
       <div className="mb-2 flex items-center justify-between">
         <h2 className="font-medium">
-          Nutrition{' '}
+          {messages.recipes.detail.nutrition}{' '}
           {unitLabel && (
             <span className="text-xs font-normal opacity-60">{unitLabel}</span>
           )}
         </h2>
         {source && (
           <span className="rounded-full border border-[var(--app-border)] px-2 py-0.5 text-xs opacity-70">
-            {SOURCE_LABELS[source]}
+            {nutrients.sources[source]}
           </span>
         )}
       </div>
       <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm sm:grid-cols-4">
         {present.map((key) => (
           <div key={key}>
-            <dt className="opacity-60">{NUTRIENT_LABELS[key]}</dt>
+            <dt className="opacity-60">{nutrients.labels[key]}</dt>
             <dd className="font-medium">{nutrition[key]}</dd>
           </div>
         ))}

--- a/src/components/recipes/RecipeDestinationNotice.tsx
+++ b/src/components/recipes/RecipeDestinationNotice.tsx
@@ -1,3 +1,4 @@
+import { useMessages } from '../../lib/i18n'
 import type { RecipeDestination } from './recipeDestination'
 
 /**
@@ -14,15 +15,15 @@ export function RecipeDestinationNotice({
 }: {
   destination: RecipeDestination
 }) {
+  const notice = useMessages().recipes.destination
+
   return (
     <p className="m-0 text-xs text-[var(--app-muted)]">
-      Adding to{' '}
+      {notice.prefix}{' '}
       <span className="font-semibold text-[var(--app-fg)]">
         {destination.groupName}
       </span>
-      {destination.fallback
-        ? ' — your personal group, because this page is not inside one.'
-        : '.'}
+      {destination.fallback ? ` ${notice.fallbackSuffix}` : notice.suffix}
     </p>
   )
 }

--- a/src/components/recipes/RecipeDetailPage.tsx
+++ b/src/components/recipes/RecipeDetailPage.tsx
@@ -4,6 +4,7 @@ import { ConvexError } from 'convex/values'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { fmt, useMessages } from '../../lib/i18n'
 import { NutritionPanel } from './NutritionPanel'
 import { RecipeSharingPanel } from './RecipeSharingPanel'
 import type { RecipeNav } from './recipeNav'
@@ -38,11 +39,15 @@ export function RecipeDetailPage({
   const estimateNutrition = useAction(api.recipeNutrition.estimateNutrition)
   const setNutrition = useMutation(api.recipes.setNutrition)
   const [estimating, setEstimating] = useState(false)
+  const messages = useMessages()
+  const { detail, form } = messages.recipes
 
   if (recipe === undefined)
-    return <p className="text-sm opacity-60">Loading…</p>
+    return (
+      <p className="text-sm opacity-60">{messages.common.errors.loading}</p>
+    )
   if (recipe === null)
-    return <p className="text-sm opacity-60">Recipe not found.</p>
+    return <p className="text-sm opacity-60">{detail.notFound}</p>
 
   return (
     <article className="mx-auto max-w-2xl">
@@ -62,7 +67,7 @@ export function RecipeDetailPage({
               {...nav.edit(recipeId)}
               className="rounded border px-3 py-1.5 text-sm no-underline"
             >
-              Edit
+              {messages.common.actions.edit}
             </Link>
             <button
               type="button"
@@ -74,14 +79,12 @@ export function RecipeDetailPage({
                   navigate(nav.list)
                 } catch (err) {
                   setError(
-                    err instanceof Error
-                      ? err.message
-                      : 'Could not delete recipe',
+                    err instanceof Error ? err.message : detail.deleteFailed,
                   )
                 }
               }}
             >
-              Delete
+              {messages.common.actions.delete}
             </button>
           </div>
         )}
@@ -110,11 +113,13 @@ export function RecipeDetailPage({
         there, which is a better answer than an empty "Added by".
       */}
       {recipe.addedByName && (
-        <p className="mb-4 text-xs opacity-60">Added by {recipe.addedByName}</p>
+        <p className="mb-4 text-xs opacity-60">
+          {fmt(detail.addedBy, { name: recipe.addedByName })}
+        </p>
       )}
       {recipe.sourceUrl && (
         <p className="mb-4 text-xs opacity-60">
-          Imported from{' '}
+          {detail.importedFrom}{' '}
           <a
             href={recipe.sourceUrl}
             target="_blank"
@@ -134,9 +139,7 @@ export function RecipeDetailPage({
       */}
       {recipe.nutritionStale && recipe.canEdit && (
         <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
-          <p className="mb-2">
-            Ingredients changed since nutrition was calculated — re-estimate?
-          </p>
+          <p className="mb-2">{detail.staleNutrition}</p>
           <div className="flex gap-2">
             {aiConfigured && (
               <button
@@ -161,24 +164,24 @@ export function RecipeDetailPage({
                       err instanceof ConvexError
                         ? typeof err.data === 'string'
                           ? err.data
-                          : 'Could not estimate nutrition'
+                          : form.estimateFailed
                         : err instanceof Error
                           ? err.message
-                          : 'Could not estimate nutrition',
+                          : form.estimateFailed,
                     )
                   } finally {
                     setEstimating(false)
                   }
                 }}
               >
-                {estimating ? 'Estimating…' : 'Re-estimate with AI'}
+                {estimating ? form.estimating : detail.reEstimate}
               </button>
             )}
             <Link
               {...nav.edit(recipeId)}
               className="rounded border border-amber-400 px-2 py-1 text-xs font-medium no-underline"
             >
-              Edit manually
+              {detail.editManually}
             </Link>
           </div>
         </div>
@@ -200,21 +203,21 @@ export function RecipeDetailPage({
           nutrition={recipe.nutrition}
           unitLabel={
             recipe.servings
-              ? `per serving · ${recipe.servings} servings`
-              : 'per serving'
+              ? fmt(detail.perServingOf, { count: recipe.servings })
+              : detail.perServing
           }
           source={recipe.nutritionSource}
         />
       )}
 
-      <h2 className="mb-2 font-medium">Ingredients</h2>
+      <h2 className="mb-2 font-medium">{form.ingredients}</h2>
       <ul className="mb-4 list-disc pl-5 text-sm">
         {recipe.ingredients.map((i, idx) => (
           <li key={idx}>{i}</li>
         ))}
       </ul>
 
-      <h2 className="mb-2 font-medium">Steps</h2>
+      <h2 className="mb-2 font-medium">{form.steps}</h2>
       <ol className="list-decimal space-y-1 pl-5 text-sm">
         {recipe.steps.map((s, idx) => (
           <li key={idx}>{s}</li>

--- a/src/components/recipes/RecipeForm.test.tsx
+++ b/src/components/recipes/RecipeForm.test.tsx
@@ -1,11 +1,12 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { ConvexError } from 'convex/values'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { RecipeForm } from './RecipeForm'
 
 test('submits title and newline-split ingredients/steps', () => {
   const onSubmit = vi.fn()
-  render(<RecipeForm onSubmit={onSubmit} submitting={false} />)
+  renderWithI18n(<RecipeForm onSubmit={onSubmit} submitting={false} />)
 
   fireEvent.change(screen.getByLabelText('Title'), {
     target: { value: 'Pasta' },
@@ -30,7 +31,7 @@ test('submits title and newline-split ingredients/steps', () => {
 
 test('star rating can be set and submitted', () => {
   const onSubmit = vi.fn()
-  render(<RecipeForm onSubmit={onSubmit} submitting={false} />)
+  renderWithI18n(<RecipeForm onSubmit={onSubmit} submitting={false} />)
 
   fireEvent.change(screen.getByLabelText('Title'), {
     target: { value: 'Pasta' },
@@ -43,7 +44,7 @@ test('star rating can be set and submitted', () => {
 
 test('submits typed nutrition as manual source', () => {
   const onSubmit = vi.fn()
-  render(<RecipeForm onSubmit={onSubmit} submitting={false} />)
+  renderWithI18n(<RecipeForm onSubmit={onSubmit} submitting={false} />)
 
   fireEvent.change(screen.getByLabelText('Title'), {
     target: { value: 'Pasta' },
@@ -70,7 +71,7 @@ test('submits typed nutrition as manual source', () => {
 
 test('omits nutrition when all nutrient fields are empty', () => {
   const onSubmit = vi.fn()
-  render(<RecipeForm onSubmit={onSubmit} submitting={false} />)
+  renderWithI18n(<RecipeForm onSubmit={onSubmit} submitting={false} />)
 
   fireEvent.change(screen.getByLabelText('Title'), {
     target: { value: 'Pasta' },
@@ -87,7 +88,7 @@ test('omits nutrition when all nutrient fields are empty', () => {
 
 test('keeps the imported source when prefilled nutrition is untouched', () => {
   const onSubmit = vi.fn()
-  render(
+  renderWithI18n(
     <RecipeForm
       onSubmit={onSubmit}
       submitting={false}
@@ -113,7 +114,7 @@ test('keeps the imported source when prefilled nutrition is untouched', () => {
 test('estimate button fills nutrition and submits ai source', async () => {
   const onSubmit = vi.fn()
   const onEstimate = vi.fn().mockResolvedValue({ calories: 300, fat: 10 })
-  render(
+  renderWithI18n(
     <RecipeForm
       onSubmit={onSubmit}
       submitting={false}
@@ -154,7 +155,7 @@ test('surfaces the ConvexError friendly data string on estimate failure', async 
     '[CONVEX A(recipeNutrition:estimateNutrition)] Uncaught ConvexError: ' +
     "Couldn't estimate nutrition — try entering it manually.\n  Called by client"
   const onEstimate = vi.fn().mockRejectedValue(err)
-  render(
+  renderWithI18n(
     <RecipeForm
       onSubmit={onSubmit}
       submitting={false}
@@ -183,7 +184,7 @@ test('disables nutrition inputs while an estimate is in flight', async () => {
         resolveEstimate = resolve
       }),
   )
-  render(
+  renderWithI18n(
     <RecipeForm
       onSubmit={onSubmit}
       submitting={false}
@@ -209,14 +210,14 @@ test('disables nutrition inputs while an estimate is in flight', async () => {
 })
 
 test('hides the estimate button when onEstimate is not provided', () => {
-  render(<RecipeForm onSubmit={vi.fn()} submitting={false} />)
+  renderWithI18n(<RecipeForm onSubmit={vi.fn()} submitting={false} />)
   expect(screen.queryByRole('button', { name: /estimate/i })).toBeNull()
 })
 
 // The destination is a claim about where a save lands, so it is asserted as
 // text a person would read rather than as a prop that was passed.
 test('names the group a save will land in', () => {
-  render(
+  renderWithI18n(
     <RecipeForm
       onSubmit={vi.fn()}
       submitting={false}
@@ -234,7 +235,7 @@ test('names the group a save will land in', () => {
 })
 
 test('says so when the group was chosen rather than asked for', () => {
-  render(
+  renderWithI18n(
     <RecipeForm
       onSubmit={vi.fn()}
       submitting={false}
@@ -252,6 +253,6 @@ test('says so when the group was chosen rather than asked for', () => {
 })
 
 test('says nothing about a destination when there is none to move', () => {
-  render(<RecipeForm onSubmit={vi.fn()} submitting={false} />)
+  renderWithI18n(<RecipeForm onSubmit={vi.fn()} submitting={false} />)
   expect(screen.queryByText(/adding to/i)).toBeNull()
 })

--- a/src/components/recipes/RecipeForm.tsx
+++ b/src/components/recipes/RecipeForm.tsx
@@ -4,6 +4,7 @@ import type {
   NutritionFacts,
   NutritionSource,
 } from '../../../convex/lib/nutrition'
+import { useMessages } from '../../lib/i18n'
 import { NutrientInputGrid } from '../nutrition/NutrientInputGrid'
 import {
   inputClass,
@@ -84,6 +85,8 @@ export function RecipeForm({
   >(initial?.nutritionSource)
   const [estimating, setEstimating] = useState(false)
   const [estimateError, setEstimateError] = useState<string | null>(null)
+  const messages = useMessages()
+  const { form, rating: ratingText } = messages.recipes
 
   return (
     <form
@@ -108,7 +111,7 @@ export function RecipeForm({
       }}
     >
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Title</span>
+        <span className="mb-1 block font-medium">{form.title}</span>
         <input
           className={inputClass}
           value={title}
@@ -117,7 +120,7 @@ export function RecipeForm({
         />
       </label>
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Description</span>
+        <span className="mb-1 block font-medium">{form.description}</span>
         <textarea
           className={inputClass}
           value={description}
@@ -125,45 +128,45 @@ export function RecipeForm({
         />
       </label>
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Ingredients</span>
+        <span className="mb-1 block font-medium">{form.ingredients}</span>
         <textarea
           className={`h-32 ${inputClass}`}
           value={ingredients}
           onChange={(e) => setIngredients(e.target.value)}
-          placeholder="One per line"
+          placeholder={form.onePerLine}
         />
       </label>
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Steps</span>
+        <span className="mb-1 block font-medium">{form.steps}</span>
         <textarea
           className={`h-32 ${inputClass}`}
           value={steps}
           onChange={(e) => setSteps(e.target.value)}
-          placeholder="One per line"
+          placeholder={form.onePerLine}
         />
       </label>
       <label className="block text-sm">
-        <span className="mb-1 block font-medium">Tags</span>
+        <span className="mb-1 block font-medium">{form.tags}</span>
         <input
           className={inputClass}
           value={tags}
           onChange={(e) => setTags(e.target.value)}
-          placeholder="comma, separated"
+          placeholder={form.commaSeparated}
         />
       </label>
 
       <fieldset className="rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">
         <legend className="px-1 text-sm font-medium">
-          Nutrition (per serving)
+          {form.nutritionLegend}
         </legend>
         <label className="mb-3 block max-w-32 text-sm">
-          <span className="mb-1 block font-medium">Servings</span>
+          <span className="mb-1 block font-medium">{form.servings}</span>
           <input
             inputMode="numeric"
             className={inputClass}
             value={servings}
             onChange={(e) => setServings(e.target.value)}
-            placeholder="4"
+            placeholder={form.servingsPlaceholder}
             disabled={estimating}
           />
         </label>
@@ -196,17 +199,17 @@ export function RecipeForm({
                     err instanceof ConvexError
                       ? typeof err.data === 'string'
                         ? err.data
-                        : 'Could not estimate nutrition'
+                        : form.estimateFailed
                       : err instanceof Error
                         ? err.message
-                        : 'Could not estimate nutrition',
+                        : form.estimateFailed,
                   )
                 } finally {
                   setEstimating(false)
                 }
               }}
             >
-              {estimating ? 'Estimating…' : 'Estimate with AI'}
+              {estimating ? form.estimating : form.estimate}
             </button>
             {estimateError && (
               <p className="mt-2 text-sm text-red-800">{estimateError}</p>
@@ -216,7 +219,7 @@ export function RecipeForm({
       </fieldset>
 
       <div className="block text-sm">
-        <span className="mb-1 block font-medium">Rating</span>
+        <span className="mb-1 block font-medium">{ratingText.label}</span>
         <StarRating value={rating} onChange={setRating} />
       </div>
       <div className="grid gap-2">
@@ -226,7 +229,7 @@ export function RecipeForm({
           disabled={submitting || estimating}
           className="w-fit rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-4 py-2 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {submitting ? 'Saving…' : 'Save recipe'}
+          {submitting ? messages.common.actions.saving : form.save}
         </button>
       </div>
     </form>

--- a/src/components/recipes/RecipeSharingPanel.test.tsx
+++ b/src/components/recipes/RecipeSharingPanel.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { RecipeSharingPanel } from './RecipeSharingPanel'
 
 /**
@@ -73,7 +74,7 @@ beforeEach(() => {
 function renderPanel(
   sharedGroups: Array<{ _id: Id<'groups'>; name: string; slug: string }> = [],
 ) {
-  render(
+  renderWithI18n(
     <RecipeSharingPanel
       recipeId={RECIPE_ID}
       homeGroupName="Household"

--- a/src/components/recipes/RecipeSharingPanel.tsx
+++ b/src/components/recipes/RecipeSharingPanel.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import { groupLink } from '../../lib/groupPaths'
+import { fmt, useMessages } from '../../lib/i18n'
 
 export interface RecipeSharingPanelProps {
   recipeId: Id<'recipes'>
@@ -38,6 +39,8 @@ export function RecipeSharingPanel({
   const share = useMutation(api.recipes.share)
   const unshare = useMutation(api.recipes.unshare)
   const navigate = useNavigate()
+  const messages = useMessages()
+  const { sharing } = messages.recipes
 
   const [moveTo, setMoveTo] = useState('')
   const [shareWith, setShareWith] = useState('')
@@ -54,7 +57,9 @@ export function RecipeSharingPanel({
     try {
       await action()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not do that')
+      setError(
+        err instanceof Error ? err.message : messages.common.errors.didNotWork,
+      )
     } finally {
       setBusy(false)
     }
@@ -62,19 +67,22 @@ export function RecipeSharingPanel({
 
   return (
     <section className="mb-4 rounded-md border px-3 py-3 text-sm">
-      <h2 className="mb-2 font-medium">Groups</h2>
+      <h2 className="mb-2 font-medium">{sharing.title}</h2>
 
       <p className="mb-1 opacity-80">
-        Lives in <strong>{homeGroupName ?? 'a group you are in'}</strong>
+        {sharing.livesIn}{' '}
+        <strong>{homeGroupName ?? sharing.unknownGroup}</strong>
       </p>
 
       {sharedGroups.length === 0 ? (
-        <p className="mb-3 opacity-60">Not shared with any other group.</p>
+        <p className="mb-3 opacity-60">{sharing.notShared}</p>
       ) : (
         <ul className="mb-3 list-none space-y-1 p-0">
           {sharedGroups.map((group) => (
             <li key={group._id} className="flex items-center gap-2">
-              <span className="opacity-80">Shared with {group.name}</span>
+              <span className="opacity-80">
+                {fmt(sharing.sharedWith, { group: group.name })}
+              </span>
               <button
                 type="button"
                 disabled={busy}
@@ -85,7 +93,7 @@ export function RecipeSharingPanel({
                   )
                 }
               >
-                Unshare
+                {sharing.unshare}
               </button>
             </li>
           ))}
@@ -99,15 +107,12 @@ export function RecipeSharingPanel({
       )}
 
       {others.length === 0 ? (
-        <p className="opacity-60">
-          You are only in one group, so there is nowhere to move or share this
-          to yet.
-        </p>
+        <p className="opacity-60">{sharing.onlyOneGroup}</p>
       ) : (
         <div className="grid gap-2">
           <div className="flex items-center gap-2">
             <label className="opacity-80" htmlFor="recipe-move-to">
-              Move to
+              {sharing.moveTo}
             </label>
             <select
               id="recipe-move-to"
@@ -115,7 +120,7 @@ export function RecipeSharingPanel({
               value={moveTo}
               onChange={(e) => setMoveTo(e.target.value)}
             >
-              <option value="">Choose a group…</option>
+              <option value="">{sharing.chooseGroup}</option>
               {others.map((group) => (
                 <option key={group._id} value={group.slug}>
                   {group.name}
@@ -137,14 +142,14 @@ export function RecipeSharingPanel({
                 })
               }
             >
-              Move
+              {sharing.move}
             </button>
           </div>
 
           {shareOptions.length > 0 && (
             <div className="flex items-center gap-2">
               <label className="opacity-80" htmlFor="recipe-share-with">
-                Share with
+                {sharing.shareWith}
               </label>
               <select
                 id="recipe-share-with"
@@ -152,7 +157,7 @@ export function RecipeSharingPanel({
                 value={shareWith}
                 onChange={(e) => setShareWith(e.target.value)}
               >
-                <option value="">Choose a group…</option>
+                <option value="">{sharing.chooseGroup}</option>
                 {shareOptions.map((group) => (
                   <option key={group._id} value={group.slug}>
                     {group.name}
@@ -170,7 +175,7 @@ export function RecipeSharingPanel({
                   })
                 }
               >
-                Share
+                {sharing.share}
               </button>
             </div>
           )}

--- a/src/components/recipes/RecipesPage.tsx
+++ b/src/components/recipes/RecipesPage.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router'
 import { useQuery } from 'convex/react'
 import { Plus } from 'lucide-react'
 import { api } from '../../../convex/_generated/api'
+import { useMessages } from '../../lib/i18n'
 import { SurfaceCard } from '../app/ShellPrimitives'
 import { RecipeCard } from './RecipeCard'
 import type { RecipeNav } from './recipeNav'
@@ -25,14 +26,18 @@ export function RecipesPage({
 }) {
   const recipes = useQuery(api.recipes.list, { groupSlug })
   const [viewMode, setViewMode] = useRecipeViewMode()
+  const messages = useMessages()
+  const { list } = messages.recipes
 
   return (
     <div className="mx-auto grid max-w-5xl gap-4">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <h2 className="m-0 text-2xl font-semibold">Recipes</h2>
+          <h2 className="m-0 text-2xl font-semibold">
+            {messages.modules.byId.recipes.label}
+          </h2>
           <p className="mt-1 text-sm text-[var(--app-muted)]">
-            Keep and rate the dishes this group cooks.
+            {list.subtitle}
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -42,7 +47,7 @@ export function RecipesPage({
             className="inline-flex min-h-9 items-center gap-2 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 text-sm font-semibold text-[var(--app-fg)] no-underline"
           >
             <Plus className="h-4 w-4" aria-hidden="true" />
-            Add recipe
+            {list.add}
           </Link>
         </div>
       </div>
@@ -59,15 +64,15 @@ export function RecipesPage({
       ) : recipes.length === 0 ? (
         <SurfaceCard>
           <div className="grid gap-3 text-center">
-            <h3 className="m-0 text-base font-semibold">No recipes yet</h3>
+            <h3 className="m-0 text-base font-semibold">{list.emptyTitle}</h3>
             <p className="m-0 text-sm text-[var(--app-muted)]">
-              Add the first recipe to make this module useful for the group.
+              {list.emptyBody}
             </p>
             <Link
               {...nav.create}
               className="mx-auto inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold no-underline"
             >
-              Add your first recipe
+              {list.emptyAction}
             </Link>
           </div>
         </SurfaceCard>

--- a/src/components/recipes/StarRating.test.tsx
+++ b/src/components/recipes/StarRating.test.tsx
@@ -1,23 +1,24 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { StarRating } from './StarRating'
 
 test('clicking a star sets the rating', () => {
   const onChange = vi.fn()
-  render(<StarRating value={undefined} onChange={onChange} />)
+  renderWithI18n(<StarRating value={undefined} onChange={onChange} />)
   fireEvent.click(screen.getByRole('radio', { name: '3 stars' }))
   expect(onChange).toHaveBeenCalledWith(3)
 })
 
 test('clicking the already-selected star clears the rating', () => {
   const onChange = vi.fn()
-  render(<StarRating value={3} onChange={onChange} />)
+  renderWithI18n(<StarRating value={3} onChange={onChange} />)
   fireEvent.click(screen.getByRole('radio', { name: '3 stars' }))
   expect(onChange).toHaveBeenCalledWith(undefined)
 })
 
 test('only the star matching the current value is marked checked', () => {
-  render(<StarRating value={3} onChange={() => {}} />)
+  renderWithI18n(<StarRating value={3} onChange={() => {}} />)
   expect(screen.getByRole('radio', { name: '3 stars' })).toHaveAttribute(
     'aria-checked',
     'true',

--- a/src/components/recipes/StarRating.tsx
+++ b/src/components/recipes/StarRating.tsx
@@ -1,3 +1,5 @@
+import { plural, useI18n } from '../../lib/i18n'
+
 const STAR_VALUES = [1, 2, 3, 4, 5]
 
 interface StarRatingProps {
@@ -6,8 +8,11 @@ interface StarRatingProps {
 }
 
 export function StarRating({ value, onChange }: StarRatingProps) {
+  const { locale, messages } = useI18n()
+  const rating = messages.recipes.rating
+
   return (
-    <div role="radiogroup" aria-label="Rating" className="flex gap-1">
+    <div role="radiogroup" aria-label={rating.label} className="flex gap-1">
       {STAR_VALUES.map((star) => (
         // biome-ignore lint/a11y/useSemanticElements: custom radio-group widget (WAI-ARIA radio pattern) needs a clickable button, not a native input, to render the star glyph
         <button
@@ -15,7 +20,7 @@ export function StarRating({ value, onChange }: StarRatingProps) {
           type="button"
           role="radio"
           aria-checked={value === star}
-          aria-label={`${star} star${star === 1 ? '' : 's'}`}
+          aria-label={plural(locale, star, rating.stars)}
           className="text-2xl leading-none"
           onClick={() => onChange(value === star ? undefined : star)}
         >

--- a/src/components/recipes/ViewModeToggle.test.tsx
+++ b/src/components/recipes/ViewModeToggle.test.tsx
@@ -1,16 +1,17 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { ViewModeToggle } from './ViewModeToggle'
 
 test('clicking an option calls onChange with that mode', () => {
   const onChange = vi.fn()
-  render(<ViewModeToggle mode="grid" onChange={onChange} />)
+  renderWithI18n(<ViewModeToggle mode="grid" onChange={onChange} />)
   fireEvent.click(screen.getByRole('radio', { name: 'Compact view' }))
   expect(onChange).toHaveBeenCalledWith('compact')
 })
 
 test('the active mode is marked checked', () => {
-  render(<ViewModeToggle mode="banner" onChange={() => {}} />)
+  renderWithI18n(<ViewModeToggle mode="banner" onChange={() => {}} />)
   expect(screen.getByRole('radio', { name: 'Banner view' })).toHaveAttribute(
     'aria-checked',
     'true',

--- a/src/components/recipes/ViewModeToggle.tsx
+++ b/src/components/recipes/ViewModeToggle.tsx
@@ -1,15 +1,13 @@
 import type { LucideIcon } from 'lucide-react'
 import { GalleryVerticalEnd, LayoutGrid, Rows3 } from 'lucide-react'
+import { useMessages } from '../../lib/i18n'
 import type { RecipeViewMode } from './RecipeCard'
 
-const OPTIONS: Array<{
-  mode: RecipeViewMode
-  label: string
-  icon: LucideIcon
-}> = [
-  { mode: 'grid', label: 'Grid view', icon: LayoutGrid },
-  { mode: 'banner', label: 'Banner view', icon: GalleryVerticalEnd },
-  { mode: 'compact', label: 'Compact view', icon: Rows3 },
+/** Which layouts there are and which glyph each wears — not a translator's call. */
+const OPTIONS: Array<{ mode: RecipeViewMode; icon: LucideIcon }> = [
+  { mode: 'grid', icon: LayoutGrid },
+  { mode: 'banner', icon: GalleryVerticalEnd },
+  { mode: 'compact', icon: Rows3 },
 ]
 
 interface ViewModeToggleProps {
@@ -18,20 +16,22 @@ interface ViewModeToggleProps {
 }
 
 export function ViewModeToggle({ mode, onChange }: ViewModeToggleProps) {
+  const viewMode = useMessages().recipes.viewMode
+
   return (
     <div
       role="radiogroup"
-      aria-label="Recipe view"
+      aria-label={viewMode.label}
       className="flex gap-1 rounded-lg border p-1"
     >
-      {OPTIONS.map(({ mode: optionMode, label, icon: Icon }) => (
+      {OPTIONS.map(({ mode: optionMode, icon: Icon }) => (
         // biome-ignore lint/a11y/useSemanticElements: custom radio-group widget (WAI-ARIA radio pattern) needs a clickable button, not a native input, to render the icon
         <button
           key={optionMode}
           type="button"
           role="radio"
           aria-checked={mode === optionMode}
-          aria-label={label}
+          aria-label={viewMode[optionMode]}
           onClick={() => onChange(optionMode)}
           className={`rounded-md p-1.5 ${mode === optionMode ? 'bg-black/10 dark:bg-white/20' : ''}`}
         >

--- a/src/components/settings/ConnectionsSettings.test.tsx
+++ b/src/components/settings/ConnectionsSettings.test.tsx
@@ -1,11 +1,6 @@
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { ConnectionsSettings } from './ConnectionsSettings'
 
 /**
@@ -62,7 +57,7 @@ beforeEach(() => {
 })
 
 function renderPanel() {
-  render(
+  renderWithI18n(
     <ConnectionsSettings
       groupSlug="jansen-household"
       groupName="Jansen Household"

--- a/src/components/settings/ConnectionsSettings.tsx
+++ b/src/components/settings/ConnectionsSettings.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import { errorMessage } from '../../lib/errorMessage'
 import { groupHref } from '../../lib/groupPaths'
+import { fmt, useMessages } from '../../lib/i18n'
 import {
   type ExternalProvider,
   newOAuthState,
@@ -57,6 +58,7 @@ export function ConnectionsSettings({
   groupName,
 }: ConnectionsSettingsProps) {
   const connections = useQuery(api.integrations.listConnections, { groupSlug })
+  const { connections: connectionsText } = useMessages().settings
   const disconnect = useMutation(api.integrations.disconnect)
   const connect = useConnectProvider(
     groupSlug,
@@ -73,16 +75,17 @@ export function ConnectionsSettings({
       await connect(provider)
     } catch (e) {
       setBusy(null)
-      setError(errorMessage(e, 'Could not start the connection — try again.'))
+      setError(errorMessage(e, connectionsText.startFailed))
     }
   }
 
   return (
     <SurfaceCard>
-      <h2 className="m-0 mb-1 text-base font-semibold">Connections</h2>
+      <h2 className="m-0 mb-1 text-base font-semibold">
+        {connectionsText.title}
+      </h2>
       <p className="m-0 mb-3 text-sm text-[var(--app-muted)]">
-        Connect an external app for {groupName}. Every member of {groupName} can
-        use it — Tasks can mirror a list from it — and nobody outside can.
+        {fmt(connectionsText.intro, { group: groupName })}
       </p>
       {error && <p className="m-0 mb-2 text-sm text-red-600">{error}</p>}
       <ul className="m-0 grid list-none gap-2 p-0">
@@ -97,8 +100,11 @@ export function ConnectionsSettings({
                 <span className="text-sm font-semibold">{p.label}</span>
                 <p className="m-0 text-xs text-[var(--app-muted)]">
                   {conn
-                    ? `${conn.accountLabel} — connected by ${conn.connectedByName}`
-                    : 'Not connected'}
+                    ? fmt(connectionsText.connectedBy, {
+                        account: conn.accountLabel,
+                        name: conn.connectedByName,
+                      })
+                    : connectionsText.notConnected}
                 </p>
               </div>
               {conn ? (
@@ -107,16 +113,21 @@ export function ConnectionsSettings({
                   className={buttonClass}
                   onClick={() =>
                     confirm({
-                      title: `Disconnect ${p.label} from ${groupName}?`,
-                      body: 'Linked lists stop loading until it is reconnected.',
-                      confirmLabel: 'Disconnect',
-                      errorFallback: `Could not disconnect ${p.label}.`,
+                      title: fmt(connectionsText.disconnectTitle, {
+                        provider: p.label,
+                        group: groupName,
+                      }),
+                      body: connectionsText.disconnectBody,
+                      confirmLabel: connectionsText.disconnect,
+                      errorFallback: fmt(connectionsText.disconnectFailed, {
+                        provider: p.label,
+                      }),
                       run: () =>
                         disconnect({ connectionId: conn._id, groupSlug }),
                     })
                   }
                 >
-                  Disconnect
+                  {connectionsText.disconnect}
                 </button>
               ) : (
                 <button
@@ -125,7 +136,9 @@ export function ConnectionsSettings({
                   disabled={busy === p.id}
                   onClick={() => void onConnect(p.id)}
                 >
-                  {busy === p.id ? 'Opening…' : 'Connect'}
+                  {busy === p.id
+                    ? connectionsText.opening
+                    : connectionsText.connect}
                 </button>
               )}
             </li>

--- a/src/components/settings/GroupIdentitySettings.tsx
+++ b/src/components/settings/GroupIdentitySettings.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery } from 'convex/react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import { errorMessage } from '../../lib/errorMessage'
+import { fmt, useMessages } from '../../lib/i18n'
 import { useConfirmAction } from '../app/ConfirmAction'
 import type { ActiveGroup } from '../app/GroupGate'
 import { Pill, SurfaceCard } from '../app/ShellPrimitives'
@@ -37,6 +38,9 @@ export function GroupIdentitySettings({ group }: GroupIdentitySettingsProps) {
   const rename = useMutation(api.groups.renameGroup)
   const leave = useMutation(api.groups.leaveGroup)
   const { confirm, dialog } = useConfirmAction()
+  const messages = useMessages()
+  const group_ = messages.settings.group
+  const actions = messages.common.actions
   const [name, setName] = useState(group.name)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -59,7 +63,7 @@ export function GroupIdentitySettings({ group }: GroupIdentitySettingsProps) {
         params: { groupSlug: slug },
       })
     } catch (err) {
-      setError(errorMessage(err, 'Could not rename this group.'))
+      setError(errorMessage(err, group_.renameFailed))
     } finally {
       setSaving(false)
     }
@@ -67,11 +71,9 @@ export function GroupIdentitySettings({ group }: GroupIdentitySettingsProps) {
 
   return (
     <SurfaceCard>
-      <h2 className="m-0 mb-1 text-base font-semibold">This group</h2>
+      <h2 className="m-0 mb-1 text-base font-semibold">{group_.title}</h2>
       <p className="m-0 mb-3 text-sm text-[var(--app-muted)]">
-        {group.isPersonal
-          ? 'Your personal group. It is only ever yours, so there is nothing here to share or leave.'
-          : 'Its name, the code that lets somebody in, and the way out.'}
+        {group.isPersonal ? group_.personalNote : group_.sharedNote}
       </p>
 
       {error && (
@@ -84,7 +86,7 @@ export function GroupIdentitySettings({ group }: GroupIdentitySettingsProps) {
         {canRename ? (
           <form onSubmit={(e) => void submitRename(e)} className="grid gap-2">
             <label htmlFor="group-name" className="text-sm font-semibold">
-              Name
+              {group_.name}
             </label>
             <div className="flex flex-wrap items-center gap-2">
               <input
@@ -98,12 +100,11 @@ export function GroupIdentitySettings({ group }: GroupIdentitySettingsProps) {
                 disabled={saving || !name.trim() || name.trim() === group.name}
                 className={`${buttonClass} disabled:opacity-60`}
               >
-                {saving ? 'Saving…' : 'Rename'}
+                {saving ? actions.saving : group_.rename}
               </button>
             </div>
             <p className="m-0 text-xs text-[var(--app-muted)]">
-              The address changes with the name, so old links to this group stop
-              working.
+              {group_.addressChanges}
             </p>
           </form>
         ) : null}
@@ -112,20 +113,20 @@ export function GroupIdentitySettings({ group }: GroupIdentitySettingsProps) {
 
         {group.isPersonal ? null : (
           <div className="grid gap-2">
-            <span className="text-sm font-semibold">Leave</span>
+            <span className="text-sm font-semibold">{group_.leave}</span>
             <div>
               <button
                 type="button"
                 className={buttonClass}
                 onClick={() =>
                   confirm({
-                    title: `Leave ${group.name}?`,
-                    body: 'You stop seeing everything in it. Anything you added stays with the group.',
-                    confirmLabel: 'Leave group',
+                    title: fmt(group_.leaveTitle, { group: group.name }),
+                    body: group_.leaveBody,
+                    confirmLabel: group_.leaveConfirm,
                     // The one refusal a reader can act on is the last admin's,
                     // and the server's message names the fix; Members below is
                     // where it happens.
-                    errorFallback: 'Could not leave this group.',
+                    errorFallback: group_.leaveFailed,
                     run: async () => {
                       await leave({ groupId: group._id })
                       await navigate({ to: '/groups' })
@@ -133,7 +134,7 @@ export function GroupIdentitySettings({ group }: GroupIdentitySettingsProps) {
                   })
                 }
               >
-                Leave this group
+                {group_.leaveButton}
               </button>
             </div>
           </div>
@@ -154,20 +155,23 @@ export function GroupIdentitySettings({ group }: GroupIdentitySettingsProps) {
  */
 function InviteCode({ slug }: { slug: string }) {
   const code = useQuery(api.groups.inviteCode, { slug })
+  const messages = useMessages()
+  const group_ = messages.settings.group
 
   return (
     <div className="grid gap-2">
-      <span className="text-sm font-semibold">Invite code</span>
+      <span className="text-sm font-semibold">{group_.inviteCode}</span>
       <div className="flex flex-wrap items-center gap-2">
         {code === undefined ? (
-          <span className="text-sm text-[var(--app-muted)]">Loading…</span>
+          <span className="text-sm text-[var(--app-muted)]">
+            {messages.common.errors.loading}
+          </span>
         ) : (
           <Pill>{code}</Pill>
         )}
       </div>
       <p className="m-0 text-xs text-[var(--app-muted)]">
-        Anyone holding this code can join from Groups — share it only with
-        people you want in this group.
+        {group_.inviteCodeNote}
       </p>
     </div>
   )

--- a/src/components/settings/GroupMembersSettings.tsx
+++ b/src/components/settings/GroupMembersSettings.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from 'convex/react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import { errorMessage } from '../../lib/errorMessage'
+import { useMessages } from '../../lib/i18n'
 import type { ActiveGroup } from '../app/GroupGate'
 import { Pill, SurfaceCard } from '../app/ShellPrimitives'
 
@@ -31,6 +32,7 @@ export function GroupMembersSettings({ group }: GroupMembersSettingsProps) {
   const me = useQuery(api.users.me)
   const setRole = useMutation(api.groups.setMemberRole)
   const [error, setError] = useState<string | null>(null)
+  const { members: membersText } = useMessages().settings
   const [busyUserId, setBusyUserId] = useState<string | null>(null)
 
   if (group.isPersonal) return null
@@ -48,19 +50,17 @@ export function GroupMembersSettings({ group }: GroupMembersSettingsProps) {
         role,
       })
     } catch (e) {
-      setError(errorMessage(e, 'Could not change that role.'))
+      setError(errorMessage(e, membersText.roleFailed))
     } finally {
       setBusyUserId(null)
     }
   }
 
   return (
-    <SurfaceCard ariaLabel="Members">
-      <h2 className="m-0 mb-1 text-base font-semibold">Members</h2>
+    <SurfaceCard ariaLabel={membersText.title}>
+      <h2 className="m-0 mb-1 text-base font-semibold">{membersText.title}</h2>
       <p className="m-0 mb-3 text-sm text-[var(--app-muted)]">
-        {isAdmin
-          ? 'Admins can rename this group, change roles, and delete it. Everyone else can use everything in it.'
-          : 'Admins can rename this group and change roles. Everyone here can use everything in it.'}
+        {isAdmin ? membersText.personalNote : membersText.sharedNote}
       </p>
 
       {error && (
@@ -87,9 +87,11 @@ export function GroupMembersSettings({ group }: GroupMembersSettingsProps) {
                   <span className="truncate text-sm font-semibold">
                     {member.name}
                   </span>
-                  {member.userId === me?._id ? <Pill>You</Pill> : null}
+                  {member.userId === me?._id ? (
+                    <Pill>{membersText.you}</Pill>
+                  ) : null}
                   {member.role === 'admin' ? (
-                    <Pill tone="dark">Admin</Pill>
+                    <Pill tone="dark">{membersText.admin}</Pill>
                   ) : null}
                 </span>
 
@@ -98,11 +100,7 @@ export function GroupMembersSettings({ group }: GroupMembersSettingsProps) {
                     type="button"
                     className={buttonClass}
                     disabled={busyUserId === member.userId || isLastAdmin}
-                    title={
-                      isLastAdmin
-                        ? 'A group needs at least one admin'
-                        : undefined
-                    }
+                    title={isLastAdmin ? membersText.lastAdmin : undefined}
                     onClick={() =>
                       void change(
                         member.userId,
@@ -110,7 +108,9 @@ export function GroupMembersSettings({ group }: GroupMembersSettingsProps) {
                       )
                     }
                   >
-                    {member.role === 'admin' ? 'Make member' : 'Make admin'}
+                    {member.role === 'admin'
+                      ? membersText.makeMember
+                      : membersText.makeAdmin}
                   </button>
                 ) : null}
               </li>

--- a/src/components/settings/GroupSettingsLinks.test.tsx
+++ b/src/components/settings/GroupSettingsLinks.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { GroupSettingsLinks } from './GroupSettingsLinks'
 
 /**
@@ -42,7 +43,7 @@ beforeEach(() => {
 
 describe('the signpost to each Group’s settings', () => {
   test('says a connection belongs to a group rather than to you', () => {
-    render(<GroupSettingsLinks />)
+    renderWithI18n(<GroupSettingsLinks />)
     expect(screen.getByText(/belong to a group, not to you/i)).toBeDefined()
   })
 
@@ -52,7 +53,7 @@ describe('the signpost to each Group’s settings', () => {
       { _id: 'g2', name: 'Cooking club', slug: 'cooking-club' },
     ]
 
-    render(<GroupSettingsLinks />)
+    renderWithI18n(<GroupSettingsLinks />)
 
     expect(
       screen
@@ -65,7 +66,7 @@ describe('the signpost to each Group’s settings', () => {
   })
 
   test('offers nothing at all until the answer has arrived', () => {
-    render(<GroupSettingsLinks />)
+    renderWithI18n(<GroupSettingsLinks />)
     expect(screen.queryAllByRole('link')).toEqual([])
   })
 })

--- a/src/components/settings/GroupSettingsLinks.tsx
+++ b/src/components/settings/GroupSettingsLinks.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router'
 import { useQuery } from 'convex/react'
 import { api } from '../../../convex/_generated/api'
 import { groupLink } from '../../lib/groupPaths'
+import { useMessages } from '../../lib/i18n'
 import { SurfaceCard } from '../app/ShellPrimitives'
 
 /**
@@ -15,17 +16,21 @@ import { SurfaceCard } from '../app/ShellPrimitives'
  */
 export function GroupSettingsLinks() {
   const groups = useQuery(api.groups.myGroups)
+  const messages = useMessages()
+  const { groupSettings } = messages.settings
 
   return (
     <SurfaceCard>
-      <h2 className="m-0 mb-1 text-base font-semibold">Group settings</h2>
+      <h2 className="m-0 mb-1 text-base font-semibold">
+        {groupSettings.title}
+      </h2>
       <p className="m-0 mb-3 text-sm text-[var(--app-muted)]">
-        Connections to Notion and Todoist belong to a group, not to you — every
-        member of that group can use one, and nobody outside it can. Each group
-        keeps its own.
+        {groupSettings.description}
       </p>
       {groups === undefined ? (
-        <p className="m-0 text-sm text-[var(--app-muted)]">Loading…</p>
+        <p className="m-0 text-sm text-[var(--app-muted)]">
+          {messages.common.errors.loading}
+        </p>
       ) : (
         <ul className="m-0 grid list-none gap-2 p-0">
           {groups.map((group) => (
@@ -36,7 +41,7 @@ export function GroupSettingsLinks() {
               >
                 {group.name}
                 <span className="text-xs font-normal text-[var(--app-muted)]">
-                  Settings
+                  {groupSettings.open}
                 </span>
               </Link>
             </li>

--- a/src/components/settings/LanguageSettings.tsx
+++ b/src/components/settings/LanguageSettings.tsx
@@ -1,0 +1,48 @@
+import { type Locale, SUPPORTED_LOCALES, useI18n } from '../../lib/i18n'
+import { SurfaceCard } from '../app/ShellPrimitives'
+
+/**
+ * The same choice the topbar toggle makes, on the page somebody looks at when
+ * they are looking for a setting rather than for a button.
+ *
+ * Not a duplicate state to keep in step — both read and write the one
+ * `useI18n()` value — but a duplicate *entrance*, which is the point: the
+ * toggle is for flipping, this is for finding.
+ *
+ * Each language is written in itself. "Dutch" is only helpful to somebody who
+ * already reads English, which is exactly the reader this row is not for.
+ */
+export function LanguageSettings() {
+  const { locale, messages, setLocale } = useI18n()
+  const { language } = messages.settings
+
+  return (
+    <SurfaceCard>
+      <h2 className="m-0 mb-1 text-base font-semibold">{language.title}</h2>
+      <p className="m-0 mb-3 text-sm text-[var(--app-muted)]">
+        {language.description}
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {SUPPORTED_LOCALES.map((option: Locale) => {
+          const isOn = option === locale
+          return (
+            <button
+              key={option}
+              type="button"
+              lang={option}
+              aria-pressed={isOn}
+              onClick={() => setLocale(option)}
+              className={`inline-flex min-h-9 items-center justify-center rounded-[var(--app-radius)] border px-3 text-sm font-semibold ${
+                isOn
+                  ? 'border-[var(--app-fg)] bg-[var(--app-fg)] text-[var(--app-surface)]'
+                  : 'border-[var(--app-border)] bg-[var(--app-surface)] text-[var(--app-fg)]'
+              }`}
+            >
+              {language.names[option]}
+            </button>
+          )
+        })}
+      </div>
+    </SurfaceCard>
+  )
+}

--- a/src/components/settings/SampleDataSettings.tsx
+++ b/src/components/settings/SampleDataSettings.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import { SAMPLE_GROUP_NAME } from '../../../convex/lib/seed/sampleHousehold'
 import { errorMessage } from '../../lib/errorMessage'
+import { fmt, plural, useI18n } from '../../lib/i18n'
 import { SurfaceCard } from '../app/ShellPrimitives'
 
 const buttonClass =
@@ -29,6 +30,8 @@ export function SampleDataSettings() {
   const loadSampleData = useMutation(api.seed.loadSampleData)
   const resetSampleData = useMutation(api.seed.resetSampleData)
   const [busy, setBusy] = useState<Busy>(null)
+  const { locale, messages } = useI18n()
+  const { sampleData } = messages.settings
   const [error, setError] = useState<string | null>(null)
   const [result, setResult] = useState<string | null>(null)
 
@@ -42,20 +45,26 @@ export function SampleDataSettings() {
       if (kind === 'load') {
         const out = await loadSampleData({})
         setResult(
-          `Loaded ${out.sample.recipes} recipes, ${out.sample.tasks} tasks, ${out.sample.babyEvents} baby events and ${out.sample.diaryEntries} diary entries into “${SAMPLE_GROUP_NAME}”.`,
+          fmt(sampleData.loaded, {
+            recipes: out.sample.recipes,
+            tasks: out.sample.tasks,
+            babyEvents: out.sample.babyEvents,
+            diaryEntries: out.sample.diaryEntries,
+            group: SAMPLE_GROUP_NAME,
+          }),
         )
       } else {
         const out = await resetSampleData({})
         setResult(
-          `Removed ${out.deleted} sample rows${
-            out.orphaned > 0
-              ? ` and ${out.orphaned} ${out.orphaned === 1 ? 'row' : 'rows'} added inside them`
-              : ''
-          }.`,
+          out.orphaned > 0
+            ? fmt(plural(locale, out.orphaned, sampleData.removedWithOrphans), {
+                deleted: out.deleted,
+              })
+            : fmt(sampleData.removed, { deleted: out.deleted }),
         )
       }
     } catch (e) {
-      setError(errorMessage(e, 'Could not run the seed — check the logs.'))
+      setError(errorMessage(e, sampleData.failed))
     } finally {
       setBusy(null)
     }
@@ -63,14 +72,11 @@ export function SampleDataSettings() {
 
   return (
     <SurfaceCard>
-      <h2 className="m-0 mb-1 text-base font-semibold">Sample data</h2>
+      <h2 className="m-0 mb-1 text-base font-semibold">{sampleData.title}</h2>
       <p className="m-0 mb-3 text-sm opacity-70">
-        Rebuilds a sample household around your account, with dates anchored to
-        today. Both actions remove the sample household completely —{' '}
-        <strong>including anything you added inside it</strong>, such as a task
-        on a sample list. Your own groups, your food diary and recipes you own
-        are left alone, and your default group is put back. Not available in
-        production.
+        {sampleData.descriptionBefore}{' '}
+        <strong>{sampleData.descriptionStrong}</strong>
+        {sampleData.descriptionAfter}
       </p>
 
       {error && (
@@ -87,23 +93,19 @@ export function SampleDataSettings() {
           disabled={busy !== null}
           onClick={() => run('load')}
         >
-          {busy === 'load' ? 'Loading…' : 'Load sample data'}
+          {busy === 'load' ? sampleData.loading : sampleData.load}
         </button>
         <button
           type="button"
           className={buttonClass}
           disabled={busy !== null}
           onClick={() => {
-            if (
-              window.confirm(
-                'Remove the sample household, including anything you added inside it? Your own groups, diary and recipes are left alone.',
-              )
-            ) {
+            if (window.confirm(sampleData.confirmRemove)) {
               void run('reset')
             }
           }}
         >
-          {busy === 'reset' ? 'Removing…' : 'Remove sample data'}
+          {busy === 'reset' ? sampleData.removing : sampleData.remove}
         </button>
       </div>
     </SurfaceCard>

--- a/src/components/tasks/AddListFlow.tsx
+++ b/src/components/tasks/AddListFlow.tsx
@@ -7,6 +7,7 @@ import type {
   SourceProperty,
 } from '../../../convex/lib/taskProviders/types'
 import { errorMessage } from '../../lib/errorMessage'
+import { fmt, type Messages, useMessages } from '../../lib/i18n'
 import type { ExternalProvider } from '../../lib/oauth'
 import { SurfaceCard } from '../app/ShellPrimitives'
 import { useConnectProvider } from '../settings/ConnectionsSettings'
@@ -40,6 +41,8 @@ export function AddListFlow({ groupSlug, returnTo, onDone }: AddListFlowProps) {
   const getSourceSchema = useAction(api.integrations.getSourceSchema)
   const createList = useMutation(api.taskLists.create)
   const connect = useConnectProvider(groupSlug, returnTo)
+  const messages = useMessages()
+  const { addList, notionMapping } = messages.tasks
 
   const [step, setStep] = useState<Step>({ kind: 'provider' })
   const [name, setName] = useState('')
@@ -52,7 +55,7 @@ export function AddListFlow({ groupSlug, returnTo, onDone }: AddListFlowProps) {
     try {
       await fn()
     } catch (e) {
-      setError(errorMessage(e, 'Something went wrong — try again.'))
+      setError(errorMessage(e, addList.failed))
     } finally {
       setBusy(false)
     }
@@ -132,13 +135,13 @@ export function AddListFlow({ groupSlug, returnTo, onDone }: AddListFlowProps) {
   return (
     <SurfaceCard>
       <div className="mb-2 flex items-center justify-between">
-        <h3 className="m-0 text-base font-semibold">Add a list</h3>
+        <h3 className="m-0 text-base font-semibold">{addList.title}</h3>
         <button
           type="button"
           className="text-sm text-[var(--app-muted)]"
           onClick={onDone}
         >
-          Cancel
+          {messages.common.actions.cancel}
         </button>
       </div>
       {error && <p className="m-0 mb-2 text-sm text-red-600">{error}</p>}
@@ -150,7 +153,7 @@ export function AddListFlow({ groupSlug, returnTo, onDone }: AddListFlowProps) {
             className={buttonClass}
             onClick={() => setStep({ kind: 'local-name' })}
           >
-            Local list — created and edited here
+            {addList.local}
           </button>
           {(['notion', 'todoist'] as const).map((provider) =>
             connectionFor(provider) ? (
@@ -161,8 +164,9 @@ export function AddListFlow({ groupSlug, returnTo, onDone }: AddListFlowProps) {
                 disabled={busy}
                 onClick={() => void pickExternal(provider)}
               >
-                {provider === 'notion' ? 'Notion' : 'Todoist'} — read-only
-                mirror
+                {fmt(addList.mirror, {
+                  provider: provider === 'notion' ? 'Notion' : 'Todoist',
+                })}
               </button>
             ) : (
               <button
@@ -172,7 +176,9 @@ export function AddListFlow({ groupSlug, returnTo, onDone }: AddListFlowProps) {
                 disabled={busy}
                 onClick={() => void run(() => connect(provider))}
               >
-                Connect {provider === 'notion' ? 'Notion' : 'Todoist'} first…
+                {fmt(addList.connectFirst, {
+                  provider: provider === 'notion' ? 'Notion' : 'Todoist',
+                })}
               </button>
             ),
           )}
@@ -184,12 +190,12 @@ export function AddListFlow({ groupSlug, returnTo, onDone }: AddListFlowProps) {
           <input
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="List name"
-            aria-label="List name"
+            placeholder={addList.listName}
+            aria-label={addList.listName}
             className={`${inputClass} flex-1`}
           />
           <button type="submit" className={buttonClass} disabled={busy}>
-            Create
+            {addList.create}
           </button>
         </form>
       )}
@@ -198,13 +204,14 @@ export function AddListFlow({ groupSlug, returnTo, onDone }: AddListFlowProps) {
         <div className="grid gap-2">
           <p className="m-0 text-sm text-[var(--app-muted)]">
             {step.provider === 'notion'
-              ? 'Pick the Notion database to mirror:'
-              : 'Pick the Todoist project to mirror:'}
+              ? addList.pickNotion
+              : addList.pickTodoist}
           </p>
           {step.sources.length === 0 && (
             <p className="m-0 text-sm text-[var(--app-muted)]">
-              Nothing found — make sure the connection has access to at least
-              one {step.provider === 'notion' ? 'database' : 'project'}.
+              {step.provider === 'notion'
+                ? addList.nothingFoundNotion
+                : addList.nothingFoundTodoist}
             </p>
           )}
           {step.sources.map((source) => (
@@ -223,6 +230,8 @@ export function AddListFlow({ groupSlug, returnTo, onDone }: AddListFlowProps) {
 
       {step.kind === 'notion-mapping' && (
         <NotionMappingForm
+          text={notionMapping}
+          listNameLabel={addList.listName}
           schema={step.schema}
           name={name}
           onNameChange={setName}
@@ -234,13 +243,22 @@ export function AddListFlow({ groupSlug, returnTo, onDone }: AddListFlowProps) {
   )
 }
 
+/**
+ * Takes its words as props rather than reading the context itself — it is
+ * defined below its only caller and rendered by it alone, so threading them
+ * through keeps the whole flow's strings resolved in one place.
+ */
 function NotionMappingForm({
+  text,
+  listNameLabel,
   schema,
   name,
   onNameChange,
   busy,
   onSubmit,
 }: {
+  text: Messages['tasks']['notionMapping']
+  listNameLabel: string
   schema: SourceProperty[]
   name: string
   onNameChange: (name: string) => void
@@ -297,7 +315,7 @@ function NotionMappingForm({
           onChange={(e) => onChange(e.target.value)}
           className={selectClass}
         >
-          {!required && <option value="">Not mapped</option>}
+          {!required && <option value="">{text.notMapped}</option>}
           {options.map((p) => (
             <option key={p.name} value={p.name}>
               {p.name}
@@ -310,47 +328,44 @@ function NotionMappingForm({
 
   return (
     <form onSubmit={submit} className="grid gap-3">
-      <p className="m-0 text-sm text-[var(--app-muted)]">
-        Map this database's properties so gather knows how to read it. A status
-        property counts as done when it is named Done, Complete, or Completed.
-      </p>
+      <p className="m-0 text-sm text-[var(--app-muted)]">{text.intro}</p>
       <label className="grid gap-1 text-sm">
-        List name
+        {listNameLabel}
         <input
           value={name}
           onChange={(e) => onNameChange(e.target.value)}
           className={selectClass}
-          aria-label="List name"
+          aria-label={listNameLabel}
         />
       </label>
       <MappingSelect
-        label="Title property"
+        label={text.titleProperty}
         value={title}
         onChange={setTitle}
         options={titleProps}
         required
       />
       <MappingSelect
-        label="Done property (checkbox or status)"
+        label={text.doneProperty}
         value={done}
         onChange={setDone}
         options={doneProps}
         required
       />
       <MappingSelect
-        label="Due date property"
+        label={text.dueDateProperty}
         value={dueDate}
         onChange={setDueDate}
         options={dateProps}
       />
       <MappingSelect
-        label="Priority property (select named 1–4 or P1–P4)"
+        label={text.priorityProperty}
         value={priority}
         onChange={setPriority}
         options={selectProps}
       />
       <MappingSelect
-        label="Labels property"
+        label={text.labelsProperty}
         value={labels}
         onChange={setLabels}
         options={multiSelectProps}
@@ -360,7 +375,7 @@ function NotionMappingForm({
         disabled={busy || !title || !done}
         className="inline-flex min-h-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold"
       >
-        Create linked list
+        {text.create}
       </button>
     </form>
   )

--- a/src/components/tasks/ExternalTaskList.tsx
+++ b/src/components/tasks/ExternalTaskList.tsx
@@ -6,6 +6,7 @@ import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import type { UnifiedTask } from '../../../convex/lib/taskProviders/types'
 import { groupLink } from '../../lib/groupPaths'
+import { fmt, useMessages } from '../../lib/i18n'
 import { Pill, SurfaceCard } from '../app/ShellPrimitives'
 import { TaskRow } from './TaskRow'
 
@@ -35,15 +36,17 @@ export function ExternalTaskList({
 }: ExternalTaskListProps) {
   const getTasks = useAction(api.taskLists.getTasks)
   const [state, setState] = useState<LoadState>({ status: 'loading' })
+  const messages = useMessages()
+  const { external } = messages.tasks
 
   const load = useCallback(async () => {
     setState({ status: 'loading' })
     try {
       setState(await getTasks({ listId, groupSlug }))
     } catch {
-      setState({ status: 'error', message: 'Could not load this list.' })
+      setState({ status: 'error', message: external.loadFailed })
     }
-  }, [getTasks, listId, groupSlug])
+  }, [getTasks, listId, groupSlug, external.loadFailed])
 
   useEffect(() => {
     void load()
@@ -57,7 +60,7 @@ export function ExternalTaskList({
           <Pill>{PROVIDER_LABELS[provider]}</Pill>
           <button
             type="button"
-            aria-label={`Refresh ${name}`}
+            aria-label={fmt(external.refresh, { name })}
             className="inline-flex items-center text-[var(--app-muted)]"
             onClick={() => void load()}
             disabled={state.status === 'loading'}
@@ -66,7 +69,7 @@ export function ExternalTaskList({
           </button>
           <button
             type="button"
-            aria-label={`Delete list ${name}`}
+            aria-label={fmt(messages.tasks.local.deleteList, { name })}
             className="inline-flex items-center text-[var(--app-muted)]"
             onClick={onRemoveList}
           >
@@ -87,12 +90,13 @@ export function ExternalTaskList({
       )}
       {state.status === 'reconnect' && (
         <p className="m-0 text-sm text-[var(--app-muted)]">
-          The {PROVIDER_LABELS[state.provider]} connection needs to be
-          reconnected.{' '}
+          {fmt(external.reconnect, {
+            provider: PROVIDER_LABELS[state.provider],
+          })}{' '}
           {/* The connection belongs to this Group, so the page that can fix it
               is this Group's settings and not the reader's own. */}
           <Link {...groupLink('settings', groupSlug)} className="font-semibold">
-            Go to group settings
+            {external.goToSettings}
           </Link>
         </p>
       )}
@@ -104,14 +108,14 @@ export function ExternalTaskList({
             className="font-semibold"
             onClick={() => void load()}
           >
-            Retry
+            {messages.common.actions.retry}
           </button>
         </p>
       )}
       {state.status === 'ok' &&
         (state.tasks.length === 0 ? (
           <p className="m-0 text-sm text-[var(--app-muted)]">
-            No open tasks in this {PROVIDER_LABELS[provider]} list.
+            {fmt(external.empty, { provider: PROVIDER_LABELS[provider] })}
           </p>
         ) : (
           state.tasks.map((t) => <TaskRow key={t.externalId} task={t} />)

--- a/src/components/tasks/LocalTaskList.tsx
+++ b/src/components/tasks/LocalTaskList.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronUp, Pencil, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { fmt, useMessages } from '../../lib/i18n'
 import { Pill, SurfaceCard } from '../app/ShellPrimitives'
 import { TaskEditor, type TaskEditorValues } from './TaskEditor'
 import { TaskRow } from './TaskRow'
@@ -33,6 +34,8 @@ export function LocalTaskList({
   const [quickTitle, setQuickTitle] = useState('')
   const [showDetails, setShowDetails] = useState(false)
   const [editingId, setEditingId] = useState<Id<'tasks'> | null>(null)
+  const messages = useMessages()
+  const { local } = messages.tasks
 
   async function quickAdd(e: React.FormEvent) {
     e.preventDefault()
@@ -64,10 +67,10 @@ export function LocalTaskList({
       <div className="mb-2 flex items-center justify-between gap-2">
         <h3 className="m-0 text-base font-semibold">{name}</h3>
         <div className="flex items-center gap-2">
-          <Pill>Local</Pill>
+          <Pill>{local.pill}</Pill>
           <button
             type="button"
-            aria-label={`Delete list ${name}`}
+            aria-label={fmt(local.deleteList, { name })}
             className={iconButtonClass}
             onClick={onRemoveList}
           >
@@ -80,13 +83,13 @@ export function LocalTaskList({
         <input
           value={quickTitle}
           onChange={(e) => setQuickTitle(e.target.value)}
-          placeholder="Add a task…"
-          aria-label={`New task in ${name}`}
+          placeholder={local.quickAdd}
+          aria-label={fmt(local.newTaskIn, { name })}
           className="min-h-9 flex-1 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-transparent px-3 text-sm"
         />
         <button
           type="submit"
-          aria-label="Add task"
+          aria-label={local.addTask}
           className="inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3"
         >
           <Plus className="h-4 w-4" aria-hidden="true" />
@@ -97,11 +100,11 @@ export function LocalTaskList({
         className="mb-2 text-xs text-[var(--app-muted)]"
         onClick={() => setShowDetails((s) => !s)}
       >
-        {showDetails ? 'Hide details' : 'Add with details…'}
+        {showDetails ? local.hideDetails : local.showDetails}
       </button>
       {showDetails && (
         <TaskEditor
-          submitLabel="Add task"
+          submitLabel={local.addTask}
           onSubmit={(values) => void detailedAdd(values)}
           onCancel={() => setShowDetails(false)}
         />
@@ -117,7 +120,7 @@ export function LocalTaskList({
               priority: t.priority,
               labels: t.labels,
             }}
-            submitLabel="Save"
+            submitLabel={messages.common.actions.save}
             onSubmit={(values) => void saveEdit(t._id, values)}
             onCancel={() => setEditingId(null)}
           />
@@ -137,7 +140,7 @@ export function LocalTaskList({
               <span className="flex items-center gap-1">
                 <button
                   type="button"
-                  aria-label={`Move ${t.title} up`}
+                  aria-label={fmt(local.moveUp, { task: t.title })}
                   className={iconButtonClass}
                   disabled={i === 0 || tasks[i - 1].done !== t.done}
                   onClick={() =>
@@ -148,7 +151,7 @@ export function LocalTaskList({
                 </button>
                 <button
                   type="button"
-                  aria-label={`Move ${t.title} down`}
+                  aria-label={fmt(local.moveDown, { task: t.title })}
                   className={iconButtonClass}
                   disabled={
                     i === tasks.length - 1 || tasks[i + 1].done !== t.done
@@ -161,7 +164,7 @@ export function LocalTaskList({
                 </button>
                 <button
                   type="button"
-                  aria-label={`Edit ${t.title}`}
+                  aria-label={fmt(local.edit, { task: t.title })}
                   className={iconButtonClass}
                   onClick={() => setEditingId(t._id)}
                 >
@@ -169,7 +172,7 @@ export function LocalTaskList({
                 </button>
                 <button
                   type="button"
-                  aria-label={`Delete ${t.title}`}
+                  aria-label={fmt(local.delete, { task: t.title })}
                   className={iconButtonClass}
                   onClick={() => void removeTask({ taskId: t._id, groupSlug })}
                 >
@@ -181,7 +184,7 @@ export function LocalTaskList({
         ),
       )}
       {tasks?.length === 0 && (
-        <p className="m-0 text-sm text-[var(--app-muted)]">No tasks yet.</p>
+        <p className="m-0 text-sm text-[var(--app-muted)]">{local.empty}</p>
       )}
     </SurfaceCard>
   )

--- a/src/components/tasks/TaskEditor.tsx
+++ b/src/components/tasks/TaskEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useMessages } from '../../lib/i18n'
 
 export interface TaskEditorValues {
   title: string
@@ -29,6 +30,8 @@ export function TaskEditor({
     initial?.priority ? String(initial.priority) : '',
   )
   const [labels, setLabels] = useState(initial?.labels?.join(', ') ?? '')
+  const messages = useMessages()
+  const { editor } = messages.tasks
 
   function submit(e: React.FormEvent) {
     e.preventDefault()
@@ -51,8 +54,8 @@ export function TaskEditor({
       <input
         value={title}
         onChange={(e) => setTitle(e.target.value)}
-        placeholder="Task title"
-        aria-label="Task title"
+        placeholder={editor.title}
+        aria-label={editor.title}
         className={inputClass}
       />
       <div className="flex flex-wrap gap-2">
@@ -60,26 +63,26 @@ export function TaskEditor({
           type="date"
           value={dueDate}
           onChange={(e) => setDueDate(e.target.value)}
-          aria-label="Due date"
+          aria-label={editor.dueDate}
           className={inputClass}
         />
         <select
           value={priority}
           onChange={(e) => setPriority(e.target.value)}
-          aria-label="Priority"
+          aria-label={editor.priority}
           className={inputClass}
         >
-          <option value="">No priority</option>
-          <option value="1">P1 — urgent</option>
-          <option value="2">P2</option>
-          <option value="3">P3</option>
-          <option value="4">P4</option>
+          <option value="">{editor.noPriority}</option>
+          <option value="1">{editor.p1}</option>
+          <option value="2">{editor.p2}</option>
+          <option value="3">{editor.p3}</option>
+          <option value="4">{editor.p4}</option>
         </select>
         <input
           value={labels}
           onChange={(e) => setLabels(e.target.value)}
-          placeholder="Labels, comma-separated"
-          aria-label="Labels"
+          placeholder={editor.labelsPlaceholder}
+          aria-label={editor.labels}
           className={`${inputClass} flex-1`}
         />
       </div>
@@ -95,7 +98,7 @@ export function TaskEditor({
           onClick={onCancel}
           className="min-h-9 px-2 text-sm text-[var(--app-muted)]"
         >
-          Cancel
+          {messages.common.actions.cancel}
         </button>
       </div>
     </form>

--- a/src/components/tasks/TaskRow.test.tsx
+++ b/src/components/tasks/TaskRow.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
 import { TaskRow } from './TaskRow'
 
 const fullTask = {
@@ -13,7 +14,7 @@ const fullTask = {
 }
 
 test('renders title, priority, labels, due date and link-out', () => {
-  render(<TaskRow task={fullTask} />)
+  renderWithI18n(<TaskRow task={fullTask} />)
   expect(screen.getByText('Buy milk')).toBeInTheDocument()
   expect(screen.getByText('P1')).toBeInTheDocument()
   expect(screen.getByText('home')).toBeInTheDocument()
@@ -27,7 +28,7 @@ test('renders title, priority, labels, due date and link-out', () => {
 
 test('checkbox toggles when onToggle is provided', () => {
   const onToggle = vi.fn()
-  render(
+  renderWithI18n(
     <TaskRow
       task={{ externalId: '1', title: 'x', done: false }}
       onToggle={onToggle}
@@ -40,6 +41,8 @@ test('checkbox toggles when onToggle is provided', () => {
 })
 
 test('done tasks render struck through', () => {
-  render(<TaskRow task={{ externalId: '1', title: 'Old', done: true }} />)
+  renderWithI18n(
+    <TaskRow task={{ externalId: '1', title: 'Old', done: true }} />,
+  )
   expect(screen.getByText('Old').className).toContain('line-through')
 })

--- a/src/components/tasks/TaskRow.tsx
+++ b/src/components/tasks/TaskRow.tsx
@@ -1,6 +1,7 @@
 import { ArrowUpRight } from 'lucide-react'
 import type { ReactNode } from 'react'
 import type { UnifiedTask } from '../../../convex/lib/taskProviders/types'
+import { fmt, useMessages } from '../../lib/i18n'
 
 const PRIORITY_STYLES: Record<1 | 2 | 3 | 4, string> = {
   1: 'bg-red-500/15 text-red-600',
@@ -17,6 +18,8 @@ export interface TaskRowProps {
 }
 
 export function TaskRow({ task, onToggle, actions }: TaskRowProps) {
+  const { row } = useMessages().tasks
+
   return (
     <div className="flex items-center gap-2 py-1.5">
       <input
@@ -24,7 +27,7 @@ export function TaskRow({ task, onToggle, actions }: TaskRowProps) {
         checked={task.done}
         disabled={!onToggle}
         onChange={onToggle}
-        aria-label={`Toggle ${task.title}`}
+        aria-label={fmt(row.toggle, { task: task.title })}
       />
       <span
         className={`min-w-0 flex-1 truncate text-sm ${
@@ -56,7 +59,7 @@ export function TaskRow({ task, onToggle, actions }: TaskRowProps) {
           href={task.url}
           target="_blank"
           rel="noreferrer"
-          aria-label={`Open ${task.title} in its source app`}
+          aria-label={fmt(row.openInSource, { task: task.title })}
           className="text-[var(--app-muted)]"
         >
           <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />

--- a/src/components/tasks/TasksPage.tsx
+++ b/src/components/tasks/TasksPage.tsx
@@ -3,6 +3,7 @@ import { Plus } from 'lucide-react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
+import { fmt, useMessages } from '../../lib/i18n'
 import { useConfirmAction } from '../app/ConfirmAction'
 import { SurfaceCard } from '../app/ShellPrimitives'
 import { AddListFlow } from './AddListFlow'
@@ -30,13 +31,15 @@ export function TasksPage({ groupSlug, nav }: TasksPageProps) {
   const removeList = useMutation(api.taskLists.remove)
   const [adding, setAdding] = useState(false)
   const { confirm, dialog } = useConfirmAction()
+  const messages = useMessages()
+  const { page } = messages.tasks
 
   function confirmRemove(listId: Id<'taskLists'>, name: string) {
     confirm({
-      title: `Delete the list “${name}”?`,
-      body: 'Its tasks go with it, for everyone in this group.',
-      confirmLabel: 'Delete list',
-      errorFallback: 'Could not delete that list.',
+      title: fmt(page.deleteListTitle, { name }),
+      body: page.deleteListBody,
+      confirmLabel: page.deleteListConfirm,
+      errorFallback: page.deleteListFailed,
       run: () => removeList({ listId, groupSlug }),
     })
   }
@@ -51,10 +54,11 @@ export function TasksPage({ groupSlug, nav }: TasksPageProps) {
     <div className="grid gap-4">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <h2 className="m-0 text-2xl font-semibold">Tasks</h2>
+          <h2 className="m-0 text-2xl font-semibold">
+            {messages.modules.byId.tasks.label}
+          </h2>
           <p className="mt-1 text-sm text-[var(--app-muted)]">
-            Shared lists — local ones live here, linked ones mirror Notion or
-            Todoist.
+            {page.subtitle}
           </p>
         </div>
         <button
@@ -63,7 +67,7 @@ export function TasksPage({ groupSlug, nav }: TasksPageProps) {
           className="inline-flex min-h-9 items-center gap-2 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 text-sm font-semibold"
         >
           <Plus className="h-4 w-4" aria-hidden="true" />
-          Add list
+          {page.addList}
         </button>
       </div>
 
@@ -87,16 +91,16 @@ export function TasksPage({ groupSlug, nav }: TasksPageProps) {
       ) : lists.length === 0 && !adding ? (
         <SurfaceCard>
           <div className="grid gap-3 text-center">
-            <h3 className="m-0 text-base font-semibold">No lists yet</h3>
+            <h3 className="m-0 text-base font-semibold">{page.emptyTitle}</h3>
             <p className="m-0 text-sm text-[var(--app-muted)]">
-              Create a local list, or link one from Notion or Todoist.
+              {page.emptyBody}
             </p>
             <button
               type="button"
               onClick={() => setAdding(true)}
               className="mx-auto inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold"
             >
-              Add your first list
+              {page.emptyAction}
             </button>
           </div>
         </SurfaceCard>

--- a/src/lib/appNavigation.test.ts
+++ b/src/lib/appNavigation.test.ts
@@ -7,6 +7,7 @@ import {
   jumpTargets,
   navItems,
 } from './appNavigation'
+import { en } from './i18n/messages/en'
 import { MODULES } from './modules'
 import { DEFAULT_PINS } from './pins'
 
@@ -19,7 +20,7 @@ import { DEFAULT_PINS } from './pins'
 const SLUG = 'jansen-household'
 
 function ids(pins: readonly string[] | undefined, slug: string | null = SLUG) {
-  return navItems(pins, slug).map((item) => item.id)
+  return navItems(pins, slug, en).map((item) => item.id)
 }
 
 describe('the navigation list', () => {
@@ -45,7 +46,7 @@ describe('the navigation list', () => {
   })
 
   test('keeps every pinned link inside the Group I am standing in', () => {
-    for (const item of navItems(['recipes', 'tasks', 'nutrition'], SLUG)) {
+    for (const item of navItems(['recipes', 'tasks', 'nutrition'], SLUG, en)) {
       expect(String(item.link.to).startsWith('/g/$groupSlug')).toBe(true)
     }
   })
@@ -54,25 +55,25 @@ describe('the navigation list', () => {
   // Group to name, so there is nothing to render rather than something to
   // render badly — the surfaces say so in words instead.
   test('is empty off any Group route, however much I have pinned', () => {
-    expect(navItems(['recipes', 'tasks'], null)).toEqual([])
-    expect(navItems(undefined, null)).toEqual([])
-    expect(navItems([], null)).toEqual([])
+    expect(navItems(['recipes', 'tasks'], null, en)).toEqual([])
+    expect(navItems(undefined, null, en)).toEqual([])
+    expect(navItems([], null, en)).toEqual([])
   })
 
   test('marks a Module whose data is only ever mine', () => {
-    const items = navItems(['recipes', 'nutrition'], SLUG)
+    const items = navItems(['recipes', 'nutrition'], SLUG, en)
     const personal = items.filter((item) => item.personal).map((i) => i.id)
     expect(personal).toEqual(['nutrition'])
   })
 
   test('marks a Module that is not built yet', () => {
-    const items = navItems(['recipes', 'wines'], SLUG)
+    const items = navItems(['recipes', 'wines'], SLUG, en)
     expect(items.find((i) => i.id === 'wines')?.placeholder).toBe(true)
     expect(items.find((i) => i.id === 'recipes')?.placeholder).toBe(false)
   })
 
   test('can reach every live Module through All, pinned or not', () => {
-    const list = navItems([], SLUG)
+    const list = navItems([], SLUG, en)
     expect(list.map((i) => i.id)).toContain('all')
     // Nothing is pinned, so every Module is only reachable via All — which is
     // the page that lists all of them.
@@ -82,7 +83,7 @@ describe('the navigation list', () => {
 
 describe('the mobile dock', () => {
   test('shows the whole list when it fits', () => {
-    const items = navItems(['recipes', 'tasks'], SLUG)
+    const items = navItems(['recipes', 'tasks'], SLUG, en)
     expect(dockNavItems(items).map((i) => i.id)).toEqual([
       'home',
       'recipes',
@@ -95,6 +96,7 @@ describe('the mobile dock', () => {
     const items = navItems(
       ['recipes', 'tasks', 'nutrition', 'baby-log', 'wines'],
       SLUG,
+      en,
     )
     const shown = dockNavItems(items)
     expect(shown).toHaveLength(DOCK_SLOTS)
@@ -108,7 +110,7 @@ describe('the mobile dock', () => {
   })
 
   test('copes with someone who has pinned nothing', () => {
-    expect(dockNavItems(navItems([], SLUG)).map((i) => i.id)).toEqual([
+    expect(dockNavItems(navItems([], SLUG, en)).map((i) => i.id)).toEqual([
       'home',
       'all',
     ])
@@ -117,7 +119,7 @@ describe('the mobile dock', () => {
 
 describe('which item is active', () => {
   const pins = ['recipes', 'tasks', 'nutrition']
-  const items = navItems(pins, SLUG)
+  const items = navItems(pins, SLUG, en)
 
   test('is Home on the Group landing page', () => {
     expect(activeNavItemId(`/g/${SLUG}`, items)).toBe('home')
@@ -176,6 +178,7 @@ describe('which item is active', () => {
     const many = navItems(
       ['recipes', 'tasks', 'nutrition', 'baby-log', 'wines'],
       SLUG,
+      en,
     )
     const paths = [
       `/g/${SLUG}`,
@@ -201,6 +204,7 @@ describe('which item is active', () => {
     const many = navItems(
       ['recipes', 'tasks', 'nutrition', 'baby-log', 'wines'],
       SLUG,
+      en,
     )
     expect(dockNavItems(many, 'baby-log').map((i) => i.id)).toEqual([
       'home',
@@ -214,7 +218,7 @@ describe('which item is active', () => {
 
 describe('where the jump-to palette can send you', () => {
   function labels(slug: string | null) {
-    return jumpTargets(slug).map((t) => t.label)
+    return jumpTargets(slug, en).map((t) => t.label)
   }
 
   test('starts at Home and offers All, whatever you have pinned', () => {
@@ -223,13 +227,13 @@ describe('where the jump-to palette can send you', () => {
   })
 
   test('offers every Module, not only the pinned ones', () => {
-    const offered = jumpTargets(SLUG).map((t) => t.id)
+    const offered = jumpTargets(SLUG, en).map((t) => t.id)
     for (const module of MODULES) expect(offered).toContain(module.id)
   })
 
   test('keeps Home, All and every Module in the Group I am standing in', () => {
     const staysFlat = new Set(['settings', 'groups'])
-    for (const target of jumpTargets(SLUG)) {
+    for (const target of jumpTargets(SLUG, en)) {
       if (staysFlat.has(target.id)) continue
       // Every other target names a page inside a Group, and it has to be the
       // Group the reader is standing in.
@@ -239,8 +243,8 @@ describe('where the jump-to palette can send you', () => {
   })
 
   test('sends Home and All to the same places the sidebar does', () => {
-    const nav = navItems([], SLUG)
-    const jump = jumpTargets(SLUG)
+    const nav = navItems([], SLUG, en)
+    const jump = jumpTargets(SLUG, en)
     for (const id of ['home', 'all']) {
       expect(jump.find((t) => t.id === id)?.link).toEqual(
         nav.find((i) => i.id === id)?.link,
@@ -252,7 +256,10 @@ describe('where the jump-to palette can send you', () => {
   // else would have to pick a Group on the reader's behalf, which is the thing
   // the slug in the URL exists to stop (ADR-0002).
   test('offers only the pages that exist without a Group, outside one', () => {
-    expect(jumpTargets(null).map((t) => t.id)).toEqual(['settings', 'groups'])
+    expect(jumpTargets(null, en).map((t) => t.id)).toEqual([
+      'settings',
+      'groups',
+    ])
   })
 
   test('names each destination once', () => {
@@ -262,7 +269,7 @@ describe('where the jump-to palette can send you', () => {
   // A Group's settings and your own are two pages, and the palette is where
   // they are most easily confused: both would otherwise be one word.
   test('offers this Group’s settings, apart from your own', () => {
-    const settings = jumpTargets(SLUG).filter((t) =>
+    const settings = jumpTargets(SLUG, en).filter((t) =>
       t.label.toLowerCase().includes('settings'),
     )
     expect(settings.map((t) => t.label)).toEqual(['Group settings', 'Settings'])
@@ -271,7 +278,7 @@ describe('where the jump-to palette can send you', () => {
   })
 
   test('offers no Group settings when you are standing in no Group', () => {
-    expect(jumpTargets(null).map((t) => t.label)).not.toContain(
+    expect(jumpTargets(null, en).map((t) => t.label)).not.toContain(
       'Group settings',
     )
   })
@@ -279,25 +286,27 @@ describe('where the jump-to palette can send you', () => {
 
 describe('the route context the topbar shows', () => {
   test('names the Group surfaces', () => {
-    expect(getRouteContext(`/g/${SLUG}`).title).toBe('Home')
-    expect(getRouteContext(`/g/${SLUG}/all`).title).toBe('All modules')
+    expect(getRouteContext(`/g/${SLUG}`, en).title).toBe('Home')
+    expect(getRouteContext(`/g/${SLUG}/all`, en).title).toBe('All modules')
   })
 
   test('names the Module you are in, from anywhere inside it', () => {
-    expect(getRouteContext(`/g/${SLUG}/recipes`)).toMatchObject({
+    expect(getRouteContext(`/g/${SLUG}/recipes`, en)).toMatchObject({
       title: 'Recipes',
       subtitle: 'Keep and rate the dishes you cook.',
     })
-    expect(getRouteContext(`/g/${SLUG}/recipes/new`).title).toBe('Recipes')
-    expect(getRouteContext(`/g/${SLUG}/recipes/r1/edit`).title).toBe('Recipes')
+    expect(getRouteContext(`/g/${SLUG}/recipes/new`, en).title).toBe('Recipes')
+    expect(getRouteContext(`/g/${SLUG}/recipes/r1/edit`, en).title).toBe(
+      'Recipes',
+    )
   })
 
   test('names the shell pages', () => {
-    expect(getRouteContext('/settings').title).toBe('Settings')
-    expect(getRouteContext('/account').title).toBe('Account')
+    expect(getRouteContext('/settings', en).title).toBe('Settings')
+    expect(getRouteContext('/account', en).title).toBe('Account')
   })
 
   test('falls back rather than showing an empty header', () => {
-    expect(getRouteContext('/nowhere').title).toBe('Gather')
+    expect(getRouteContext('/nowhere', en).title).toBe('Gather')
   })
 })

--- a/src/lib/appNavigation.ts
+++ b/src/lib/appNavigation.ts
@@ -20,9 +20,33 @@ import {
   moduleLink,
   moduleSegment,
 } from './groupPaths'
-import type { ModuleDef } from './modules'
+import type { Messages } from './i18n/messages/en'
+import type { ModuleDef, ModuleId } from './modules'
 import { MODULES, moduleById } from './modules'
 import { pinnedModules } from './pins'
+
+/**
+ * The strings this file needs to say what it is returning.
+ *
+ * Passed in rather than read from a hook: everything here is a plain function
+ * over plain data, called from tests and from React alike, and importing the
+ * i18n context would end that (ADR-0011). A narrow slice rather than the whole
+ * tree, so the signature says which strings are actually involved.
+ */
+export type NavMessages = Pick<Messages, 'shell' | 'modules'>
+
+/**
+ * What a Module is called and what it is for, in the reader's language.
+ *
+ * The cast is the one place a `ModuleDef.id` is narrowed to a declared id, and
+ * it is safe for the same reason it is needed: every `ModuleDef` in circulation
+ * came out of `MODULES`, and the message tree is typed `Record<ModuleId, …>`
+ * against that same list, but `moduleById` has to accept the arbitrary strings
+ * that arrive from URLs and stored Pins.
+ */
+export function moduleText(module: ModuleDef, messages: NavMessages) {
+  return messages.modules.byId[module.id as ModuleId]
+}
 
 /** Where a navigation item points. */
 export type NavDestination = Pick<
@@ -103,10 +127,14 @@ function allDestination(groupSlug: string): NavDestination {
   return groupLink(ALL, groupSlug)
 }
 
-function moduleItem(module: ModuleDef, groupSlug: string): NavItem {
+function moduleItem(
+  module: ModuleDef,
+  groupSlug: string,
+  messages: NavMessages,
+): NavItem {
   return {
     id: module.id,
-    label: module.label,
+    label: moduleText(module, messages).label,
     icon: module.icon,
     // The shell renders above the route it is showing, so this is the one kind
     // of link a route cannot build. `moduleLink` knows where each Module lives
@@ -134,22 +162,25 @@ function moduleItem(module: ModuleDef, groupSlug: string): NavItem {
 export function navItems(
   pins: readonly string[] | undefined,
   groupSlug: string | null,
+  messages: NavMessages,
 ): NavItem[] {
   if (!groupSlug) return []
 
   return [
     {
       id: HOME,
-      label: 'Home',
+      label: messages.shell.nav.home,
       icon: 'Home',
       link: homeDestination(groupSlug),
       personal: false,
       placeholder: false,
     },
-    ...pinnedModules(pins).map((module) => moduleItem(module, groupSlug)),
+    ...pinnedModules(pins).map((module) =>
+      moduleItem(module, groupSlug, messages),
+    ),
     {
       id: ALL,
-      label: 'All',
+      label: messages.shell.nav.all,
       icon: 'Grid2X2',
       link: allDestination(groupSlug),
       personal: false,
@@ -251,75 +282,64 @@ export interface JumpTarget {
  * under a label that says whose settings they are, because the two would
  * otherwise be one word meaning two things.
  */
-export function jumpTargets(groupSlug: string | null): JumpTarget[] {
+export function jumpTargets(
+  groupSlug: string | null,
+  messages: NavMessages,
+): JumpTarget[] {
+  const nav = messages.shell.nav
   const shellPages: JumpTarget[] = [
-    { id: 'settings', label: 'Settings', link: { to: '/settings' } },
-    { id: 'groups', label: 'Groups', link: { to: '/groups' } },
+    { id: 'settings', label: nav.settings, link: { to: '/settings' } },
+    { id: 'groups', label: nav.groups, link: { to: '/groups' } },
   ]
   if (!groupSlug) return shellPages
 
   return [
-    { id: HOME, label: 'Home', link: homeDestination(groupSlug) },
+    { id: HOME, label: nav.home, link: homeDestination(groupSlug) },
     ...MODULES.map((module) => ({
       id: module.id,
-      label: module.label,
+      label: moduleText(module, messages).label,
       link: moduleLink(module, groupSlug),
     })),
-    { id: ALL, label: 'All', link: allDestination(groupSlug) },
+    { id: ALL, label: nav.all, link: allDestination(groupSlug) },
     {
       id: GROUP_SETTINGS,
-      label: 'Group settings',
+      label: nav.groupSettings,
       link: groupLink('settings', groupSlug),
     },
     ...shellPages,
   ]
 }
 
-const STATIC_ROUTE_CONTEXT: Record<string, RouteContext> = {
-  '/groups': {
-    title: 'Groups',
-    subtitle: 'Manage sharing and membership.',
-  },
-  '/settings': {
-    title: 'Settings',
-    subtitle: 'Tune appearance and app preferences.',
-  },
-  '/account': {
-    title: 'Account',
-    subtitle: 'Manage your profile and sign-in details.',
-  },
-}
+export function getRouteContext(
+  pathname: string,
+  messages: NavMessages,
+): RouteContext {
+  const routes = messages.shell.routes
+  const staticContext: Record<string, RouteContext> = {
+    '/groups': routes.groups,
+    '/settings': routes.settings,
+    '/account': routes.account,
+  }
+  const ownContext: Record<string, RouteContext> = {
+    [HOME]: routes.home,
+    [ALL]: routes.all,
+    [GROUP_SETTINGS]: routes.groupSettings,
+  }
 
-const OWN_ROUTE_CONTEXT: Record<string, RouteContext> = {
-  [HOME]: {
-    title: 'Home',
-    subtitle: 'What your group has been up to.',
-  },
-  [ALL]: {
-    title: 'All modules',
-    subtitle: 'Every module in this group. Pin the ones you use.',
-  },
-  [GROUP_SETTINGS]: {
-    title: 'Group settings',
-    subtitle: 'Settings everyone in this group shares.',
-  },
-}
-
-export function getRouteContext(pathname: string): RouteContext {
-  const staticContext = STATIC_ROUTE_CONTEXT[normalizePath(pathname)]
-  if (staticContext) return staticContext
+  const flat = staticContext[normalizePath(pathname)]
+  if (flat) return flat
 
   const target = navTargetOf(pathname)
-  const own = target ? OWN_ROUTE_CONTEXT[target] : undefined
+  const own = target ? ownContext[target] : undefined
   if (own) return own
 
   const module = target ? moduleById(target) : undefined
-  if (module) return { title: module.label, subtitle: module.description }
-
-  return {
-    title: 'Gather',
-    subtitle: 'Shared plans, modules, and context.',
+  if (module) {
+    const text = moduleText(module, messages)
+    return { title: text.label, subtitle: text.description }
   }
+
+  return routes.fallback
 }
 
 function normalizePath(pathname: string) {

--- a/src/lib/babyDate.test.ts
+++ b/src/lib/babyDate.test.ts
@@ -5,43 +5,61 @@ import {
   toDateInputValue,
   toTimeInputValue,
 } from './babyDate'
+import { en } from './i18n/messages/en'
 
 const DAY = 24 * 60 * 60 * 1000
+
+const AGE = en.baby.log.child.age
 
 describe('formatAge', () => {
   test('under two weeks reports days', () => {
     const birth = '2026-01-01'
     const at = new Date('2026-01-01T00:00:00').getTime() + 5 * DAY
-    expect(formatAge(birth, at)).toBe('5 days old')
+    expect(formatAge(birth, AGE, 'en', at)).toBe('5 days old')
   })
 
   test('singular day', () => {
     const birth = '2026-01-01'
     const at = new Date('2026-01-01T00:00:00').getTime() + 1 * DAY
-    expect(formatAge(birth, at)).toBe('1 day old')
+    expect(formatAge(birth, AGE, 'en', at)).toBe('1 day old')
   })
 
   test('two to eight weeks reports weeks', () => {
     const birth = '2026-01-01'
     const at = new Date('2026-01-01T00:00:00').getTime() + 21 * DAY
-    expect(formatAge(birth, at)).toBe('3 weeks old')
+    expect(formatAge(birth, AGE, 'en', at)).toBe('3 weeks old')
   })
 
   test('two months and beyond reports months', () => {
     expect(
-      formatAge('2026-01-01', new Date('2026-04-01T00:00:00').getTime()),
+      formatAge(
+        '2026-01-01',
+        AGE,
+        'en',
+        new Date('2026-04-01T00:00:00').getTime(),
+      ),
     ).toBe('3 months old')
   })
 
   test('two years and beyond reports years, with leftover months', () => {
     expect(
-      formatAge('2024-01-01', new Date('2026-07-01T00:00:00').getTime()),
+      formatAge(
+        '2024-01-01',
+        AGE,
+        'en',
+        new Date('2026-07-01T00:00:00').getTime(),
+      ),
     ).toBe('2y 6m old')
   })
 
   test('exact whole years with no leftover months', () => {
     expect(
-      formatAge('2024-01-01', new Date('2026-01-01T00:00:00').getTime()),
+      formatAge(
+        '2024-01-01',
+        AGE,
+        'en',
+        new Date('2026-01-01T00:00:00').getTime(),
+      ),
     ).toBe('2 years old')
   })
 })

--- a/src/lib/babyDate.ts
+++ b/src/lib/babyDate.ts
@@ -1,3 +1,6 @@
+import { fmt, plural } from './i18n'
+import type { Messages } from './i18n/messages/en'
+
 const MS_PER_DAY = 24 * 60 * 60 * 1000
 
 /** Whole months between `birth` and `now` (0 if `now` is before `birth`). */
@@ -10,25 +13,33 @@ function monthsBetween(birth: Date, now: Date): number {
 }
 
 /** Age as of `atMs` (defaults to now), e.g. "5 days old", "3 months old". */
+export type AgeMessages = Messages['baby']['log']['child']['age']
+
+/**
+ * How old the child is, in the largest unit that still says something useful.
+ *
+ * The words and the locale come in as arguments: this is a plain function the
+ * PDF export calls too, and English's one/other plural is not every language's
+ * (ADR-0011).
+ */
 export function formatAge(
   birthDate: string,
+  m: AgeMessages,
+  locale: string,
   atMs: number = Date.now(),
 ): string {
   const birth = new Date(`${birthDate}T00:00:00`)
   const now = new Date(atMs)
   const days = Math.max(0, Math.floor((atMs - birth.getTime()) / MS_PER_DAY))
-  if (days < 14) return `${days} day${days === 1 ? '' : 's'} old`
-  if (days < 60) {
-    const weeks = Math.floor(days / 7)
-    return `${weeks} week${weeks === 1 ? '' : 's'} old`
-  }
+  if (days < 14) return plural(locale, days, m.days)
+  if (days < 60) return plural(locale, Math.floor(days / 7), m.weeks)
   const months = monthsBetween(birth, now)
-  if (months < 24) return `${months} month${months === 1 ? '' : 's'} old`
+  if (months < 24) return plural(locale, months, m.months)
   const years = Math.floor(months / 12)
   const remMonths = months % 12
   return remMonths === 0
-    ? `${years} year${years === 1 ? '' : 's'} old`
-    : `${years}y ${remMonths}m old`
+    ? plural(locale, years, m.years)
+    : fmt(m.yearsMonths, { years, months: remMonths })
 }
 
 // `<input type="datetime-local">` renders unpredictably wide on mobile
@@ -55,8 +66,8 @@ export function combineDateTime(dateStr: string, timeStr: string): number {
   return new Date(`${dateStr}T${timeStr || '00:00'}`).getTime()
 }
 
-export function formatEventTimestamp(ms: number): string {
-  return new Date(ms).toLocaleString(undefined, {
+export function formatEventTimestamp(ms: number, locale: string): string {
+  return new Date(ms).toLocaleString(locale, {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
@@ -65,8 +76,8 @@ export function formatEventTimestamp(ms: number): string {
   })
 }
 
-export function formatEventDateHeading(ms: number): string {
-  return new Date(ms).toLocaleDateString(undefined, {
+export function formatEventDateHeading(ms: number, locale: string): string {
+  return new Date(ms).toLocaleDateString(locale, {
     weekday: 'long',
     month: 'long',
     day: 'numeric',

--- a/src/lib/babyEventFields.ts
+++ b/src/lib/babyEventFields.ts
@@ -11,31 +11,22 @@ export const TEMPERATURE_OPTIONS: string[] = Array.from(
   (_, i) => (34 + i * 0.1).toFixed(1),
 )
 
-export const TEMPERATURE_METHOD_LABELS: Record<string, string> = {
-  oral: 'Oral',
-  rectal: 'Rectal',
-  axillary: 'Armpit',
-  ear: 'Ear',
-  forehead: 'Forehead',
-}
+// The option *labels* — how a temperature was taken, which side a feed was
+// on, what was in the diaper — used to live here as four records. They are
+// read by a person, so they are translated, and they now live under
+// `baby.log.options` in each locale's `baby.ts` (ADR-0011). The keys they are
+// stored under are unchanged and remain the schema's business.
 
-export const FEEDING_METHOD_LABELS: Record<string, string> = {
-  breast: 'Breastfeeding',
-  bottle: 'Bottle',
-  solid: 'Solid food',
-}
-
-export const FEEDING_SIDE_LABELS: Record<string, string> = {
-  left: 'Left',
-  right: 'Right',
-  both: 'Both',
-}
-
-export const DIAPER_KIND_LABELS: Record<string, string> = {
-  wet: 'Wet',
-  dirty: 'Dirty',
-  both: 'Both',
-}
+/** The option keys, in the order the selects offer them. */
+export const TEMPERATURE_METHODS = [
+  'oral',
+  'rectal',
+  'axillary',
+  'ear',
+  'forehead',
+] as const
+export const FEEDING_METHODS = ['breast', 'bottle', 'solid'] as const
+export const DIAPER_KINDS = ['wet', 'dirty', 'both'] as const
 
 export const EVENT_TYPE_ICONS: Record<string, string> = {
   temperature: 'Thermometer',

--- a/src/lib/babyEventFormValues.test.ts
+++ b/src/lib/babyEventFormValues.test.ts
@@ -129,7 +129,7 @@ describe('buildEventInput — breast feeds', () => {
     expect(
       buildEventInput('feeding', { method: 'breast', leftMin: '-5' }, START)
         .error,
-    ).toBe('Minutes cannot be negative')
+    ).toBe('negativeMinutes')
   })
 
   test('produces data the server validator accepts', () => {
@@ -168,15 +168,15 @@ describe('buildEventInput — other types', () => {
     expect(built.endTimestamp).toBe(START + 3600000)
   })
 
+  // Keys rather than sentences: the words live in the message tree and the
+  // component that shows the complaint resolves them (ADR-0011).
   test('reports the incomplete-entry errors', () => {
-    expect(buildEventInput('growth', {}, START).error).toBe(
-      'Enter at least one measurement',
-    )
+    expect(buildEventInput('growth', {}, START).error).toBe('enterMeasurement')
     expect(buildEventInput('medication', { name: '  ' }, START).error).toBe(
-      'Enter a medication name',
+      'enterMedicationName',
     )
     expect(buildEventInput('vaccination', { name: '' }, START).error).toBe(
-      'Enter a vaccine name',
+      'enterVaccineName',
     )
   })
 

--- a/src/lib/babyEventFormValues.ts
+++ b/src/lib/babyEventFormValues.ts
@@ -1,7 +1,17 @@
 import type { Doc } from '../../convex/_generated/dataModel'
 import type { BabyEventData, BabyEventType } from '../../convex/lib/babyEvents'
 import { DEFAULT_TEMPERATURE_CELSIUS } from './babyEventFields'
+import type { Messages } from './i18n/messages/en'
 import { readLastUsed, writeLastUsed } from './lastUsed'
+
+/**
+ * Why an entry could not be built, as a key rather than a sentence.
+ *
+ * This is a pure validator called from two forms, and a key keeps it that way:
+ * it never has to be handed a message tree, and the component that renders the
+ * complaint is the one that already knows the reader's language (ADR-0011).
+ */
+export type EventValidationError = keyof Messages['baby']['log']['validation']
 
 /** Flat, string-keyed form state for one event type. Kept as plain values
  * (rather than a `useState` per field) so a single form can hold several
@@ -12,7 +22,7 @@ export interface EventInput {
   data: BabyEventData
   /** Absent means "no end time"; callers editing an event should send null. */
   endTimestamp?: number
-  error?: string
+  error?: EventValidationError
 }
 
 function str(value: string | boolean | undefined): string {
@@ -121,7 +131,7 @@ function buildFeeding(values: EventValues, timestampMs: number): EventInput {
   const leftMin = num(values.leftMin)
   const rightMin = num(values.rightMin)
   if ((leftMin ?? 0) < 0 || (rightMin ?? 0) < 0) {
-    return { data: {}, error: 'Minutes cannot be negative' }
+    return { data: {}, error: 'negativeMinutes' }
   }
 
   // Which side(s) got minutes *is* the side. With no minutes at all, keep
@@ -161,7 +171,7 @@ export function buildEventInput(
     case 'temperature': {
       const celsius = num(values.celsius)
       if (celsius === undefined) {
-        return { data: {}, error: 'Select a temperature' }
+        return { data: {}, error: 'selectTemperature' }
       }
       return { data: { celsius, method: str(values.method) || undefined } }
     }
@@ -180,13 +190,13 @@ export function buildEventInput(
         heightCm === undefined &&
         headCircumferenceCm === undefined
       ) {
-        return { data: {}, error: 'Enter at least one measurement' }
+        return { data: {}, error: 'enterMeasurement' }
       }
       return { data: { weightKg, heightCm, headCircumferenceCm } }
     }
     case 'medication': {
       const name = str(values.name).trim()
-      if (!name) return { data: {}, error: 'Enter a medication name' }
+      if (!name) return { data: {}, error: 'enterMedicationName' }
       return {
         data: {
           name,
@@ -197,7 +207,7 @@ export function buildEventInput(
     }
     case 'vaccination': {
       const name = str(values.name).trim()
-      if (!name) return { data: {}, error: 'Enter a vaccine name' }
+      if (!name) return { data: {}, error: 'enterVaccineName' }
       return { data: { name } }
     }
     case 'note':

--- a/src/lib/babyEventSummary.test.ts
+++ b/src/lib/babyEventSummary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import type { Doc } from '../../convex/_generated/dataModel'
 import { summarizeEvent } from './babyEventSummary'
+import { en } from './i18n/messages/en'
 
 const START = new Date('2026-07-25T09:00:00').getTime()
 
@@ -25,25 +26,29 @@ describe('summarizeEvent — feeding', () => {
     expect(
       summarizeEvent(
         feeding({ method: 'breast', side: 'both', leftMin: 10, rightMin: 8 }),
+        en.baby.log,
       ),
     ).toBe('Breastfeeding · Left 10m · Right 8m')
   })
 
   test('shows only the side that was fed', () => {
     expect(
-      summarizeEvent(feeding({ method: 'breast', side: 'right', rightMin: 7 })),
+      summarizeEvent(
+        feeding({ method: 'breast', side: 'right', rightMin: 7 }),
+        en.baby.log,
+      ),
     ).toBe('Breastfeeding · Right 7m')
   })
 
   test('falls back to the plain side for entries without minutes', () => {
-    expect(summarizeEvent(feeding({ method: 'breast', side: 'left' }))).toBe(
-      'Breastfeeding · Left',
-    )
+    expect(
+      summarizeEvent(feeding({ method: 'breast', side: 'left' }), en.baby.log),
+    ).toBe('Breastfeeding · Left')
   })
 
   test('bottle feeds still show the amount', () => {
-    expect(summarizeEvent(feeding({ method: 'bottle', amountMl: 120 }))).toBe(
-      'Bottle · 120 ml',
-    )
+    expect(
+      summarizeEvent(feeding({ method: 'bottle', amountMl: 120 }), en.baby.log),
+    ).toBe('Bottle · 120 ml')
   })
 })

--- a/src/lib/babyEventSummary.ts
+++ b/src/lib/babyEventSummary.ts
@@ -1,27 +1,43 @@
 import type { Doc } from '../../convex/_generated/dataModel'
-import {
-  DIAPER_KIND_LABELS,
-  FEEDING_METHOD_LABELS,
-  FEEDING_SIDE_LABELS,
-  TEMPERATURE_METHOD_LABELS,
-} from './babyEventFields'
+import { fmt } from './i18n'
+import type { Messages } from './i18n/messages/en'
+
+/**
+ * The words this file needs. Passed in rather than read from a hook: the
+ * timeline renders it from React and the PDF export from a plain function, and
+ * only one of those has a context to read (ADR-0011).
+ */
+export type BabySummaryMessages = Messages['baby']['log']
 
 /** One-line human summary of an event's `data` payload, used in the timeline and PDF export. */
-export function summarizeEvent(event: Doc<'babyEvents'>): string {
+export function summarizeEvent(
+  event: Doc<'babyEvents'>,
+  m: BabySummaryMessages,
+): string {
   const data = event.data as Record<string, unknown>
+  const { options, summary } = m
+
   switch (event.type) {
     case 'temperature': {
       const method =
         typeof data.method === 'string'
-          ? TEMPERATURE_METHOD_LABELS[data.method]
+          ? options.temperatureMethod[
+              data.method as keyof typeof options.temperatureMethod
+            ]
           : undefined
-      const celsius = typeof data.celsius === 'number' ? data.celsius : 0
-      return `${celsius.toFixed(1)}°C${method ? ` (${method})` : ''}`
+      const celsius = (
+        typeof data.celsius === 'number' ? data.celsius : 0
+      ).toFixed(1)
+      return method
+        ? fmt(summary.celsiusWithMethod, { celsius, method })
+        : fmt(summary.celsius, { celsius })
     }
     case 'feeding': {
       const method =
         typeof data.method === 'string'
-          ? (FEEDING_METHOD_LABELS[data.method] ?? data.method)
+          ? (options.feedingMethod[
+              data.method as keyof typeof options.feedingMethod
+            ] ?? data.method)
           : ''
       const amount =
         typeof data.amountMl === 'number' ? ` · ${data.amountMl} ml` : ''
@@ -29,44 +45,59 @@ export function summarizeEvent(event: Doc<'babyEvents'>): string {
       // "Left 10m · Right 8m" already says which side(s).
       const sides: string[] = []
       if (typeof data.leftMin === 'number') {
-        sides.push(`${FEEDING_SIDE_LABELS.left} ${data.leftMin}m`)
+        sides.push(
+          fmt(summary.sideMinutes, {
+            side: options.feedingSide.left,
+            minutes: data.leftMin,
+          }),
+        )
       }
       if (typeof data.rightMin === 'number') {
-        sides.push(`${FEEDING_SIDE_LABELS.right} ${data.rightMin}m`)
+        sides.push(
+          fmt(summary.sideMinutes, {
+            side: options.feedingSide.right,
+            minutes: data.rightMin,
+          }),
+        )
       }
       if (sides.length > 0) {
         return `${method} · ${sides.join(' · ')}${amount}`
       }
       const side =
         typeof data.side === 'string'
-          ? ` · ${FEEDING_SIDE_LABELS[data.side] ?? data.side}`
+          ? ` · ${options.feedingSide[data.side as keyof typeof options.feedingSide] ?? data.side}`
           : ''
       return `${method}${side}${amount}`
     }
     case 'diaper': {
       const kind = typeof data.kind === 'string' ? data.kind : ''
-      return `${DIAPER_KIND_LABELS[kind] ?? kind} diaper`
+      return summary.diaper[kind as keyof typeof summary.diaper] ?? kind
     }
     case 'sleep': {
       if (event.endTimestamp) {
         const mins = Math.round((event.endTimestamp - event.timestamp) / 60000)
-        const h = Math.floor(mins / 60)
-        const m = mins % 60
-        return `Sleep · ${h > 0 ? `${h}h ` : ''}${m}m`
+        const hours = Math.floor(mins / 60)
+        const rest = mins % 60
+        return fmt(summary.sleepFor, {
+          duration: `${hours > 0 ? `${hours}h ` : ''}${rest}m`,
+        })
       }
-      return 'Sleep'
+      return summary.sleep
     }
     case 'growth': {
       const parts: string[] = []
       if (typeof data.weightKg === 'number') parts.push(`${data.weightKg} kg`)
       if (typeof data.heightCm === 'number') parts.push(`${data.heightCm} cm`)
       if (typeof data.headCircumferenceCm === 'number') {
-        parts.push(`head ${data.headCircumferenceCm} cm`)
+        parts.push(
+          fmt(summary.headCircumference, { value: data.headCircumferenceCm }),
+        )
       }
-      return parts.join(' · ') || 'Growth measurement'
+      return parts.join(' · ') || summary.growth
     }
     case 'medication': {
-      const name = typeof data.name === 'string' ? data.name : 'Medication'
+      const name =
+        typeof data.name === 'string' ? data.name : summary.medication
       const dose =
         typeof data.doseAmount === 'number'
           ? ` · ${data.doseAmount}${data.doseUnit ? ` ${data.doseUnit}` : ''}`
@@ -74,9 +105,9 @@ export function summarizeEvent(event: Doc<'babyEvents'>): string {
       return `${name}${dose}`
     }
     case 'vaccination':
-      return typeof data.name === 'string' ? data.name : 'Vaccination'
+      return typeof data.name === 'string' ? data.name : summary.vaccination
     case 'note':
-      return data.milestone === true ? 'Milestone' : 'Note'
+      return data.milestone === true ? summary.milestone : summary.note
     default:
       return ''
   }

--- a/src/lib/babyPdfExport.ts
+++ b/src/lib/babyPdfExport.ts
@@ -2,17 +2,20 @@ import { jsPDF } from 'jspdf'
 import autoTable from 'jspdf-autotable'
 import type { Doc } from '../../convex/_generated/dataModel'
 import type { BabyEventType } from '../../convex/lib/babyEvents'
-import {
-  BABY_EVENT_LABELS,
-  BABY_EVENT_TYPES,
-} from '../../convex/lib/babyEvents'
+import { BABY_EVENT_TYPES } from '../../convex/lib/babyEvents'
 import { formatAge } from './babyDate'
+import type { BabySummaryMessages } from './babyEventSummary'
 import { summarizeEvent } from './babyEventSummary'
+import { fmt } from './i18n'
 
 export type BabyPdfLayout = 'category' | 'chronological'
 
 export interface BabyPdfExportOptions {
   baby: { name: string; birthDate: string }
+  /** The Baby log's words, and the locale to format dates in (ADR-0011). */
+  messages: BabySummaryMessages
+  eventTypes: Record<BabyEventType, string>
+  locale: string
   events: Doc<'babyEvents'>[]
   from: number
   to: number
@@ -74,13 +77,18 @@ function drawHeader(
   baby: { name: string; birthDate: string },
   from: number,
   to: number,
+  m: BabySummaryMessages,
+  locale: string,
 ) {
   doc.setFontSize(16)
-  doc.text(`${baby.name} — baby log`, 14, 18)
+  doc.text(fmt(m.pdf.title, { name: baby.name }), 14, 18)
   doc.setFontSize(10)
   doc.setTextColor(90)
   doc.text(
-    `Born ${new Date(`${baby.birthDate}T00:00:00`).toLocaleDateString()} · ${formatAge(baby.birthDate, to)}`,
+    fmt(m.pdf.born, {
+      date: new Date(`${baby.birthDate}T00:00:00`).toLocaleDateString(locale),
+      age: formatAge(baby.birthDate, m.child.age, locale, to),
+    }),
     14,
     25,
   )
@@ -93,6 +101,8 @@ function drawByCategory(
   doc: jsPDF,
   events: Doc<'babyEvents'>[],
   included: BabyEventType[],
+  m: BabySummaryMessages,
+  eventTypes: Record<BabyEventType, string>,
 ): boolean {
   let cursorY = 40
   let printedAny = false
@@ -110,15 +120,22 @@ function drawByCategory(
     }
 
     doc.setFontSize(12)
-    doc.text(BABY_EVENT_LABELS[type], 14, cursorY)
+    doc.text(eventTypes[type], 14, cursorY)
 
     autoTable(doc, {
       startY: cursorY + 3,
-      head: [['Date', 'Time', 'Details', 'Notes']],
+      head: [
+        [
+          m.pdf.columnDate,
+          m.pdf.columnTime,
+          m.pdf.columnDetails,
+          m.pdf.columnNotes,
+        ],
+      ],
       body: rows.map((e) => [
         formatDate(e.timestamp),
         formatTime(e.timestamp),
-        summarizeEvent(e),
+        summarizeEvent(e, m),
         e.notes ?? '',
       ]),
       ...TABLE_STYLES,
@@ -138,25 +155,34 @@ function drawChronological(
   doc: jsPDF,
   events: Doc<'babyEvents'>[],
   included: BabyEventType[],
+  m: BabySummaryMessages,
+  eventTypes: Record<BabyEventType, string>,
 ): boolean {
   const groups = groupEventsByMinute(events, included)
   if (groups.length === 0) return false
 
   autoTable(doc, {
     startY: 40,
-    head: [['Date', 'Time', 'Entries', 'Notes']],
+    head: [
+      [
+        m.pdf.columnDate,
+        m.pdf.columnTime,
+        m.pdf.columnEntries,
+        m.pdf.columnNotes,
+      ],
+    ],
     body: groups.map((group) => [
       formatDate(group.minuteMs),
       formatTime(group.minuteMs),
       group.events
-        .map((e) => `${BABY_EVENT_LABELS[e.type]}: ${summarizeEvent(e)}`)
+        .map((e) => `${eventTypes[e.type]}: ${summarizeEvent(e, m)}`)
         .join('\n'),
       group.events
         .filter((e) => e.notes)
         .map((e) =>
           // Only worth labelling whose note it is when the row holds several.
           group.events.length > 1
-            ? `${BABY_EVENT_LABELS[e.type]}: ${e.notes}`
+            ? `${eventTypes[e.type]}: ${e.notes}`
             : e.notes,
         )
         .join('\n'),
@@ -171,6 +197,9 @@ function drawChronological(
  * see the Baby log module plan). */
 export function exportBabyLogPdf({
   baby,
+  messages: m,
+  eventTypes,
+  locale,
   events,
   from,
   to,
@@ -180,19 +209,21 @@ export function exportBabyLogPdf({
   const included = types ?? [...BABY_EVENT_TYPES]
   const doc = new jsPDF()
 
-  drawHeader(doc, baby, from, to)
+  drawHeader(doc, baby, from, to, m, locale)
 
   const printedAny =
     layout === 'chronological'
-      ? drawChronological(doc, events, included)
-      : drawByCategory(doc, events, included)
+      ? drawChronological(doc, events, included, m, eventTypes)
+      : drawByCategory(doc, events, included, m, eventTypes)
 
   if (!printedAny) {
     doc.setFontSize(11)
-    doc.text('No entries in this date range.', 14, 40)
+    doc.text(m.pdf.empty, 14, 40)
   }
 
   const dateStamp = new Date(to).toISOString().slice(0, 10)
-  const safeName = baby.name.trim().replace(/\s+/g, '-').toLowerCase() || 'baby'
+  const safeName =
+    baby.name.trim().replace(/\s+/g, '-').toLowerCase() ||
+    m.pdf.fileNameFallback
   doc.save(`${safeName}-log-${dateStamp}.pdf`)
 }

--- a/src/lib/groupActivity.test.ts
+++ b/src/lib/groupActivity.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, test } from 'vitest'
 import {
   ACTIVITY_MODULE_ID,
-  ACTIVITY_PHRASES,
   activityModuleLabel,
+  activityPhrase,
   formatActivityTime,
 } from './groupActivity'
+import { en } from './i18n/messages/en'
+import { nl } from './i18n/messages/nl'
 import { moduleById } from './modules'
 
 /**
  * The client half of an activity entry: which Module it came from, and when.
+ *
+ * The words come in as an argument, so these read the same as they always did
+ * — with `en` passed where the strings used to be hardcoded — and one case at
+ * the end proves the argument is actually being used.
  */
 
 const MINUTE = 60_000
@@ -24,42 +30,64 @@ describe('every kind of entry names a real Module', () => {
   })
 
   test('and is labelled the way the rest of the app labels it', () => {
-    expect(activityModuleLabel('recipe')).toBe('Recipes')
-    expect(activityModuleLabel('task')).toBe('Tasks')
-    expect(activityModuleLabel('babyEvent')).toBe('Baby log')
+    expect(activityModuleLabel('recipe', en)).toBe('Recipes')
+    expect(activityModuleLabel('task', en)).toBe('Tasks')
+    expect(activityModuleLabel('babyEvent', en)).toBe('Baby log')
   })
 
   test('every kind has a sentence to sit in', () => {
     for (const kind of Object.keys(ACTIVITY_MODULE_ID) as Array<
       keyof typeof ACTIVITY_MODULE_ID
     >) {
-      expect(ACTIVITY_PHRASES[kind].verb.length).toBeGreaterThan(0)
+      expect(activityPhrase(kind, en).verb.length).toBeGreaterThan(0)
     }
+  })
+
+  // A recipe entry carries no context, so there is nothing for a connector to
+  // join it to — and no word for a translator to have to invent.
+  test('only the kinds that carry a context have a connector', () => {
+    expect(activityPhrase('recipe', en).connector).toBeNull()
+    expect(activityPhrase('task', en).connector).toBe('to')
+    expect(activityPhrase('babyEvent', en).connector).toBe('for')
   })
 })
 
 describe('when it happened', () => {
   test('the last minute reads as just now', () => {
-    expect(formatActivityTime(NOW - 1_000, NOW)).toBe('Just now')
-    expect(formatActivityTime(NOW, NOW)).toBe('Just now')
+    expect(formatActivityTime(NOW - 1_000, en, 'en', NOW)).toBe('Just now')
+    expect(formatActivityTime(NOW, en, 'en', NOW)).toBe('Just now')
   })
 
   test('a clock running slightly ahead does not produce a negative age', () => {
-    expect(formatActivityTime(NOW + 5_000, NOW)).toBe('Just now')
+    expect(formatActivityTime(NOW + 5_000, en, 'en', NOW)).toBe('Just now')
   })
 
   test('minutes, hours and days, singular and plural', () => {
-    expect(formatActivityTime(NOW - MINUTE, NOW)).toBe('1 minute ago')
-    expect(formatActivityTime(NOW - 5 * MINUTE, NOW)).toBe('5 minutes ago')
-    expect(formatActivityTime(NOW - HOUR, NOW)).toBe('1 hour ago')
-    expect(formatActivityTime(NOW - 5 * HOUR, NOW)).toBe('5 hours ago')
-    expect(formatActivityTime(NOW - DAY, NOW)).toBe('Yesterday')
-    expect(formatActivityTime(NOW - 3 * DAY, NOW)).toBe('3 days ago')
+    const ago = (elapsed: number) =>
+      formatActivityTime(NOW - elapsed, en, 'en', NOW)
+    expect(ago(MINUTE)).toBe('1 minute ago')
+    expect(ago(5 * MINUTE)).toBe('5 minutes ago')
+    expect(ago(HOUR)).toBe('1 hour ago')
+    expect(ago(5 * HOUR)).toBe('5 hours ago')
+    expect(ago(DAY)).toBe('Yesterday')
+    expect(ago(3 * DAY)).toBe('3 days ago')
   })
 
   test('beyond a week it is a date, because "43 days ago" is not an answer', () => {
-    const formatted = formatActivityTime(NOW - 43 * DAY, NOW)
+    const formatted = formatActivityTime(NOW - 43 * DAY, en, 'en', NOW)
     expect(formatted).not.toMatch(/ago/)
     expect(formatted).toMatch(/2026/)
+  })
+
+  // The locale is not decoration: it picks the plural form and formats the
+  // date past a week. Both would look fine in English if it were ignored.
+  test('reads in the locale it was given', () => {
+    expect(formatActivityTime(NOW - MINUTE, nl, 'nl', NOW)).toBe(
+      '1 minuut geleden',
+    )
+    expect(formatActivityTime(NOW - 5 * MINUTE, nl, 'nl', NOW)).toBe(
+      '5 minuten geleden',
+    )
+    expect(formatActivityTime(NOW - DAY, nl, 'nl', NOW)).toBe('Gisteren')
   })
 })

--- a/src/lib/groupActivity.ts
+++ b/src/lib/groupActivity.ts
@@ -7,9 +7,16 @@
  * Module catalog in particular is one `convex/schema.ts` says out loud the
  * backend must not know, and a URL is one `groupPaths.ts` type-checks against
  * the route tree, which Convex cannot do.
+ *
+ * The words themselves come in as an argument rather than out of a hook: this
+ * is a plain module over plain data, and it stays callable from a test without
+ * a React tree around it (ADR-0011).
  */
 
+import { fmt, plural } from '@appelent/i18n'
 import type { ActivityKind } from '../../convex/activity'
+import type { NavMessages } from './appNavigation'
+import { moduleText } from './appNavigation'
 import { moduleById } from './modules'
 
 /** Which Module in `MODULES` each kind of entry came out of. */
@@ -20,8 +27,12 @@ export const ACTIVITY_MODULE_ID: Record<ActivityKind, string> = {
 }
 
 /** The Module an entry belongs to, named as the rest of the app names it. */
-export function activityModuleLabel(kind: ActivityKind): string {
-  return moduleById(ACTIVITY_MODULE_ID[kind])?.label ?? ''
+export function activityModuleLabel(
+  kind: ActivityKind,
+  messages: NavMessages,
+): string {
+  const module = moduleById(ACTIVITY_MODULE_ID[kind])
+  return module ? moduleText(module, messages).label : ''
 }
 
 export function activityModuleIcon(kind: ActivityKind): string {
@@ -38,16 +49,26 @@ export interface ActivityPhrase {
   connector: string | null
 }
 
-export const ACTIVITY_PHRASES: Record<ActivityKind, ActivityPhrase> = {
-  recipe: { verb: 'added the recipe', connector: null },
-  task: { verb: 'added the task', connector: 'to' },
-  // No article: it has to read as well for "Growth" and "Sleep" as it does for
-  // "Feeding", and eight event labels do not share one.
-  babyEvent: { verb: 'logged', connector: 'for' },
+/**
+ * Which kinds take a connector is a fact about the data, not about English, so
+ * it is settled here and the message tree only supplies words. A recipe entry
+ * carries no context, so asking a translator for a connector to put in front of
+ * one would be asking them to invent something.
+ */
+export function activityPhrase(
+  kind: ActivityKind,
+  messages: NavMessages,
+): ActivityPhrase {
+  const { verbs, connectors } = messages.shell.activity
+  switch (kind) {
+    case 'recipe':
+      return { verb: verbs.recipe, connector: null }
+    case 'task':
+      return { verb: verbs.task, connector: connectors.task }
+    case 'babyEvent':
+      return { verb: verbs.babyEvent, connector: connectors.babyEvent }
+  }
 }
-
-/** What the stream calls somebody whose `users` row has since gone. */
-export const UNKNOWN_ACTOR = 'Someone'
 
 const MINUTE = 60_000
 const HOUR = 60 * MINUTE
@@ -60,25 +81,29 @@ const DAY = 24 * HOUR
  * absolute date after that, because "43 days ago" is not an answer anybody
  * wants. A time in the future — a clock skewed by a few seconds, most likely —
  * reads as just now rather than as a negative number of minutes.
+ *
+ * The day count needs no plural form: one day is "Yesterday", so the template
+ * is only ever reached with two or more.
  */
 export function formatActivityTime(
   at: number,
+  messages: NavMessages,
+  locale: string,
   now: number = Date.now(),
 ): string {
+  const time = messages.shell.activity
   const elapsed = now - at
-  if (elapsed < MINUTE) return 'Just now'
+  if (elapsed < MINUTE) return time.justNow
   if (elapsed < HOUR) {
-    const minutes = Math.floor(elapsed / MINUTE)
-    return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+    return plural(locale, Math.floor(elapsed / MINUTE), time.minutesAgo)
   }
   if (elapsed < DAY) {
-    const hours = Math.floor(elapsed / HOUR)
-    return `${hours} hour${hours === 1 ? '' : 's'} ago`
+    return plural(locale, Math.floor(elapsed / HOUR), time.hoursAgo)
   }
   const days = Math.floor(elapsed / DAY)
-  if (days === 1) return 'Yesterday'
-  if (days < 7) return `${days} days ago`
-  return new Date(at).toLocaleDateString(undefined, {
+  if (days === 1) return time.yesterday
+  if (days < 7) return fmt(time.daysAgo, { count: days })
+  return new Date(at).toLocaleDateString(locale, {
     day: 'numeric',
     month: 'short',
     year: 'numeric',

--- a/src/lib/i18n/LanguageSync.tsx
+++ b/src/lib/i18n/LanguageSync.tsx
@@ -1,0 +1,13 @@
+import { createLanguageSync } from '@appelent/i18n/clerk-sync'
+import { hasExplicitLocaleChoice, SUPPORTED_LOCALES, useI18n } from './index'
+
+/**
+ * Mirrors an explicit language choice onto the signed-in user, so it follows
+ * them to another device. The cookie stays the source of truth on this one —
+ * this is a best-effort copy, not a second answer to the same question.
+ */
+export const LanguageSync = createLanguageSync({
+  useI18n,
+  hasExplicitLocaleChoice,
+  locales: SUPPORTED_LOCALES,
+})

--- a/src/lib/i18n/__tests__/messages.test.ts
+++ b/src/lib/i18n/__tests__/messages.test.ts
@@ -1,0 +1,18 @@
+import { assertMessageParity } from '@appelent/i18n/test-utils'
+import { en } from '../messages/en'
+import { nl } from '../messages/nl'
+
+/**
+ * Every locale says the same things, in the same slots, with the same
+ * placeholders.
+ *
+ * `satisfies` in each locale's files already catches a missing or stray *key*
+ * at compile time. This catches what a type cannot see: a string left empty,
+ * and a `{placeholder}` that one locale interpolates and another silently
+ * drops — which is how a translated sentence ends up naming nothing.
+ *
+ * It is also what makes every later extraction provably finished. There is no
+ * app-specific test of `resolveLocale`, `fmt` or `plural` here: those live in
+ * `@appelent/i18n` and are tested there.
+ */
+assertMessageParity({ en, nl })

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,0 +1,29 @@
+import { createI18n } from '@appelent/i18n'
+import { en, type Messages } from './messages/en'
+import { nl } from './messages/nl'
+
+/**
+ * Gather's i18n engine, built once from its own locale set and message tree.
+ *
+ * The engine itself — locale resolution, `fmt`/`plural`, the provider and hooks
+ * — lives in `@appelent/i18n` and is shared across Appelent apps. What is
+ * gather's own is this file's three lines of configuration and everything under
+ * `messages/`. See ADR-0011 for which strings belong there and which do not.
+ */
+export const SUPPORTED_LOCALES = ['en', 'nl'] as const
+export type Locale = (typeof SUPPORTED_LOCALES)[number]
+export type { Messages }
+
+export const {
+  LocaleProvider,
+  useI18n,
+  useMessages,
+  readClientLocale,
+  hasExplicitLocaleChoice,
+} = createI18n<Locale, Messages>({
+  locales: SUPPORTED_LOCALES,
+  fallback: 'en',
+  messages: { en, nl },
+})
+
+export { fmt, plural } from '@appelent/i18n'

--- a/src/lib/i18n/messages/en/baby.ts
+++ b/src/lib/i18n/messages/en/baby.ts
@@ -1,0 +1,214 @@
+import type { BabyEventType } from '../../../../../convex/lib/babyEvents'
+
+/**
+ * The names of the eight things a log entry can be.
+ *
+ * They used to be `BABY_EVENT_LABELS` in `convex/lib/babyEvents.ts`, and unlike
+ * the nutrient and meal labels one Convex function *did* read them —
+ * `activity.ts` put one in each entry's `title`. That was the backend choosing
+ * a display word, so it now sends the type key instead and the client looks it
+ * up here (ADR-0011).
+ */
+export const eventTypes = {
+  temperature: 'Temperature',
+  feeding: 'Feeding',
+  diaper: 'Diaper',
+  sleep: 'Sleep',
+  growth: 'Growth',
+  medication: 'Medication',
+  vaccination: 'Vaccination',
+  note: 'Note',
+} satisfies Record<BabyEventType, string>
+
+export const log = {
+  list: {
+    subtitle:
+      'Temperature, feeding, sleep, growth and more — shared with the group.',
+    addChild: 'Add child',
+    emptyTitle: 'No children yet',
+    emptyBody:
+      'Add a child to start logging temperature, feeding, sleep and more.',
+    emptyAction: 'Add your first child',
+  },
+
+  child: {
+    age: {
+      days: { one: '{count} day old', other: '{count} days old' },
+      weeks: { one: '{count} week old', other: '{count} weeks old' },
+      months: { one: '{count} month old', other: '{count} months old' },
+      years: { one: '{count} year old', other: '{count} years old' },
+      yearsMonths: '{years}y {months}m old',
+    },
+    notFound: 'Child not found.',
+    switch: 'Switch child',
+    todo: 'To-do',
+    todoPlaceholder: 'Buy diapers, call pediatrician…',
+    questions: 'Questions',
+    questionsPlaceholder: 'Ask about sleep regression…',
+    addTo: 'Add to {list}',
+    deleteTask: 'Delete {task}',
+    temperatureTrend: 'Temperature trend',
+    weightTrend: 'Weight trend',
+    checklistEmpty: 'Nothing here — nice.',
+    trendEmpty: 'Log at least two entries to see a trend line.',
+    trendChart: 'Trend chart, {unit}, {count} points',
+  },
+
+  form: {
+    name: 'Name',
+    birthDate: 'Birth date',
+    sex: 'Sex',
+    sexUnspecified: 'Prefer not to say',
+    sexFemale: 'Female',
+    sexMale: 'Male',
+    saveFailed: 'Could not save that child',
+    createTitle: 'Add a child',
+    editTitle: 'Edit {name}',
+    deleteTitle: 'Delete {name}?',
+    deleteBody:
+      'Every entry logged for them goes too, for everyone in this group.',
+    deleteConfirm: 'Delete {name}',
+    deleteFailed: 'Could not delete that child.',
+  },
+
+  quickLog: {
+    heading: 'Log an entry',
+    several: 'Log several',
+  },
+
+  entry: {
+    logTitle: 'Log {type}',
+    editTitle: 'Edit {type}',
+    when: 'When',
+    start: 'Start',
+    notes: 'Notes',
+    saveFailed: 'Could not save this entry',
+  },
+
+  multi: {
+    heading: 'Log several entries',
+    when: 'When',
+    include: 'Include',
+    pickOne: 'Pick at least one thing to log.',
+    save: { one: 'Save {count} entry', other: 'Save {count} entries' },
+    partial: 'Saved {saved} of {total} entries — {detail}',
+  },
+
+  timeline: {
+    empty: 'No entries yet — log the first one above.',
+    deleteEntry: 'Delete {type} entry',
+    deleteTitle: 'Delete this entry?',
+    deleteConfirm: 'Delete entry',
+    deleteFailed: 'Could not delete that entry.',
+  },
+
+  /** The type-specific half of an entry form. */
+  fields: {
+    temperature: 'Temperature (°C)',
+    method: 'Method',
+    notSpecified: 'Not specified',
+    leftMin: 'Left (min)',
+    rightMin: 'Right (min)',
+    amountMl: 'Amount (ml)',
+    end: 'End (optional)',
+    kind: 'Kind',
+    weightKg: 'Weight (kg)',
+    heightCm: 'Height (cm)',
+    headCm: 'Head circ. (cm)',
+    medicationName: 'Name',
+    doseAmount: 'Dose amount',
+    doseUnit: 'Dose unit',
+    doseUnitPlaceholder: 'ml, mg…',
+    vaccineName: 'Vaccine name',
+    milestone: 'Mark as a milestone',
+  },
+
+  /** The vocabulary each of those selects offers. */
+  options: {
+    temperatureMethod: {
+      oral: 'Oral',
+      rectal: 'Rectal',
+      axillary: 'Armpit',
+      ear: 'Ear',
+      forehead: 'Forehead',
+    },
+    feedingMethod: {
+      breast: 'Breastfeeding',
+      bottle: 'Bottle',
+      solid: 'Solid food',
+    },
+    feedingSide: {
+      left: 'Left',
+      right: 'Right',
+      both: 'Both',
+    },
+    diaperKind: {
+      wet: 'Wet',
+      dirty: 'Dirty',
+      both: 'Both',
+    },
+  },
+
+  /** What a form says when it cannot build an entry out of what was typed. */
+  validation: {
+    negativeMinutes: 'Minutes cannot be negative',
+    selectTemperature: 'Select a temperature',
+    enterMeasurement: 'Enter at least one measurement',
+    enterMedicationName: 'Enter a medication name',
+    enterVaccineName: 'Enter a vaccine name',
+  },
+
+  /** The one-line summary under each timeline row, and in the PDF. */
+  summary: {
+    celsiusWithMethod: '{celsius}°C ({method})',
+    celsius: '{celsius}°C',
+    sideMinutes: '{side} {minutes}m',
+    /**
+     * Whole phrases per kind rather than "{kind} diaper": Dutch inflects the
+     * adjective ("natte luier"), so a language that composes the two in English
+     * cannot be assumed to compose them anywhere else.
+     */
+    diaper: {
+      wet: 'Wet diaper',
+      dirty: 'Dirty diaper',
+      both: 'Wet and dirty diaper',
+    },
+    sleepFor: 'Sleep · {duration}',
+    sleep: 'Sleep',
+    headCircumference: 'head {value} cm',
+    growth: 'Growth measurement',
+    medication: 'Medication',
+    vaccination: 'Vaccination',
+    milestone: 'Milestone',
+    note: 'Note',
+  },
+
+  /** The PDF itself, which is a document a person reads like any other. */
+  pdf: {
+    title: '{name} — baby log',
+    born: 'Born {date} · {age}',
+    columnDate: 'Date',
+    columnTime: 'Time',
+    columnDetails: 'Details',
+    columnEntries: 'Entries',
+    columnNotes: 'Notes',
+    empty: 'No entries in this date range.',
+    fileNameFallback: 'baby',
+  },
+
+  export: {
+    button: 'Export PDF',
+    title: 'Export PDF',
+    from: 'From',
+    to: 'To',
+    layout: 'Layout',
+    byCategory: 'By category',
+    chronological: 'Chronological',
+    include: 'Include',
+    download: 'Download PDF',
+    generating: 'Generating…',
+    failed: 'Could not generate the PDF',
+  },
+}
+
+export const baby = { eventTypes, log }

--- a/src/lib/i18n/messages/en/common.ts
+++ b/src/lib/i18n/messages/en/common.ts
@@ -1,0 +1,26 @@
+/**
+ * The base vocabulary: words that mean the same thing wherever they appear.
+ *
+ * Anything that only ever reads correctly in one place belongs to that place's
+ * file instead. A key here is a promise that the same English word is the right
+ * word in every screen that reaches for it — which is why "Save" is here and
+ * "Unpin" is not.
+ */
+export const common = {
+  actions: {
+    start: 'Start',
+    cancel: 'Cancel',
+    close: 'Close',
+    save: 'Save',
+    delete: 'Delete',
+    copy: 'Copy',
+    copied: 'Copied!',
+    retry: 'Try again',
+    back: 'Back',
+  },
+  errors: {
+    somethingWentWrong: 'Something went wrong. Please try again.',
+    notFound: 'Not found.',
+    loading: 'Loading…',
+  },
+}

--- a/src/lib/i18n/messages/en/common.ts
+++ b/src/lib/i18n/messages/en/common.ts
@@ -12,7 +12,12 @@ export const common = {
     cancel: 'Cancel',
     close: 'Close',
     save: 'Save',
+    saving: 'Saving…',
     delete: 'Delete',
+    edit: 'Edit',
+    add: 'Add',
+    confirm: 'Confirm',
+    working: 'Working…',
     copy: 'Copy',
     copied: 'Copied!',
     retry: 'Try again',
@@ -22,5 +27,14 @@ export const common = {
     somethingWentWrong: 'Something went wrong. Please try again.',
     notFound: 'Not found.',
     loading: 'Loading…',
+    didNotWork: 'That did not work — try again.',
+  },
+
+  /** The photo field a recipe and a child's profile both use. */
+  image: {
+    label: 'Photo',
+    uploading: 'Uploading…',
+    failed: 'Could not upload that image',
+    remove: 'Remove photo',
   },
 }

--- a/src/lib/i18n/messages/en/foods.ts
+++ b/src/lib/i18n/messages/en/foods.ts
@@ -1,0 +1,76 @@
+/**
+ * The Foods module's own words.
+ *
+ * A food's name and brand are content — most of them come from Open Food Facts
+ * or from the Catalog seed — and nothing here translates them.
+ */
+export const foods = {
+  list: {
+    title: 'Foods',
+    scanHeading: 'Scan a barcode',
+    search: 'Search foods',
+    searchPlaceholder: 'e.g. hagelslag',
+    addManually: 'Add manually',
+    searching: 'Searching…',
+    noResults: 'No foods found for "{term}".',
+  },
+
+  scanner: {
+    scan: 'Scan barcode',
+    stop: 'Stop camera',
+    cameraDenied:
+      'Camera access was denied or unavailable — enter the barcode number instead.',
+    manualLabel: 'Or enter the barcode number',
+    manualPlaceholder: '8710398160005',
+    lookUp: 'Look up',
+  },
+
+  detail: {
+    notFound: 'Food not found.',
+    builtIn: 'Built-in',
+    builtInNote:
+      'Part of gather’s built-in food catalog, so it can’t be edited. Need a different version?',
+    createYourOwn: 'Create your own food',
+    per100: 'per 100 {unit}',
+    serving: 'Serving: {label}',
+    dataFrom: 'Nutrition data from',
+    openFoodFacts: 'Open Food Facts',
+    odbl: '(ODbL).',
+    refresh: 'Refresh from Open Food Facts',
+    refreshTitle: 'Refresh from Open Food Facts?',
+    refreshBody:
+      'This food is overwritten with the latest data there. Any local edits are replaced.',
+    refreshConfirm: 'Refresh',
+    refreshFailed: 'Could not refresh from Open Food Facts.',
+  },
+
+  form: {
+    name: 'Name',
+    brand: 'Brand',
+    barcode: 'Barcode: {barcode}',
+    baseUnit: 'Base unit',
+    grams: 'grams',
+    milliliters: 'milliliters',
+    nutritionLegend: 'Nutrition per 100 {unit}',
+    servingSize: 'Serving size ({unit})',
+    servingLabel: 'Serving label',
+    servingLabelPlaceholder: 'e.g. "1 slice (30 g)"',
+    save: 'Save food',
+    saveFailed: 'Could not save food',
+  },
+
+  create: {
+    title: 'Add food',
+    lookingUp: 'Looking up barcode…',
+    fromOff: 'From Open Food Facts — review before saving.',
+    offUnreachable:
+      'Couldn’t reach Open Food Facts — fill in the details yourself.',
+  },
+
+  edit: {
+    title: 'Edit food',
+    builtInBefore:
+      'This is part of gather’s built-in food catalog and can’t be edited.',
+    builtInAfter: 'if you need a different version.',
+  },
+}

--- a/src/lib/i18n/messages/en/index.ts
+++ b/src/lib/i18n/messages/en/index.ts
@@ -1,0 +1,14 @@
+import { common } from './common'
+import { modules } from './modules'
+import { settings } from './settings'
+import { shell } from './shell'
+
+export const en = { common, shell, modules, settings }
+
+/**
+ * The shape every other locale has to have. English is the source language:
+ * a string is written here first, and every other locale's file `satisfies`
+ * this, so a missing or stray key is a typecheck failure rather than a hole
+ * somebody notices in production.
+ */
+export type Messages = typeof en

--- a/src/lib/i18n/messages/en/index.ts
+++ b/src/lib/i18n/messages/en/index.ts
@@ -1,9 +1,35 @@
+import { baby } from './baby'
 import { common } from './common'
+import { foods } from './foods'
 import { modules } from './modules'
+import { nutrients } from './nutrients'
+import { nutrition } from './nutrition'
+import { recipes } from './recipes'
 import { settings } from './settings'
 import { shell } from './shell'
+import { tasks } from './tasks'
 
-export const en = { common, shell, modules, settings }
+/**
+ * One area per surface, plus two that cut across them.
+ *
+ * `common` is vocabulary every screen shares. `nutrients` is the nutrient names
+ * and where a set of figures came from — read by Recipes, Nutrition and Foods
+ * alike, which is why it is not inside any of the three. `nutrition` beside it
+ * is the food-diary module itself; the two are easy to confuse and are kept
+ * apart because one is a shared glossary and the other is a screen.
+ */
+export const en = {
+  common,
+  shell,
+  modules,
+  nutrients,
+  recipes,
+  nutrition,
+  foods,
+  tasks,
+  baby,
+  settings,
+}
 
 /**
  * The shape every other locale has to have. English is the source language:

--- a/src/lib/i18n/messages/en/modules.ts
+++ b/src/lib/i18n/messages/en/modules.ts
@@ -1,0 +1,78 @@
+import type { ModuleGroup, ModuleId } from '../../../modules'
+
+/**
+ * What every Module is called and what it is for.
+ *
+ * These used to live in `lib/modules.ts` beside each Module's icon and scope.
+ * They moved because a label is the most-rendered string in the app — sidebar,
+ * dock, topbar title, All, the palette, nine placeholder pages — and a registry
+ * that no React context may reach cannot hold a translated one.
+ *
+ * `satisfies Record<ModuleId, …>` is the part that matters: declaring a Module
+ * without naming it here is a typecheck failure, not a page reading
+ * `undefined`.
+ */
+export const byId = {
+  recipes: {
+    label: 'Recipes',
+    description: 'Keep and rate the dishes you cook.',
+  },
+  nutrition: {
+    label: 'Nutrition',
+    description: 'Log what you eat and track daily targets.',
+  },
+  'meal-planner': {
+    label: 'Meal planner',
+    description: 'Plan the week’s meals.',
+  },
+  groceries: {
+    label: 'Groceries',
+    description: 'A shared shopping list you both check off.',
+  },
+  pantry: {
+    label: 'Pantry',
+    description: 'Track what’s in stock at home.',
+  },
+  finances: {
+    label: 'Finances',
+    description: 'Budgets and spending overview.',
+  },
+  bills: {
+    label: 'Bills & subscriptions',
+    description: 'Recurring bills and subscriptions.',
+  },
+  tasks: {
+    label: 'Tasks',
+    description: 'Shared to-do lists.',
+  },
+  'baby-log': {
+    label: 'Baby log',
+    description: 'Temperature, feeding, sleep, growth and more.',
+  },
+  calendar: {
+    label: 'Calendar',
+    description: 'Household events and reminders.',
+  },
+  notes: {
+    label: 'Notes',
+    description: 'Quick shared notes.',
+  },
+  cheeses: {
+    label: 'Cheeses',
+    description: 'Rate the cheeses you try.',
+  },
+  wines: {
+    label: 'Wines',
+    description: 'Rate the wines you try.',
+  },
+} satisfies Record<ModuleId, { label: string; description: string }>
+
+/** The headings All groups the catalog under. */
+export const groups = {
+  kitchen: 'Kitchen',
+  money: 'Money',
+  home: 'Home & life',
+  tasting: 'Tasting',
+} satisfies Record<ModuleGroup, string>
+
+export const modules = { byId, groups }

--- a/src/lib/i18n/messages/en/nutrients.ts
+++ b/src/lib/i18n/messages/en/nutrients.ts
@@ -1,0 +1,36 @@
+import type {
+  NutrientKey,
+  NutritionSource,
+} from '../../../../../convex/lib/nutrition'
+
+/**
+ * The nutrient names, shared by Recipes, Nutrition and Foods.
+ *
+ * They used to be `NUTRIENT_LABELS` in `convex/lib/nutrition.ts`, beside the
+ * keys and the validator. No Convex function ever read them — only three client
+ * components did — so they were display strings sitting in a backend file that
+ * no message tree could reach. The keys and the shape stayed there, where the
+ * schema needs them; the words came here (ADR-0011).
+ *
+ * The unit is part of the label because it is part of the name a reader knows:
+ * "Protein (g)" is one column heading, not a heading plus a unit to compose.
+ */
+export const labels = {
+  calories: 'Calories (kcal)',
+  protein: 'Protein (g)',
+  carbs: 'Carbs (g)',
+  sugars: 'Sugars (g)',
+  fat: 'Fat (g)',
+  saturatedFat: 'Saturated fat (g)',
+  fiber: 'Fiber (g)',
+  salt: 'Salt (g)',
+} satisfies Record<NutrientKey, string>
+
+/** Where a set of figures came from, said wherever they are shown. */
+export const sources = {
+  imported: 'Imported',
+  ai: 'AI estimate',
+  manual: 'Manual',
+} satisfies Record<NutritionSource, string>
+
+export const nutrients = { labels, sources }

--- a/src/lib/i18n/messages/en/nutrition.ts
+++ b/src/lib/i18n/messages/en/nutrition.ts
@@ -1,0 +1,95 @@
+import type {
+  MealName,
+  QuantityUnit,
+} from '../../../../../convex/lib/consumption'
+
+/**
+ * Meal names, moved out of `convex/lib/consumption.ts` for the same reason the
+ * nutrient labels left `lib/nutrition.ts`: no Convex function read them, three
+ * client components did, and they are words a person reads (ADR-0011).
+ */
+export const meals = {
+  breakfast: 'Breakfast',
+  lunch: 'Lunch',
+  dinner: 'Dinner',
+  snack: 'Snack',
+} satisfies Record<MealName, string>
+
+/** How much of something was eaten. Grams and millilitres are symbols, not words. */
+export const units = {
+  serving: 'serving',
+  g: 'g',
+  ml: 'ml',
+  piece: 'piece',
+} satisfies Record<QuantityUnit, string>
+
+export const diary = {
+  personalNote:
+    'Yours alone. Nobody else in the group can see it, and it looks the same whichever group you are in.',
+  prevDay: '← Prev',
+  nextDay: 'Next →',
+
+  totalsToday: "Today's totals",
+  totalsOn: 'Totals — {date}',
+
+  targets: {
+    title: 'Daily targets',
+    save: 'Save targets',
+    saveFailed: 'Could not save targets',
+  },
+
+  slot: {
+    add: '+ Add',
+    empty: 'Nothing logged yet.',
+  },
+
+  entry: {
+    viewRecipe: 'View recipe',
+    viewFood: 'View food',
+    quantity: 'Qty',
+    meal: 'Meal',
+    date: 'Date',
+    saveFailed: 'Could not save changes',
+  },
+
+  add: {
+    title: 'Add to {meal}',
+    tabs: {
+      recipes: 'Recipes',
+      foods: 'Foods',
+      quick: 'Quick add',
+    },
+  },
+
+  quickAdd: {
+    label: 'Label',
+    placeholder: 'e.g. "Restaurant meal"',
+    adding: 'Adding…',
+    failed: 'Could not log this',
+  },
+
+  recipeAdd: {
+    none: 'No recipes with nutrition data yet.',
+    servings: 'servings',
+    failed: 'Could not log this recipe',
+    withoutNutrition: 'These recipes have no nutrition data yet:',
+  },
+
+  foodAdd: {
+    lookingUp: 'Looking up…',
+    barcodeFailed: 'Couldn’t look up that barcode — try again.',
+    addFailed: 'Couldn’t add that item — try again.',
+    notFound: 'Not found.',
+    addToLibrary: 'Add it to the foods library',
+    addToLibraryAfter: 'first.',
+    searchPlaceholder: 'Search foods…',
+    searching: 'Searching Open Food Facts…',
+    searchFailed: 'Couldn’t search Open Food Facts.',
+    fromOff: 'From Open Food Facts',
+    perHundred: '{calories} kcal/100g',
+    pieceOf: 'piece ({size}{unit})',
+    logFailed: 'Could not log this food',
+  },
+}
+
+export const nutrition = { meals, units, diary }

--- a/src/lib/i18n/messages/en/recipes.ts
+++ b/src/lib/i18n/messages/en/recipes.ts
@@ -1,0 +1,101 @@
+/**
+ * The Recipes module's own words.
+ *
+ * A recipe's title, its ingredients, its steps and its tags are content — the
+ * person who typed them chose those words, and nothing here translates them.
+ * What is here is the frame around them.
+ */
+export const recipes = {
+  list: {
+    subtitle: 'Keep and rate the dishes this group cooks.',
+    add: 'Add recipe',
+    emptyTitle: 'No recipes yet',
+    emptyBody: 'Add the first recipe to make this module useful for the group.',
+    emptyAction: 'Add your first recipe',
+  },
+
+  viewMode: {
+    label: 'Recipe view',
+    grid: 'Grid view',
+    banner: 'Banner view',
+    compact: 'Compact view',
+  },
+
+  rating: {
+    label: 'Rating',
+    stars: { one: '{count} star', other: '{count} stars' },
+  },
+
+  /**
+   * Split around the Group's name, which is rendered in bold between the two
+   * halves, and split again on whether the Group was chosen or fallen back to.
+   */
+  destination: {
+    prefix: 'Adding to',
+    suffix: '.',
+    fallbackSuffix:
+      '— your personal group, because this page is not inside one.',
+  },
+
+  form: {
+    title: 'Title',
+    description: 'Description',
+    ingredients: 'Ingredients',
+    steps: 'Steps',
+    tags: 'Tags',
+    onePerLine: 'One per line',
+    commaSeparated: 'comma, separated',
+    nutritionLegend: 'Nutrition (per serving)',
+    servings: 'Servings',
+    servingsPlaceholder: '4',
+    estimate: 'Estimate with AI',
+    estimating: 'Estimating…',
+    estimateFailed: 'Could not estimate nutrition',
+    save: 'Save recipe',
+    saveFailed: 'Could not save recipe',
+  },
+
+  create: {
+    title: 'New recipe',
+    importLabel: 'Import from URL',
+    importPlaceholder: 'https://example.com/some-recipe',
+    import: 'Import',
+    importing: 'Importing…',
+    imported: 'Imported — review the details below, then save.',
+    importFailed: 'Could not import that recipe',
+  },
+
+  edit: {
+    title: 'Edit recipe',
+  },
+
+  detail: {
+    notFound: 'Recipe not found.',
+    deleteFailed: 'Could not delete recipe',
+    addedBy: 'Added by {name}',
+    importedFrom: 'Imported from',
+    staleNutrition:
+      'Ingredients changed since nutrition was calculated — re-estimate?',
+    reEstimate: 'Re-estimate with AI',
+    editManually: 'Edit manually',
+    perServing: 'per serving',
+    perServingOf: 'per serving · {count} servings',
+    nutrition: 'Nutrition',
+  },
+
+  sharing: {
+    title: 'Groups',
+    livesIn: 'Lives in',
+    unknownGroup: 'a group you are in',
+    notShared: 'Not shared with any other group.',
+    sharedWith: 'Shared with {group}',
+    unshare: 'Unshare',
+    onlyOneGroup:
+      'You are only in one group, so there is nowhere to move or share this to yet.',
+    moveTo: 'Move to',
+    move: 'Move',
+    shareWith: 'Share with',
+    share: 'Share',
+    chooseGroup: 'Choose a group…',
+  },
+}

--- a/src/lib/i18n/messages/en/settings.ts
+++ b/src/lib/i18n/messages/en/settings.ts
@@ -18,4 +18,85 @@ export const settings = {
       'Connections to Notion and Todoist belong to a group, not to you — every member of that group can use one, and nobody outside it can. Each group keeps its own.',
     open: 'Settings',
   },
+
+  groupPage: {
+    title: '{group} settings',
+    intro:
+      'Settings shared by everyone in this group. Your own appearance and account settings are in Settings, and are the same in every group.',
+  },
+
+  connections: {
+    title: 'Connections',
+    intro:
+      'Connect an external app for {group}. Every member of {group} can use it — Tasks can mirror a list from it — and nobody outside can.',
+    notConnected: 'Not connected',
+    connectedBy: '{account} — connected by {name}',
+    connect: 'Connect',
+    opening: 'Opening…',
+    disconnect: 'Disconnect',
+    disconnectTitle: 'Disconnect {provider} from {group}?',
+    disconnectBody: 'Linked lists stop loading until it is reconnected.',
+    disconnectFailed: 'Could not disconnect {provider}.',
+    startFailed: 'Could not start the connection — try again.',
+  },
+
+  group: {
+    title: 'This group',
+    personalNote:
+      'Your personal group. It is only ever yours, so there is nothing here to share or leave.',
+    sharedNote: 'Its name, the code that lets somebody in, and the way out.',
+    name: 'Name',
+    rename: 'Rename',
+    renameFailed: 'Could not rename this group.',
+    addressChanges:
+      'The address changes with the name, so old links to this group stop working.',
+    inviteCode: 'Invite code',
+    inviteCodeNote:
+      'Anyone holding this code can join from Groups — share it only with people you want in this group.',
+    leave: 'Leave',
+    leaveButton: 'Leave this group',
+    leaveTitle: 'Leave {group}?',
+    leaveBody:
+      'You stop seeing everything in it. Anything you added stays with the group.',
+    leaveConfirm: 'Leave group',
+    leaveFailed: 'Could not leave this group.',
+  },
+
+  members: {
+    title: 'Members',
+    personalNote:
+      'Admins can rename this group, change roles, and delete it. Everyone else can use everything in it.',
+    sharedNote:
+      'Admins can rename this group and change roles. Everyone here can use everything in it.',
+    you: 'You',
+    admin: 'Admin',
+    lastAdmin: 'A group needs at least one admin',
+    makeMember: 'Make member',
+    makeAdmin: 'Make admin',
+    roleFailed: 'Could not change that role.',
+  },
+
+  sampleData: {
+    title: 'Sample data',
+    descriptionBefore:
+      'Rebuilds a sample household around your account, with dates anchored to today. Both actions remove the sample household completely —',
+    descriptionStrong: 'including anything you added inside it',
+    descriptionAfter:
+      ', such as a task on a sample list. Your own groups, your food diary and recipes you own are left alone, and your default group is put back. Not available in production.',
+    load: 'Load sample data',
+    loading: 'Loading…',
+    remove: 'Remove sample data',
+    removing: 'Removing…',
+    confirmRemove:
+      'Remove the sample household, including anything you added inside it? Your own groups, diary and recipes are left alone.',
+    loaded:
+      'Loaded {recipes} recipes, {tasks} tasks, {babyEvents} baby events and {diaryEntries} diary entries into “{group}”.',
+    removed: 'Removed {deleted} sample rows.',
+    removedWithOrphans: {
+      one: 'Removed {deleted} sample rows and {count} row added inside them.',
+      other:
+        'Removed {deleted} sample rows and {count} rows added inside them.',
+    },
+    failed: 'Could not run the seed — check the logs.',
+  },
 }

--- a/src/lib/i18n/messages/en/settings.ts
+++ b/src/lib/i18n/messages/en/settings.ts
@@ -1,0 +1,21 @@
+export const settings = {
+  title: 'Settings',
+
+  language: {
+    title: 'Language',
+    description:
+      'Which language Gather itself is in. What you and your groups have written stays in the language you wrote it.',
+    /** The name of each language in that language, as a speaker of it writes it. */
+    names: {
+      en: 'English',
+      nl: 'Nederlands',
+    },
+  },
+
+  groupSettings: {
+    title: 'Group settings',
+    description:
+      'Connections to Notion and Todoist belong to a group, not to you — every member of that group can use one, and nobody outside it can. Each group keeps its own.',
+    open: 'Settings',
+  },
+}

--- a/src/lib/i18n/messages/en/shell.ts
+++ b/src/lib/i18n/messages/en/shell.ts
@@ -125,9 +125,105 @@ export const shell = {
     goHome: 'Go to Gather',
   },
 
+  /** The gate in front of every `/g/<slug>` page. */
+  groupGate: {
+    unknownTitle: 'No such group',
+    unknownBody:
+      'Nothing here is called “{slug}”. Check the link, or pick a group from the sidebar.',
+    forbiddenTitle: 'This group is not yours',
+    forbiddenBody:
+      'You are not a member of it. Ask an admin of the group for an invite.',
+  },
+
+  /** The Groups page: the households you are in, and the two ways to get another. */
+  groups: {
+    title: 'Groups',
+    intro:
+      'The households you are in. Open one to change its name, share its invite code, or leave it.',
+    yours: 'Your groups',
+    personal: 'Personal',
+    createTitle: 'New group',
+    createBody: 'A household of your own. You start as its admin.',
+    createPlaceholder: 'e.g. Wine club',
+    createLabel: 'New group name',
+    create: 'Create',
+    createFailed: 'Could not create that group.',
+    joinTitle: 'Join with a code',
+    joinBody: "Somebody in the group finds it in that group's settings.",
+    joinPlaceholder: '8-char code',
+    joinLabel: 'Invite code',
+    join: 'Join',
+    joinFailed: 'Could not join with that code.',
+  },
+
+  /** What the app layout says while the session is still settling. */
+  session: {
+    stalledTitle: 'Could not finish signing in',
+    stalledBody:
+      'Gather could not connect your session to the backend. Reloading usually fixes it.',
+    reload: 'Reload',
+  },
+
+  /** The page a provider's OAuth round-trip comes back to. */
+  oauthCallback: {
+    finishing: 'Finishing the connection…',
+    failedTitle: 'Connection failed',
+    backToSettings: 'Back to settings',
+    cancelled: 'The connection was cancelled or refused.',
+    invalid: 'Invalid connection response — try connecting again.',
+    noGroup:
+      'That connection came back without a group — start it again from the group’s settings page.',
+    failed: 'Connecting failed — try again.',
+  },
+
+  /** The public About page. */
+  about: {
+    eyebrow: 'About Gather',
+    title: 'One shared group for everyday coordination',
+    subtitle:
+      'Gather keeps shared recipes, plans, lists, tasks, notes, and tasting logs in one place, for the people who share a household.',
+    modules:
+      'Recipes and Nutrition are live today, and the surrounding modules are staged so a group can grow into meal planning, groceries, pantry tracking, finances, bills, tasks, calendar, notes, cheeses, and wines without changing products.',
+    pins: "Every module is available in every group. You pin the ones you use to your own navigation, and the rest stay one click away — your choices are yours alone and never move anybody else's.",
+  },
+
   publicFrame: {
     brand: 'Gather',
     tagline: 'Household plans, shared',
+  },
+
+  /** The panel the topbar's Ask Gather button opens. */
+  gatherPanel: {
+    title: 'Ask Gather',
+    close: 'Close Ask Gather',
+    context: 'Context: {page}',
+    preview: 'Preview',
+    notConnected:
+      'Automation is not connected yet. Use this panel as a command scratchpad for the active group; real actions will arrive in a later feature.',
+    tryAsking: 'Try asking',
+    prompts: {
+      recent: 'Show me what changed recently',
+      plan: 'Draft a plan for this group',
+      summarize: 'Summarize this page',
+    },
+    placeholder: 'Ask Gather to help with this group...',
+  },
+
+  /** The modal behind the topbar's bug button and Ctrl+Shift+I. */
+  issueReporter: {
+    title: 'Report an issue',
+    types: {
+      bug: 'Bug',
+      enhancement: 'Enhancement',
+      docs: 'Docs',
+      question: 'Question',
+    },
+    placeholder: 'What happened, or what would you like to see?',
+    send: 'Send',
+    sending: 'Sending…',
+    filed: 'Thanks — your report was filed.',
+    viewIssue: 'View issue',
+    unreachable: 'Could not reach the server.',
   },
 
   home: {

--- a/src/lib/i18n/messages/en/shell.ts
+++ b/src/lib/i18n/messages/en/shell.ts
@@ -1,0 +1,188 @@
+/**
+ * The app around the app: navigation, the topbar, the Group switcher, the
+ * pages that are not a Module, and the words Home puts around an activity
+ * entry.
+ *
+ * Grouped by the surface that renders each one, and named for what the string
+ * means rather than where it sits — a key called after its position stops being
+ * true the first time the layout moves.
+ */
+export const shell = {
+  topbar: {
+    openNavigation: 'Open navigation',
+    jumpTo: 'Jump to',
+    askGather: 'Ask Gather',
+    reportIssue: 'Report an issue',
+    switchLanguage: 'Switch to {language}',
+  },
+
+  sidebar: {
+    label: 'Gather navigation',
+    primary: 'Primary',
+    footer: 'Settings and groups',
+    noGroup: 'Pick a group to see its modules.',
+  },
+
+  dock: {
+    label: 'Mobile navigation',
+  },
+
+  drawer: {
+    label: 'Navigation',
+    close: 'Close navigation',
+  },
+
+  palette: {
+    placeholder: 'Jump to…',
+  },
+
+  groupSwitcher: {
+    label: 'Switch group',
+    none: 'No group',
+    elsewhere: 'Go back to it',
+    personal: 'Your own group',
+    shared: 'Shared group',
+    pick: 'Pick a group',
+    personalPill: 'Personal',
+    manage: 'Manage groups',
+  },
+
+  /** The marks a Module carries wherever it is listed. */
+  marks: {
+    soon: 'Soon',
+    onlyYou: 'Only you',
+    onlyYouExplained: 'Only you can see this. It is the same in every group.',
+  },
+
+  /** Navigation item names that belong to no Module. */
+  nav: {
+    home: 'Home',
+    all: 'All',
+    groups: 'Groups',
+    settings: 'Settings',
+    groupSettings: 'Group settings',
+  },
+
+  /** What the topbar says it is showing you, per surface. */
+  routes: {
+    home: {
+      title: 'Home',
+      subtitle: 'What your group has been up to.',
+    },
+    all: {
+      title: 'All modules',
+      subtitle: 'Every module in this group. Pin the ones you use.',
+    },
+    groupSettings: {
+      title: 'Group settings',
+      subtitle: 'Settings everyone in this group shares.',
+    },
+    groups: {
+      title: 'Groups',
+      subtitle: 'Manage sharing and membership.',
+    },
+    settings: {
+      title: 'Settings',
+      subtitle: 'Tune appearance and app preferences.',
+    },
+    account: {
+      title: 'Account',
+      subtitle: 'Manage your profile and sign-in details.',
+    },
+    fallback: {
+      title: 'Gather',
+      subtitle: 'Shared plans, modules, and context.',
+    },
+  },
+
+  allModules: {
+    title: 'All modules',
+    intro:
+      'Every module is available in this group. Pinning one keeps it in your own navigation here — nobody else in the group sees your choices, and your other groups keep their own.',
+    yourPins: 'Your pins',
+    nothingPinned:
+      'Nothing pinned. Pin a module below to keep it in your navigation.',
+    pin: 'Pin',
+    unpin: 'Unpin',
+    pinModule: 'Pin {module}',
+    unpinModule: 'Unpin {module}',
+    moveUp: 'Move {module} up',
+    moveDown: 'Move {module} down',
+  },
+
+  placeholder: {
+    planned: 'Module planned',
+    whatWillLiveHere: 'What will live here',
+    body: 'This module is listed in every group already, so navigation, sharing, and the mobile layout are ready before the full workflow is implemented.',
+  },
+
+  notFound: {
+    eyebrow: 'Not found',
+    title: 'Page not found',
+    subtitle: 'Gather has no page at this address.',
+    signIn: 'Sign in',
+    body: 'The page may have moved, or the link may point to a module that has not been added yet.',
+    goHome: 'Go to Gather',
+  },
+
+  publicFrame: {
+    brand: 'Gather',
+    tagline: 'Household plans, shared',
+  },
+
+  home: {
+    personalSubtitle: 'Your own group. Anything kept here is private to you.',
+    sharedSubtitle: 'What everyone in this group has been up to.',
+    whoIsHere: 'Who is here',
+    admin: 'Admin',
+    /**
+     * Split around the link it contains rather than assembled from one string,
+     * so a translation can put the sentence in its own order without either
+     * half having to carry markup.
+     */
+    personalNote: {
+      before:
+        '{group} is yours alone — nothing kept here is visible to anybody else. To share something with other people, start a group with them in',
+      link: 'Groups',
+      after: '.',
+    },
+    sharedNote: {
+      before:
+        'Everyone here sees everything in {group}. To invite somebody else, or to leave, go to',
+      link: 'Groups',
+      after: '.',
+    },
+    recentActivity: 'Recent activity',
+    nothingYet: 'Nothing has happened in {group} yet.',
+    nothingYetPersonal:
+      'Whatever you add here appears in this list, and only you will ever see it.',
+    nothingYetShared:
+      'Whatever anybody here adds appears in this list, with their name on it.',
+  },
+
+  /**
+   * The sentence Home builds around an activity entry, and when it happened.
+   *
+   * Verbs and connectors are two lists rather than one record of pairs because
+   * a recipe entry has no connector at all — which kinds take one is a fact
+   * about the data, settled in `groupActivity.ts`, not something a translator
+   * should have to invent a word for.
+   */
+  activity: {
+    unknownActor: 'Someone',
+    verbs: {
+      recipe: 'added the recipe',
+      task: 'added the task',
+      babyEvent: 'logged',
+    },
+    connectors: {
+      task: 'to',
+      babyEvent: 'for',
+    },
+    justNow: 'Just now',
+    minutesAgo: { one: '{count} minute ago', other: '{count} minutes ago' },
+    hoursAgo: { one: '{count} hour ago', other: '{count} hours ago' },
+    yesterday: 'Yesterday',
+    daysAgo: '{count} days ago',
+  },
+}

--- a/src/lib/i18n/messages/en/tasks.ts
+++ b/src/lib/i18n/messages/en/tasks.ts
@@ -1,0 +1,90 @@
+/**
+ * The Tasks module's own words.
+ *
+ * A task's title, a list's name, and the labels a household invents are
+ * content. So is anything mirrored from Notion or Todoist — those rows belong
+ * to the other app, and gather only reads them.
+ */
+export const tasks = {
+  page: {
+    subtitle:
+      'Shared lists — local ones live here, linked ones mirror Notion or Todoist.',
+    addList: 'Add list',
+    emptyTitle: 'No lists yet',
+    emptyBody: 'Create a local list, or link one from Notion or Todoist.',
+    emptyAction: 'Add your first list',
+    deleteListTitle: 'Delete the list “{name}”?',
+    deleteListBody: 'Its tasks go with it, for everyone in this group.',
+    deleteListConfirm: 'Delete list',
+    deleteListFailed: 'Could not delete that list.',
+  },
+
+  row: {
+    toggle: 'Toggle {task}',
+    openInSource: 'Open {task} in its source app',
+  },
+
+  local: {
+    pill: 'Local',
+    deleteList: 'Delete list {name}',
+    quickAdd: 'Add a task…',
+    newTaskIn: 'New task in {name}',
+    addTask: 'Add task',
+    showDetails: 'Add with details…',
+    hideDetails: 'Hide details',
+    empty: 'No tasks yet.',
+    moveUp: 'Move {task} up',
+    moveDown: 'Move {task} down',
+    edit: 'Edit {task}',
+    delete: 'Delete {task}',
+  },
+
+  external: {
+    refresh: 'Refresh {name}',
+    loadFailed: 'Could not load this list.',
+    reconnect: 'The {provider} connection needs to be reconnected.',
+    goToSettings: 'Go to group settings',
+    empty: 'No open tasks in this {provider} list.',
+  },
+
+  editor: {
+    title: 'Task title',
+    dueDate: 'Due date',
+    priority: 'Priority',
+    noPriority: 'No priority',
+    p1: 'P1 — urgent',
+    p2: 'P2',
+    p3: 'P3',
+    p4: 'P4',
+    labels: 'Labels',
+    labelsPlaceholder: 'Labels, comma-separated',
+  },
+
+  addList: {
+    title: 'Add a list',
+    local: 'Local list — created and edited here',
+    mirror: '{provider} — read-only mirror',
+    connectFirst: 'Connect {provider} first…',
+    listName: 'List name',
+    create: 'Create',
+    failed: 'Something went wrong — try again.',
+    pickNotion: 'Pick the Notion database to mirror:',
+    pickTodoist: 'Pick the Todoist project to mirror:',
+    nothingFoundNotion:
+      'Nothing found — make sure the connection has access to at least one database.',
+    nothingFoundTodoist:
+      'Nothing found — make sure the connection has access to at least one project.',
+  },
+
+  notionMapping: {
+    intro:
+      'Map this database’s properties so gather knows how to read it. A status property counts as done when it is named Done, Complete, or Completed.',
+    notMapped: 'Not mapped',
+    titleProperty: 'Title property',
+    doneProperty: 'Done property (checkbox or status)',
+    dueDateProperty: 'Due date property',
+    priorityProperty: 'Priority property (select named 1–4 or P1–P4)',
+    labelsProperty: 'Labels property',
+    create: 'Create linked list',
+  },
+}

--- a/src/lib/i18n/messages/nl/baby.ts
+++ b/src/lib/i18n/messages/nl/baby.ts
@@ -1,0 +1,202 @@
+import type {
+  baby as enBaby,
+  eventTypes as enEventTypes,
+  log as enLog,
+} from '../en/baby'
+
+export const eventTypes = {
+  temperature: 'Temperatuur',
+  feeding: 'Voeding',
+  diaper: 'Luier',
+  sleep: 'Slaap',
+  growth: 'Groei',
+  medication: 'Medicatie',
+  vaccination: 'Vaccinatie',
+  note: 'Notitie',
+} satisfies typeof enEventTypes
+
+export const log = {
+  list: {
+    subtitle:
+      'Temperatuur, voeding, slaap, groei en meer — gedeeld met de Groep.',
+    addChild: 'Kind toevoegen',
+    emptyTitle: 'Nog geen kinderen',
+    emptyBody:
+      'Voeg een kind toe om temperatuur, voeding, slaap en meer bij te houden.',
+    emptyAction: 'Voeg je eerste kind toe',
+  },
+
+  child: {
+    age: {
+      days: { one: '{count} dag oud', other: '{count} dagen oud' },
+      weeks: { one: '{count} week oud', other: '{count} weken oud' },
+      months: { one: '{count} maand oud', other: '{count} maanden oud' },
+      years: { one: '{count} jaar oud', other: '{count} jaar oud' },
+      yearsMonths: '{years}j {months}m oud',
+    },
+    notFound: 'Kind niet gevonden.',
+    switch: 'Ander kind kiezen',
+    todo: 'Te doen',
+    todoPlaceholder: 'Luiers kopen, consultatiebureau bellen…',
+    questions: 'Vragen',
+    questionsPlaceholder: 'Vragen over de slaapregressie…',
+    addTo: 'Toevoegen aan {list}',
+    deleteTask: '{task} verwijderen',
+    temperatureTrend: 'Verloop temperatuur',
+    weightTrend: 'Verloop gewicht',
+    checklistEmpty: 'Niets te doen — mooi.',
+    trendEmpty: 'Noteer minstens twee keer om een lijn te zien.',
+    trendChart: 'Verloopgrafiek, {unit}, {count} punten',
+  },
+
+  form: {
+    name: 'Naam',
+    birthDate: 'Geboortedatum',
+    sex: 'Geslacht',
+    sexUnspecified: 'Zeg ik liever niet',
+    sexFemale: 'Meisje',
+    sexMale: 'Jongen',
+    saveFailed: 'Kon dat kind niet opslaan',
+    createTitle: 'Een kind toevoegen',
+    editTitle: '{name} bewerken',
+    deleteTitle: '{name} verwijderen?',
+    deleteBody:
+      'Alles wat voor dit kind is genoteerd gaat mee, voor iedereen in deze Groep.',
+    deleteConfirm: '{name} verwijderen',
+    deleteFailed: 'Kon dat kind niet verwijderen.',
+  },
+
+  quickLog: {
+    heading: 'Iets noteren',
+    several: 'Meerdere noteren',
+  },
+
+  entry: {
+    logTitle: '{type} noteren',
+    editTitle: '{type} bewerken',
+    when: 'Wanneer',
+    start: 'Begin',
+    notes: 'Notities',
+    saveFailed: 'Kon deze notitie niet opslaan',
+  },
+
+  multi: {
+    heading: 'Meerdere dingen noteren',
+    when: 'Wanneer',
+    include: 'Noteer',
+    pickOne: 'Kies minstens één ding om te noteren.',
+    save: {
+      one: '{count} notitie opslaan',
+      other: '{count} notities opslaan',
+    },
+    partial: '{saved} van {total} opgeslagen — {detail}',
+  },
+
+  timeline: {
+    empty: 'Nog niets genoteerd — noteer hierboven het eerste.',
+    deleteEntry: '{type} verwijderen',
+    deleteTitle: 'Deze notitie verwijderen?',
+    deleteConfirm: 'Verwijderen',
+    deleteFailed: 'Kon die notitie niet verwijderen.',
+  },
+
+  fields: {
+    temperature: 'Temperatuur (°C)',
+    method: 'Manier',
+    notSpecified: 'Niet opgegeven',
+    leftMin: 'Links (min)',
+    rightMin: 'Rechts (min)',
+    amountMl: 'Hoeveelheid (ml)',
+    end: 'Einde (optioneel)',
+    kind: 'Soort',
+    weightKg: 'Gewicht (kg)',
+    heightCm: 'Lengte (cm)',
+    headCm: 'Hoofdomtrek (cm)',
+    medicationName: 'Naam',
+    doseAmount: 'Dosis',
+    doseUnit: 'Eenheid',
+    doseUnitPlaceholder: 'ml, mg…',
+    vaccineName: 'Naam van het vaccin',
+    milestone: 'Markeren als mijlpaal',
+  },
+
+  options: {
+    temperatureMethod: {
+      oral: 'Oraal',
+      rectal: 'Rectaal',
+      axillary: 'Oksel',
+      ear: 'Oor',
+      forehead: 'Voorhoofd',
+    },
+    feedingMethod: {
+      breast: 'Borstvoeding',
+      bottle: 'Fles',
+      solid: 'Vast voedsel',
+    },
+    feedingSide: {
+      left: 'Links',
+      right: 'Rechts',
+      both: 'Beide',
+    },
+    diaperKind: {
+      wet: 'Nat',
+      dirty: 'Vies',
+      both: 'Beide',
+    },
+  },
+
+  validation: {
+    negativeMinutes: 'Minuten kunnen niet negatief zijn',
+    selectTemperature: 'Kies een temperatuur',
+    enterMeasurement: 'Vul minstens één meting in',
+    enterMedicationName: 'Vul een naam van het medicijn in',
+    enterVaccineName: 'Vul een naam van het vaccin in',
+  },
+
+  summary: {
+    celsiusWithMethod: '{celsius}°C ({method})',
+    celsius: '{celsius}°C',
+    sideMinutes: '{side} {minutes}m',
+    diaper: {
+      wet: 'Natte luier',
+      dirty: 'Vieze luier',
+      both: 'Natte en vieze luier',
+    },
+    sleepFor: 'Slaap · {duration}',
+    sleep: 'Slaap',
+    headCircumference: 'hoofd {value} cm',
+    growth: 'Groeimeting',
+    medication: 'Medicatie',
+    vaccination: 'Vaccinatie',
+    milestone: 'Mijlpaal',
+    note: 'Notitie',
+  },
+
+  pdf: {
+    title: '{name} — babylogboek',
+    born: 'Geboren {date} · {age}',
+    columnDate: 'Datum',
+    columnTime: 'Tijd',
+    columnDetails: 'Details',
+    columnEntries: 'Notities',
+    columnNotes: 'Opmerkingen',
+    empty: 'Geen notities in deze periode.',
+    fileNameFallback: 'baby',
+  },
+
+  export: {
+    button: 'PDF exporteren',
+    title: 'PDF exporteren',
+    from: 'Van',
+    to: 'Tot',
+    layout: 'Indeling',
+    byCategory: 'Per categorie',
+    chronological: 'Chronologisch',
+    include: 'Neem mee',
+    download: 'PDF downloaden',
+    generating: 'Genereren…',
+    failed: 'Kon de PDF niet maken',
+  },
+} satisfies typeof enLog
+
+export const baby = { eventTypes, log } satisfies typeof enBaby

--- a/src/lib/i18n/messages/nl/common.ts
+++ b/src/lib/i18n/messages/nl/common.ts
@@ -1,0 +1,20 @@
+import type { common as enCommon } from '../en/common'
+
+export const common = {
+  actions: {
+    start: 'Start',
+    cancel: 'Annuleren',
+    close: 'Sluiten',
+    save: 'Opslaan',
+    delete: 'Verwijderen',
+    copy: 'Kopiëren',
+    copied: 'Gekopieerd!',
+    retry: 'Opnieuw proberen',
+    back: 'Terug',
+  },
+  errors: {
+    somethingWentWrong: 'Er ging iets mis. Probeer het opnieuw.',
+    notFound: 'Niet gevonden.',
+    loading: 'Laden…',
+  },
+} satisfies typeof enCommon

--- a/src/lib/i18n/messages/nl/common.ts
+++ b/src/lib/i18n/messages/nl/common.ts
@@ -6,7 +6,12 @@ export const common = {
     cancel: 'Annuleren',
     close: 'Sluiten',
     save: 'Opslaan',
+    saving: 'Opslaan…',
     delete: 'Verwijderen',
+    edit: 'Bewerken',
+    add: 'Toevoegen',
+    confirm: 'Bevestigen',
+    working: 'Bezig…',
     copy: 'Kopiëren',
     copied: 'Gekopieerd!',
     retry: 'Opnieuw proberen',
@@ -16,5 +21,13 @@ export const common = {
     somethingWentWrong: 'Er ging iets mis. Probeer het opnieuw.',
     notFound: 'Niet gevonden.',
     loading: 'Laden…',
+    didNotWork: 'Dat lukte niet — probeer het opnieuw.',
+  },
+
+  image: {
+    label: 'Foto',
+    uploading: 'Uploaden…',
+    failed: 'Kon die afbeelding niet uploaden',
+    remove: 'Foto verwijderen',
   },
 } satisfies typeof enCommon

--- a/src/lib/i18n/messages/nl/foods.ts
+++ b/src/lib/i18n/messages/nl/foods.ts
@@ -1,0 +1,72 @@
+import type { foods as enFoods } from '../en/foods'
+
+export const foods = {
+  list: {
+    title: 'Voedingsmiddelen',
+    scanHeading: 'Scan een barcode',
+    search: 'Voedingsmiddelen zoeken',
+    searchPlaceholder: 'bijv. hagelslag',
+    addManually: 'Handmatig toevoegen',
+    searching: 'Zoeken…',
+    noResults: 'Niets gevonden voor "{term}".',
+  },
+
+  scanner: {
+    scan: 'Barcode scannen',
+    stop: 'Camera stoppen',
+    cameraDenied:
+      'Geen toegang tot de camera — voer het barcodenummer zelf in.',
+    manualLabel: 'Of voer het barcodenummer in',
+    manualPlaceholder: '8710398160005',
+    lookUp: 'Opzoeken',
+  },
+
+  detail: {
+    notFound: 'Voedingsmiddel niet gevonden.',
+    builtIn: 'Standaard',
+    builtInNote:
+      'Hoort bij de standaardlijst van gather en kan daarom niet worden bewerkt. Heb je een andere versie nodig?',
+    createYourOwn: 'Maak je eigen voedingsmiddel',
+    per100: 'per 100 {unit}',
+    serving: 'Portie: {label}',
+    dataFrom: 'Voedingswaarde van',
+    openFoodFacts: 'Open Food Facts',
+    odbl: '(ODbL).',
+    refresh: 'Vernieuwen vanaf Open Food Facts',
+    refreshTitle: 'Vernieuwen vanaf Open Food Facts?',
+    refreshBody:
+      'Dit voedingsmiddel wordt overschreven met de nieuwste gegevens daar. Eigen aanpassingen gaan verloren.',
+    refreshConfirm: 'Vernieuwen',
+    refreshFailed: 'Kon niet vernieuwen vanaf Open Food Facts.',
+  },
+
+  form: {
+    name: 'Naam',
+    brand: 'Merk',
+    barcode: 'Barcode: {barcode}',
+    baseUnit: 'Basiseenheid',
+    grams: 'gram',
+    milliliters: 'milliliter',
+    nutritionLegend: 'Voedingswaarde per 100 {unit}',
+    servingSize: 'Portiegrootte ({unit})',
+    servingLabel: 'Portieomschrijving',
+    servingLabelPlaceholder: 'bijv. "1 plak (30 g)"',
+    save: 'Voedingsmiddel opslaan',
+    saveFailed: 'Kon het voedingsmiddel niet opslaan',
+  },
+
+  create: {
+    title: 'Voedingsmiddel toevoegen',
+    lookingUp: 'Barcode opzoeken…',
+    fromOff: 'Van Open Food Facts — controleer het voordat je opslaat.',
+    offUnreachable:
+      'Kon Open Food Facts niet bereiken — vul de gegevens zelf in.',
+  },
+
+  edit: {
+    title: 'Voedingsmiddel bewerken',
+    builtInBefore:
+      'Dit hoort bij de standaardlijst van gather en kan niet worden bewerkt.',
+    builtInAfter: 'als je een andere versie nodig hebt.',
+  },
+} satisfies typeof enFoods

--- a/src/lib/i18n/messages/nl/index.ts
+++ b/src/lib/i18n/messages/nl/index.ts
@@ -1,7 +1,24 @@
 import type { Messages } from '../en'
+import { baby } from './baby'
 import { common } from './common'
+import { foods } from './foods'
 import { modules } from './modules'
+import { nutrients } from './nutrients'
+import { nutrition } from './nutrition'
+import { recipes } from './recipes'
 import { settings } from './settings'
 import { shell } from './shell'
+import { tasks } from './tasks'
 
-export const nl = { common, shell, modules, settings } satisfies Messages
+export const nl = {
+  common,
+  shell,
+  modules,
+  nutrients,
+  recipes,
+  nutrition,
+  foods,
+  tasks,
+  baby,
+  settings,
+} satisfies Messages

--- a/src/lib/i18n/messages/nl/index.ts
+++ b/src/lib/i18n/messages/nl/index.ts
@@ -1,0 +1,7 @@
+import type { Messages } from '../en'
+import { common } from './common'
+import { modules } from './modules'
+import { settings } from './settings'
+import { shell } from './shell'
+
+export const nl = { common, shell, modules, settings } satisfies Messages

--- a/src/lib/i18n/messages/nl/modules.ts
+++ b/src/lib/i18n/messages/nl/modules.ts
@@ -1,0 +1,69 @@
+import type {
+  byId as enById,
+  groups as enGroups,
+  modules as enModules,
+} from '../en/modules'
+
+export const byId = {
+  recipes: {
+    label: 'Recepten',
+    description: 'Bewaar en beoordeel de gerechten die je kookt.',
+  },
+  nutrition: {
+    label: 'Voeding',
+    description: 'Houd bij wat je eet en volg je dagdoelen.',
+  },
+  'meal-planner': {
+    label: 'Maaltijdplanner',
+    description: 'Plan de maaltijden van de week.',
+  },
+  groceries: {
+    label: 'Boodschappen',
+    description: 'Een gedeelde boodschappenlijst die jullie samen afvinken.',
+  },
+  pantry: {
+    label: 'Voorraadkast',
+    description: 'Houd bij wat er thuis in voorraad is.',
+  },
+  finances: {
+    label: 'Financiën',
+    description: 'Budgetten en een overzicht van je uitgaven.',
+  },
+  bills: {
+    label: 'Rekeningen & abonnementen',
+    description: 'Terugkerende rekeningen en abonnementen.',
+  },
+  tasks: {
+    label: 'Taken',
+    description: 'Gedeelde takenlijsten.',
+  },
+  'baby-log': {
+    label: 'Babylogboek',
+    description: 'Temperatuur, voeding, slaap, groei en meer.',
+  },
+  calendar: {
+    label: 'Agenda',
+    description: 'Afspraken en herinneringen voor het huishouden.',
+  },
+  notes: {
+    label: 'Notities',
+    description: 'Snelle gedeelde notities.',
+  },
+  cheeses: {
+    label: 'Kazen',
+    description: 'Beoordeel de kazen die je proeft.',
+  },
+  wines: {
+    label: 'Wijnen',
+    description: 'Beoordeel de wijnen die je proeft.',
+  },
+} satisfies typeof enById
+
+export const groups = {
+  kitchen: 'Keuken',
+  money: 'Geld',
+  home: 'Huis & leven',
+  tasting: 'Proeven',
+} satisfies typeof enGroups
+
+export const modules = { byId, groups } satisfies typeof enModules

--- a/src/lib/i18n/messages/nl/nutrients.ts
+++ b/src/lib/i18n/messages/nl/nutrients.ts
@@ -1,0 +1,24 @@
+import type {
+  labels as enLabels,
+  nutrients as enNutrients,
+  sources as enSources,
+} from '../en/nutrients'
+
+export const labels = {
+  calories: 'Calorieën (kcal)',
+  protein: 'Eiwitten (g)',
+  carbs: 'Koolhydraten (g)',
+  sugars: 'Suikers (g)',
+  fat: 'Vet (g)',
+  saturatedFat: 'Verzadigd vet (g)',
+  fiber: 'Vezels (g)',
+  salt: 'Zout (g)',
+} satisfies typeof enLabels
+
+export const sources = {
+  imported: 'Geïmporteerd',
+  ai: 'AI-schatting',
+  manual: 'Handmatig',
+} satisfies typeof enSources
+
+export const nutrients = { labels, sources } satisfies typeof enNutrients

--- a/src/lib/i18n/messages/nl/nutrition.ts
+++ b/src/lib/i18n/messages/nl/nutrition.ts
@@ -1,0 +1,91 @@
+import type {
+  diary as enDiary,
+  meals as enMeals,
+  nutrition as enNutrition,
+  units as enUnits,
+} from '../en/nutrition'
+
+export const meals = {
+  breakfast: 'Ontbijt',
+  lunch: 'Lunch',
+  dinner: 'Avondeten',
+  snack: 'Tussendoortje',
+} satisfies typeof enMeals
+
+export const units = {
+  serving: 'portie',
+  g: 'g',
+  ml: 'ml',
+  piece: 'stuk',
+} satisfies typeof enUnits
+
+export const diary = {
+  personalNote:
+    'Alleen van jou. Niemand anders in de Groep ziet dit, en het is in elke Groep hetzelfde.',
+  prevDay: '← Vorige',
+  nextDay: 'Volgende →',
+
+  totalsToday: 'Totalen van vandaag',
+  totalsOn: 'Totalen — {date}',
+
+  targets: {
+    title: 'Dagdoelen',
+    save: 'Doelen opslaan',
+    saveFailed: 'Kon de doelen niet opslaan',
+  },
+
+  slot: {
+    add: '+ Toevoegen',
+    empty: 'Nog niets genoteerd.',
+  },
+
+  entry: {
+    viewRecipe: 'Recept bekijken',
+    viewFood: 'Voedingsmiddel bekijken',
+    quantity: 'Aantal',
+    meal: 'Maaltijd',
+    date: 'Datum',
+    saveFailed: 'Kon de wijzigingen niet opslaan',
+  },
+
+  add: {
+    title: 'Toevoegen aan {meal}',
+    tabs: {
+      recipes: 'Recepten',
+      foods: 'Voedingsmiddelen',
+      quick: 'Snel toevoegen',
+    },
+  },
+
+  quickAdd: {
+    label: 'Omschrijving',
+    placeholder: 'bijv. "Uit eten"',
+    adding: 'Toevoegen…',
+    failed: 'Kon dit niet noteren',
+  },
+
+  recipeAdd: {
+    none: 'Nog geen recepten met voedingswaarde.',
+    servings: 'porties',
+    failed: 'Kon dit recept niet noteren',
+    withoutNutrition: 'Deze recepten hebben nog geen voedingswaarde:',
+  },
+
+  foodAdd: {
+    lookingUp: 'Opzoeken…',
+    barcodeFailed: 'Kon die barcode niet opzoeken — probeer het opnieuw.',
+    addFailed: 'Kon dat item niet toevoegen — probeer het opnieuw.',
+    notFound: 'Niet gevonden.',
+    addToLibrary: 'Voeg het toe aan de voedingsmiddelen',
+    addToLibraryAfter: 'en probeer het dan opnieuw.',
+    searchPlaceholder: 'Voedingsmiddelen zoeken…',
+    searching: 'Zoeken bij Open Food Facts…',
+    searchFailed: 'Kon niet zoeken bij Open Food Facts.',
+    fromOff: 'Van Open Food Facts',
+    perHundred: '{calories} kcal/100 g',
+    pieceOf: 'stuk ({size}{unit})',
+    logFailed: 'Kon dit voedingsmiddel niet noteren',
+  },
+} satisfies typeof enDiary
+
+export const nutrition = { meals, units, diary } satisfies typeof enNutrition

--- a/src/lib/i18n/messages/nl/recipes.ts
+++ b/src/lib/i18n/messages/nl/recipes.ts
@@ -1,0 +1,93 @@
+import type { recipes as enRecipes } from '../en/recipes'
+
+export const recipes = {
+  list: {
+    subtitle: 'Bewaar en beoordeel de gerechten die deze Groep kookt.',
+    add: 'Recept toevoegen',
+    emptyTitle: 'Nog geen recepten',
+    emptyBody:
+      'Voeg het eerste recept toe om deze module bruikbaar te maken voor de Groep.',
+    emptyAction: 'Voeg je eerste recept toe',
+  },
+
+  viewMode: {
+    label: 'Weergave',
+    grid: 'Rasterweergave',
+    banner: 'Bannerweergave',
+    compact: 'Compacte weergave',
+  },
+
+  rating: {
+    label: 'Beoordeling',
+    stars: { one: '{count} ster', other: '{count} sterren' },
+  },
+
+  destination: {
+    prefix: 'Wordt toegevoegd aan',
+    suffix: '.',
+    fallbackSuffix:
+      '— je persoonlijke Groep, omdat deze pagina niet in een Groep zit.',
+  },
+
+  form: {
+    title: 'Titel',
+    description: 'Omschrijving',
+    ingredients: 'Ingrediënten',
+    steps: 'Stappen',
+    tags: 'Labels',
+    onePerLine: 'Eén per regel',
+    commaSeparated: 'komma, gescheiden',
+    nutritionLegend: 'Voedingswaarde (per portie)',
+    servings: 'Porties',
+    servingsPlaceholder: '4',
+    estimate: 'Schatten met AI',
+    estimating: 'Schatten…',
+    estimateFailed: 'Kon de voedingswaarde niet schatten',
+    save: 'Recept opslaan',
+    saveFailed: 'Kon het recept niet opslaan',
+  },
+
+  create: {
+    title: 'Nieuw recept',
+    importLabel: 'Importeren vanaf URL',
+    importPlaceholder: 'https://voorbeeld.nl/een-recept',
+    import: 'Importeren',
+    importing: 'Importeren…',
+    imported: 'Geïmporteerd — controleer hieronder de gegevens en sla dan op.',
+    importFailed: 'Kon dat recept niet importeren',
+  },
+
+  edit: {
+    title: 'Recept bewerken',
+  },
+
+  detail: {
+    notFound: 'Recept niet gevonden.',
+    deleteFailed: 'Kon het recept niet verwijderen',
+    addedBy: 'Toegevoegd door {name}',
+    importedFrom: 'Geïmporteerd van',
+    staleNutrition:
+      'De ingrediënten zijn gewijzigd sinds de voedingswaarde is berekend — opnieuw schatten?',
+    reEstimate: 'Opnieuw schatten met AI',
+    editManually: 'Handmatig bewerken',
+    perServing: 'per portie',
+    perServingOf: 'per portie · {count} porties',
+    nutrition: 'Voedingswaarde',
+  },
+
+  sharing: {
+    title: 'Groepen',
+    livesIn: 'Hoort bij',
+    unknownGroup: 'een Groep waar je in zit',
+    notShared: 'Niet gedeeld met een andere Groep.',
+    sharedWith: 'Gedeeld met {group}',
+    unshare: 'Delen stoppen',
+    onlyOneGroup:
+      'Je zit maar in één Groep, dus er is nog nergens om dit heen te verplaatsen of mee te delen.',
+    moveTo: 'Verplaatsen naar',
+    move: 'Verplaatsen',
+    shareWith: 'Delen met',
+    share: 'Delen',
+    chooseGroup: 'Kies een Groep…',
+  },
+} satisfies typeof enRecipes

--- a/src/lib/i18n/messages/nl/settings.ts
+++ b/src/lib/i18n/messages/nl/settings.ts
@@ -19,4 +19,87 @@ export const settings = {
       'Koppelingen met Notion en Todoist horen bij een Groep, niet bij jou — elk lid van die Groep kan er een gebruiken, en niemand daarbuiten. Elke Groep heeft die van zichzelf.',
     open: 'Instellingen',
   },
+
+  groupPage: {
+    title: 'Instellingen van {group}',
+    intro:
+      'Instellingen die iedereen in deze Groep deelt. Je eigen weergave- en accountinstellingen staan bij Instellingen, en zijn in elke Groep hetzelfde.',
+  },
+
+  connections: {
+    title: 'Koppelingen',
+    intro:
+      'Koppel een externe app aan {group}. Elk lid van {group} kan hem gebruiken — Taken kan er een lijst uit spiegelen — en niemand daarbuiten.',
+    notConnected: 'Niet gekoppeld',
+    connectedBy: '{account} — gekoppeld door {name}',
+    connect: 'Koppelen',
+    opening: 'Openen…',
+    disconnect: 'Ontkoppelen',
+    disconnectTitle: '{provider} loskoppelen van {group}?',
+    disconnectBody:
+      'Gekoppelde lijsten laden niet meer totdat de koppeling is hersteld.',
+    disconnectFailed: 'Kon {provider} niet loskoppelen.',
+    startFailed: 'Kon de koppeling niet starten — probeer het opnieuw.',
+  },
+
+  group: {
+    title: 'Deze Groep',
+    personalNote:
+      'Je persoonlijke Groep. Die is alleen van jou, dus er valt hier niets te delen of te verlaten.',
+    sharedNote:
+      'De naam, de code waarmee iemand binnenkomt, en de weg naar buiten.',
+    name: 'Naam',
+    rename: 'Hernoemen',
+    renameFailed: 'Kon deze Groep niet hernoemen.',
+    addressChanges:
+      'Het adres verandert mee met de naam, dus oude links naar deze Groep werken daarna niet meer.',
+    inviteCode: 'Uitnodigingscode',
+    inviteCodeNote:
+      'Iedereen met deze code kan zich aanmelden via Groepen — deel hem alleen met mensen die je erbij wilt hebben.',
+    leave: 'Vertrekken',
+    leaveButton: 'Deze Groep verlaten',
+    leaveTitle: '{group} verlaten?',
+    leaveBody:
+      'Je ziet dan niets meer van wat erin zit. Wat je hebt toegevoegd blijft bij de Groep.',
+    leaveConfirm: 'Groep verlaten',
+    leaveFailed: 'Kon deze Groep niet verlaten.',
+  },
+
+  members: {
+    title: 'Leden',
+    personalNote:
+      'Beheerders kunnen deze Groep hernoemen, rollen wijzigen en hem verwijderen. Alle anderen kunnen alles erin gebruiken.',
+    sharedNote:
+      'Beheerders kunnen deze Groep hernoemen en rollen wijzigen. Iedereen hier kan alles erin gebruiken.',
+    you: 'Jij',
+    admin: 'Beheerder',
+    lastAdmin: 'Een Groep heeft minstens één beheerder nodig',
+    makeMember: 'Maak lid',
+    makeAdmin: 'Maak beheerder',
+    roleFailed: 'Kon die rol niet wijzigen.',
+  },
+
+  sampleData: {
+    title: 'Voorbeeldgegevens',
+    descriptionBefore:
+      'Bouwt een voorbeeldhuishouden rond je account, met datums rond vandaag. Beide acties verwijderen dat huishouden volledig —',
+    descriptionStrong: 'inclusief alles wat je er zelf in hebt gezet',
+    descriptionAfter:
+      ', zoals een taak op een voorbeeldlijst. Je eigen Groepen, je voedingsdagboek en je eigen recepten blijven ongemoeid, en je standaard-Groep wordt teruggezet. Niet beschikbaar in productie.',
+    load: 'Voorbeeldgegevens laden',
+    loading: 'Laden…',
+    remove: 'Voorbeeldgegevens verwijderen',
+    removing: 'Verwijderen…',
+    confirmRemove:
+      'Het voorbeeldhuishouden verwijderen, inclusief alles wat je er zelf in hebt gezet? Je eigen Groepen, dagboek en recepten blijven ongemoeid.',
+    loaded:
+      '{recipes} recepten, {tasks} taken, {babyEvents} babynotities en {diaryEntries} dagboekregels geladen in “{group}”.',
+    removed: '{deleted} voorbeeldregels verwijderd.',
+    removedWithOrphans: {
+      one: '{deleted} voorbeeldregels verwijderd, plus {count} regel die je er zelf in had gezet.',
+      other:
+        '{deleted} voorbeeldregels verwijderd, plus {count} regels die je er zelf in had gezet.',
+    },
+    failed: 'Kon de seed niet uitvoeren — bekijk de logs.',
+  },
 } satisfies typeof enSettings

--- a/src/lib/i18n/messages/nl/settings.ts
+++ b/src/lib/i18n/messages/nl/settings.ts
@@ -1,0 +1,22 @@
+import type { settings as enSettings } from '../en/settings'
+
+export const settings = {
+  title: 'Instellingen',
+
+  language: {
+    title: 'Taal',
+    description:
+      'In welke taal Gather zelf staat. Wat jij en je Groepen hebben geschreven blijft in de taal waarin je het schreef.',
+    names: {
+      en: 'English',
+      nl: 'Nederlands',
+    },
+  },
+
+  groupSettings: {
+    title: 'Groepsinstellingen',
+    description:
+      'Koppelingen met Notion en Todoist horen bij een Groep, niet bij jou — elk lid van die Groep kan er een gebruiken, en niemand daarbuiten. Elke Groep heeft die van zichzelf.',
+    open: 'Instellingen',
+  },
+} satisfies typeof enSettings

--- a/src/lib/i18n/messages/nl/shell.ts
+++ b/src/lib/i18n/messages/nl/shell.ts
@@ -116,9 +116,98 @@ export const shell = {
     goHome: 'Naar Gather',
   },
 
+  groupGate: {
+    unknownTitle: 'Die Groep bestaat niet',
+    unknownBody:
+      'Er is hier niets dat “{slug}” heet. Controleer de link, of kies een Groep in de zijbalk.',
+    forbiddenTitle: 'Deze Groep is niet van jou',
+    forbiddenBody:
+      'Je bent er geen lid van. Vraag een beheerder van de Groep om een uitnodiging.',
+  },
+
+  groups: {
+    title: 'Groepen',
+    intro:
+      'De huishoudens waar je in zit. Open er een om de naam te wijzigen, de uitnodigingscode te delen of te vertrekken.',
+    yours: 'Jouw Groepen',
+    personal: 'Persoonlijk',
+    createTitle: 'Nieuwe Groep',
+    createBody: 'Een eigen huishouden. Je begint als beheerder.',
+    createPlaceholder: 'bijv. Wijnclub',
+    createLabel: 'Naam van de nieuwe Groep',
+    create: 'Aanmaken',
+    createFailed: 'Kon die Groep niet aanmaken.',
+    joinTitle: 'Meedoen met een code',
+    joinBody: 'Iemand in de Groep vindt hem bij de instellingen van die Groep.',
+    joinPlaceholder: 'code van 8 tekens',
+    joinLabel: 'Uitnodigingscode',
+    join: 'Meedoen',
+    joinFailed: 'Kon niet meedoen met die code.',
+  },
+
+  session: {
+    stalledTitle: 'Inloggen kon niet worden afgerond',
+    stalledBody:
+      'Gather kon je sessie niet met de backend verbinden. Opnieuw laden helpt meestal.',
+    reload: 'Opnieuw laden',
+  },
+
+  oauthCallback: {
+    finishing: 'De koppeling wordt afgerond…',
+    failedTitle: 'Koppelen mislukt',
+    backToSettings: 'Terug naar instellingen',
+    cancelled: 'De koppeling is geannuleerd of geweigerd.',
+    invalid: 'Ongeldig antwoord — probeer opnieuw te koppelen.',
+    noGroup:
+      'Die koppeling kwam terug zonder Groep — begin opnieuw vanaf de instellingen van de Groep.',
+    failed: 'Koppelen mislukt — probeer het opnieuw.',
+  },
+
+  about: {
+    eyebrow: 'Over Gather',
+    title: 'Eén gedeelde Groep voor het dagelijks regelwerk',
+    subtitle:
+      'Gather houdt gedeelde recepten, plannen, lijsten, taken, notities en proefnotities op één plek, voor de mensen die een huishouden delen.',
+    modules:
+      'Recepten en Voeding werken vandaag al, en de modules eromheen staan klaar zodat een Groep kan doorgroeien naar maaltijdplanning, boodschappen, voorraad, financiën, rekeningen, taken, agenda, notities, kazen en wijnen zonder van app te wisselen.',
+    pins: 'Elke module is in elke Groep beschikbaar. Je zet de modules die je gebruikt vast in je eigen navigatie, de rest blijft één klik weg — je keuzes zijn alleen van jou en verplaatsen die van niemand anders.',
+  },
+
   publicFrame: {
     brand: 'Gather',
     tagline: 'Samen je huishouden regelen',
+  },
+
+  gatherPanel: {
+    title: 'Vraag het Gather',
+    close: 'Vraag het Gather sluiten',
+    context: 'Context: {page}',
+    preview: 'Voorproefje',
+    notConnected:
+      'Automatisering is nog niet aangesloten. Gebruik dit paneel als kladblok voor de Groep waar je staat; echte acties volgen later.',
+    tryAsking: 'Probeer eens',
+    prompts: {
+      recent: 'Laat zien wat er onlangs is veranderd',
+      plan: 'Maak een plan voor deze Groep',
+      summarize: 'Vat deze pagina samen',
+    },
+    placeholder: 'Vraag Gather om te helpen met deze Groep...',
+  },
+
+  issueReporter: {
+    title: 'Probleem melden',
+    types: {
+      bug: 'Bug',
+      enhancement: 'Verbetering',
+      docs: 'Documentatie',
+      question: 'Vraag',
+    },
+    placeholder: 'Wat ging er mis, of wat zou je graag willen zien?',
+    send: 'Versturen',
+    sending: 'Versturen…',
+    filed: 'Bedankt — je melding is aangemaakt.',
+    viewIssue: 'Melding bekijken',
+    unreachable: 'Kon de server niet bereiken.',
   },
 
   home: {

--- a/src/lib/i18n/messages/nl/shell.ts
+++ b/src/lib/i18n/messages/nl/shell.ts
@@ -1,0 +1,173 @@
+import type { shell as enShell } from '../en/shell'
+
+export const shell = {
+  topbar: {
+    openNavigation: 'Navigatie openen',
+    jumpTo: 'Ga naar',
+    askGather: 'Vraag het Gather',
+    reportIssue: 'Probleem melden',
+    switchLanguage: 'Overschakelen naar {language}',
+  },
+
+  sidebar: {
+    label: 'Gather-navigatie',
+    primary: 'Hoofdnavigatie',
+    footer: 'Instellingen en groepen',
+    noGroup: 'Kies een Groep om de modules te zien.',
+  },
+
+  dock: {
+    label: 'Mobiele navigatie',
+  },
+
+  drawer: {
+    label: 'Navigatie',
+    close: 'Navigatie sluiten',
+  },
+
+  palette: {
+    placeholder: 'Ga naar…',
+  },
+
+  groupSwitcher: {
+    label: 'Van Groep wisselen',
+    none: 'Geen Groep',
+    elsewhere: 'Ga terug',
+    personal: 'Je eigen Groep',
+    shared: 'Gedeelde Groep',
+    pick: 'Kies een Groep',
+    personalPill: 'Persoonlijk',
+    manage: 'Groepen beheren',
+  },
+
+  marks: {
+    soon: 'Binnenkort',
+    onlyYou: 'Alleen jij',
+    onlyYouExplained:
+      'Alleen jij kunt dit zien. Het is in elke Groep hetzelfde.',
+  },
+
+  nav: {
+    home: 'Start',
+    all: 'Alles',
+    groups: 'Groepen',
+    settings: 'Instellingen',
+    groupSettings: 'Groepsinstellingen',
+  },
+
+  routes: {
+    home: {
+      title: 'Start',
+      subtitle: 'Wat je Groep heeft gedaan.',
+    },
+    all: {
+      title: 'Alle modules',
+      subtitle: 'Elke module in deze Groep. Zet vast wat je gebruikt.',
+    },
+    groupSettings: {
+      title: 'Groepsinstellingen',
+      subtitle: 'Instellingen die iedereen in deze Groep deelt.',
+    },
+    groups: {
+      title: 'Groepen',
+      subtitle: 'Beheer delen en leden.',
+    },
+    settings: {
+      title: 'Instellingen',
+      subtitle: 'Stel weergave en voorkeuren in.',
+    },
+    account: {
+      title: 'Account',
+      subtitle: 'Beheer je profiel en inloggegevens.',
+    },
+    fallback: {
+      title: 'Gather',
+      subtitle: 'Gedeelde plannen, modules en context.',
+    },
+  },
+
+  allModules: {
+    title: 'Alle modules',
+    intro:
+      'Elke module is beschikbaar in deze Groep. Een module vastzetten houdt hem hier in je eigen navigatie — niemand anders in de Groep ziet jouw keuzes, en je andere Groepen houden die van henzelf.',
+    yourPins: 'Vastgezet',
+    nothingPinned:
+      'Niets vastgezet. Zet hieronder een module vast om hem in je navigatie te houden.',
+    pin: 'Vastzetten',
+    unpin: 'Losmaken',
+    pinModule: '{module} vastzetten',
+    unpinModule: '{module} losmaken',
+    moveUp: '{module} omhoog',
+    moveDown: '{module} omlaag',
+  },
+
+  placeholder: {
+    planned: 'Module gepland',
+    whatWillLiveHere: 'Wat hier komt',
+    body: 'Deze module staat al in elke Groep, zodat navigatie, delen en de mobiele indeling klaar zijn voordat de rest gebouwd is.',
+  },
+
+  notFound: {
+    eyebrow: 'Niet gevonden',
+    title: 'Pagina niet gevonden',
+    subtitle: 'Gather heeft geen pagina op dit adres.',
+    signIn: 'Inloggen',
+    body: 'De pagina is misschien verplaatst, of de link wijst naar een module die er nog niet is.',
+    goHome: 'Naar Gather',
+  },
+
+  publicFrame: {
+    brand: 'Gather',
+    tagline: 'Samen je huishouden regelen',
+  },
+
+  home: {
+    personalSubtitle: 'Je eigen Groep. Alles wat je hier bewaart is privé.',
+    sharedSubtitle: 'Wat iedereen in deze Groep heeft gedaan.',
+    whoIsHere: 'Wie er zijn',
+    admin: 'Beheerder',
+    personalNote: {
+      before:
+        '{group} is alleen van jou — niemand anders ziet wat je hier bewaart. Om iets met anderen te delen, begin je samen met hen een Groep bij',
+      link: 'Groepen',
+      after: '.',
+    },
+    sharedNote: {
+      before:
+        'Iedereen hier ziet alles in {group}. Om iemand uit te nodigen of te vertrekken, ga je naar',
+      link: 'Groepen',
+      after: '.',
+    },
+    recentActivity: 'Recente activiteit',
+    nothingYet: 'Er is nog niets gebeurd in {group}.',
+    nothingYetPersonal:
+      'Alles wat je hier toevoegt komt in deze lijst, en alleen jij ziet het ooit.',
+    nothingYetShared:
+      'Alles wat iemand hier toevoegt komt in deze lijst, met zijn of haar naam erbij.',
+  },
+
+  activity: {
+    unknownActor: 'Iemand',
+    // The title lands after the verb, which English apposition handles ("added
+    // the recipe X") and Dutch does not: "toevoegen" is separable, so the
+    // straight translation strands "toe" in front of the title. A colon puts
+    // the verb phrase back together and lets the title follow as a label.
+    verbs: {
+      recipe: 'voegde een recept toe:',
+      task: 'voegde een taak toe:',
+      babyEvent: 'noteerde',
+    },
+    connectors: {
+      task: 'aan de lijst',
+      babyEvent: 'voor',
+    },
+    justNow: 'Zojuist',
+    minutesAgo: {
+      one: '{count} minuut geleden',
+      other: '{count} minuten geleden',
+    },
+    hoursAgo: { one: '{count} uur geleden', other: '{count} uur geleden' },
+    yesterday: 'Gisteren',
+    daysAgo: '{count} dagen geleden',
+  },
+} satisfies typeof enShell

--- a/src/lib/i18n/messages/nl/tasks.ts
+++ b/src/lib/i18n/messages/nl/tasks.ts
@@ -1,0 +1,85 @@
+import type { tasks as enTasks } from '../en/tasks'
+
+export const tasks = {
+  page: {
+    subtitle:
+      'Gedeelde lijsten — lokale staan hier, gekoppelde spiegelen Notion of Todoist.',
+    addList: 'Lijst toevoegen',
+    emptyTitle: 'Nog geen lijsten',
+    emptyBody: 'Maak een lokale lijst, of koppel er een uit Notion of Todoist.',
+    emptyAction: 'Voeg je eerste lijst toe',
+    deleteListTitle: 'De lijst “{name}” verwijderen?',
+    deleteListBody: 'De taken erin gaan mee, voor iedereen in deze Groep.',
+    deleteListConfirm: 'Lijst verwijderen',
+    deleteListFailed: 'Kon die lijst niet verwijderen.',
+  },
+
+  row: {
+    toggle: '{task} afvinken',
+    openInSource: '{task} openen in de app waar het vandaan komt',
+  },
+
+  local: {
+    pill: 'Lokaal',
+    deleteList: 'Lijst {name} verwijderen',
+    quickAdd: 'Taak toevoegen…',
+    newTaskIn: 'Nieuwe taak in {name}',
+    addTask: 'Taak toevoegen',
+    showDetails: 'Toevoegen met details…',
+    hideDetails: 'Details verbergen',
+    empty: 'Nog geen taken.',
+    moveUp: '{task} omhoog',
+    moveDown: '{task} omlaag',
+    edit: '{task} bewerken',
+    delete: '{task} verwijderen',
+  },
+
+  external: {
+    refresh: '{name} vernieuwen',
+    loadFailed: 'Kon deze lijst niet laden.',
+    reconnect: 'De koppeling met {provider} moet opnieuw worden gelegd.',
+    goToSettings: 'Naar de Groepsinstellingen',
+    empty: 'Geen open taken in deze {provider}-lijst.',
+  },
+
+  editor: {
+    title: 'Taakomschrijving',
+    dueDate: 'Datum',
+    priority: 'Prioriteit',
+    noPriority: 'Geen prioriteit',
+    p1: 'P1 — dringend',
+    p2: 'P2',
+    p3: 'P3',
+    p4: 'P4',
+    labels: 'Labels',
+    labelsPlaceholder: 'Labels, gescheiden door komma’s',
+  },
+
+  addList: {
+    title: 'Een lijst toevoegen',
+    local: 'Lokale lijst — hier gemaakt en bewerkt',
+    mirror: '{provider} — alleen lezen',
+    connectFirst: 'Eerst {provider} koppelen…',
+    listName: 'Lijstnaam',
+    create: 'Aanmaken',
+    failed: 'Er ging iets mis — probeer het opnieuw.',
+    pickNotion: 'Kies de Notion-database om te spiegelen:',
+    pickTodoist: 'Kies het Todoist-project om te spiegelen:',
+    nothingFoundNotion:
+      'Niets gevonden — controleer of de koppeling toegang heeft tot minstens één database.',
+    nothingFoundTodoist:
+      'Niets gevonden — controleer of de koppeling toegang heeft tot minstens één project.',
+  },
+
+  notionMapping: {
+    intro:
+      'Koppel de eigenschappen van deze database, zodat gather weet hoe hij hem moet lezen. Een status-eigenschap telt als gedaan wanneer die Done, Complete of Completed heet.',
+    notMapped: 'Niet gekoppeld',
+    titleProperty: 'Titel-eigenschap',
+    doneProperty: 'Gedaan-eigenschap (checkbox of status)',
+    dueDateProperty: 'Datum-eigenschap',
+    priorityProperty: 'Prioriteit-eigenschap (select met 1–4 of P1–P4)',
+    labelsProperty: 'Labels-eigenschap',
+    create: 'Gekoppelde lijst aanmaken',
+  },
+} satisfies typeof enTasks

--- a/src/lib/i18n/server.ts
+++ b/src/lib/i18n/server.ts
@@ -1,0 +1,33 @@
+import { resolveLocale } from '@appelent/i18n'
+import { createServerFn } from '@tanstack/react-start'
+import { getCookie, getRequestHeader } from '@tanstack/react-start/server'
+import { type Locale, SUPPORTED_LOCALES } from './index'
+
+/**
+ * The locale to render the first paint in: the `lang` cookie if the reader has
+ * chosen one, otherwise the best match from `Accept-Language`, otherwise
+ * English.
+ *
+ * Written out here rather than built by `@appelent/i18n`'s `createGetSsrLocale`
+ * factory, which cannot work: TanStack Start's Vite plugin rewrites
+ * `createServerFn(...).handler(...)` calls it finds in **app source** into
+ * registered endpoints, and never sees one inside a pre-bundled dependency. The
+ * factory's server fn is therefore never registered, and calling it returns
+ * `undefined` instead of running the handler — which is exactly what it did
+ * here, silently, until SSR tried to destructure the result. Only the pure
+ * `resolveLocale` comes from the package; the server fn stays local.
+ *
+ * Returns `{ locale: string }` rather than the `Locale` union because a server
+ * function has to declare a concrete return type. `resolveLocale` only ever
+ * returns one of `SUPPORTED_LOCALES`, so the call site casts.
+ */
+export const getSsrLocale = createServerFn({ method: 'GET' }).handler(
+  (): { locale: string } => ({
+    locale: resolveLocale(
+      SUPPORTED_LOCALES,
+      'en' satisfies Locale,
+      getCookie('lang'),
+      getRequestHeader('accept-language'),
+    ),
+  }),
+)

--- a/src/lib/i18n/testing.tsx
+++ b/src/lib/i18n/testing.tsx
@@ -1,0 +1,27 @@
+import { type RenderOptions, render } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { type Locale, LocaleProvider } from './index'
+
+/**
+ * Render a component that reads messages.
+ *
+ * `useI18n` throws outside `LocaleProvider` rather than falling back to a
+ * default locale, which is the right call — a component quietly rendering the
+ * fallback language because a provider went missing is a bug that ships. The
+ * cost is that every test rendering a chrome component needs a wrapper, so
+ * there is one wrapper rather than one per suite.
+ *
+ * Defaults to English so existing assertions keep asserting the strings they
+ * always did; pass `locale` to check a translation actually reaches the screen.
+ */
+export function renderWithI18n(
+  ui: ReactElement,
+  { locale = 'en', ...options }: RenderOptions & { locale?: Locale } = {},
+) {
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <LocaleProvider initialLocale={locale}>{children}</LocaleProvider>
+    ),
+    ...options,
+  })
+}

--- a/src/lib/modules.ts
+++ b/src/lib/modules.ts
@@ -12,154 +12,141 @@ export type ModuleStatus = 'live' | 'placeholder'
  */
 export type ModuleScope = 'group' | 'personal'
 
-export const MODULE_GROUPS = [
-  'Kitchen',
-  'Money',
-  'Home & life',
-  'Tasting',
-] as const
+/**
+ * How All shelves the catalog. Ids rather than headings: the heading is a
+ * translated string and lives in each locale's `modules.ts` under
+ * `lib/i18n/messages/`, keyed by these (ADR-0011).
+ */
+export const MODULE_GROUPS = ['kitchen', 'money', 'home', 'tasting'] as const
 export type ModuleGroup = (typeof MODULE_GROUPS)[number]
 
 /**
- * What a Module is, minus where it lives.
+ * What a Module is, minus where it lives and minus what it is called.
  *
  * There is deliberately no path here. A Module's address is `/g/<slug>/…` and
  * nothing else, and it is written once in `groupPaths.ts` where TanStack Router
  * type-checks it against the generated route tree. A second copy in this
  * registry would be a plain string the router never sees — which is what it
  * used to be, and what let the sidebar point at a route that no longer existed.
+ *
+ * There is deliberately no label or description either, for the same shape of
+ * reason. Both are read by a person, so both are translated, and a translated
+ * string cannot live in a file that no React context may reach. They are keyed
+ * by `id` in the message tree, which typechecks that every Module declared here
+ * has been named there.
  */
 export interface ModuleDef {
   id: string
-  label: string
   icon: string // lucide-react icon name
   group: ModuleGroup
   status: ModuleStatus
   scope: ModuleScope
-  description: string
 }
 
-export const MODULES: ModuleDef[] = [
+export const MODULES = [
   {
     id: 'recipes',
-    label: 'Recipes',
     icon: 'ChefHat',
-    group: 'Kitchen',
+    group: 'kitchen',
     status: 'live',
     scope: 'group',
-    description: 'Keep and rate the dishes you cook.',
   },
   {
     id: 'nutrition',
-    label: 'Nutrition',
     icon: 'Apple',
-    group: 'Kitchen',
+    group: 'kitchen',
     status: 'live',
     // A food diary is about the person keeping it, not the household. It shows
     // the same entries in every Group (ADR-0003).
     scope: 'personal',
-    description: 'Log what you eat and track daily targets.',
   },
   {
     id: 'meal-planner',
-    label: 'Meal planner',
     icon: 'CalendarHeart',
-    group: 'Kitchen',
+    group: 'kitchen',
     status: 'placeholder',
     scope: 'group',
-    description: 'Plan the week’s meals.',
   },
   {
     id: 'groceries',
-    label: 'Groceries',
     icon: 'ShoppingCart',
-    group: 'Kitchen',
+    group: 'kitchen',
     status: 'placeholder',
     scope: 'group',
-    description: 'A shared shopping list you both check off.',
   },
   {
     id: 'pantry',
-    label: 'Pantry',
     icon: 'Refrigerator',
-    group: 'Kitchen',
+    group: 'kitchen',
     status: 'placeholder',
     scope: 'group',
-    description: 'Track what’s in stock at home.',
   },
   {
     id: 'finances',
-    label: 'Finances',
     icon: 'Wallet',
-    group: 'Money',
+    group: 'money',
     status: 'placeholder',
     scope: 'group',
-    description: 'Budgets and spending overview.',
   },
   {
     id: 'bills',
-    label: 'Bills & subscriptions',
     icon: 'Receipt',
-    group: 'Money',
+    group: 'money',
     status: 'placeholder',
     scope: 'group',
-    description: 'Recurring bills and subscriptions.',
   },
   {
     id: 'tasks',
-    label: 'Tasks',
     icon: 'ListChecks',
-    group: 'Home & life',
+    group: 'home',
     status: 'live',
     scope: 'group',
-    description: 'Shared to-do lists.',
   },
   {
     id: 'baby-log',
-    label: 'Baby log',
     icon: 'Baby',
-    group: 'Home & life',
+    group: 'home',
     status: 'live',
     scope: 'group',
-    description: 'Temperature, feeding, sleep, growth and more.',
   },
   {
     id: 'calendar',
-    label: 'Calendar',
     icon: 'Calendar',
-    group: 'Home & life',
+    group: 'home',
     status: 'placeholder',
     scope: 'group',
-    description: 'Household events and reminders.',
   },
   {
     id: 'notes',
-    label: 'Notes',
     icon: 'NotebookPen',
-    group: 'Home & life',
+    group: 'home',
     status: 'placeholder',
     scope: 'group',
-    description: 'Quick shared notes.',
   },
   {
     id: 'cheeses',
-    label: 'Cheeses',
     icon: 'Grape',
-    group: 'Tasting',
+    group: 'tasting',
     status: 'placeholder',
     scope: 'group',
-    description: 'Rate the cheeses you try.',
   },
   {
     id: 'wines',
-    label: 'Wines',
     icon: 'Wine',
-    group: 'Tasting',
+    group: 'tasting',
     status: 'placeholder',
     scope: 'group',
-    description: 'Rate the wines you try.',
   },
-]
+] as const satisfies readonly ModuleDef[]
+
+/**
+ * Every id the registry declares.
+ *
+ * `as const satisfies` above is what makes this a union of the actual ids
+ * rather than `string`, and that union is what the message tree is typed
+ * against — so adding a Module without naming it fails `pnpm typecheck`.
+ */
+export type ModuleId = (typeof MODULES)[number]['id']
 
 /** A Module by id, or undefined when nothing declares that id. */
 export function moduleById(id: string): ModuleDef | undefined {

--- a/src/lib/pins.test.ts
+++ b/src/lib/pins.test.ts
@@ -12,10 +12,10 @@ import {
 describe('what a person has pinned', () => {
   test('is a sensible default before they have chosen anything', () => {
     expect(pinnedModuleIds(undefined)).toEqual([...DEFAULT_PINS])
-    expect(pinnedModules(undefined).map((m) => m.label)).toEqual([
-      'Recipes',
-      'Tasks',
-      'Nutrition',
+    expect(pinnedModules(undefined).map((m) => m.id)).toEqual([
+      'recipes',
+      'tasks',
+      'nutrition',
     ])
   })
 

--- a/src/routes/-app-layout.test.tsx
+++ b/src/routes/-app-layout.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../lib/i18n/testing'
 import { AppLayout } from './_app'
 
 const clerk = vi.hoisted(() => ({
@@ -52,7 +53,7 @@ beforeEach(() => {
 })
 
 test('renders the app once Convex has authenticated the session', () => {
-  render(<AppLayout />)
+  renderWithI18n(<AppLayout />)
 
   expect(screen.getByTestId('app-shell')).toBeInTheDocument()
   expect(screen.getByTestId('outlet')).toBeInTheDocument()
@@ -62,9 +63,9 @@ test('waits while the Convex handshake is still in flight', () => {
   convexAuth.isLoading = true
   convexAuth.isAuthenticated = false
 
-  render(<AppLayout />)
+  renderWithI18n(<AppLayout />)
 
-  expect(screen.getByText('Loading...')).toBeInTheDocument()
+  expect(screen.getByText('Loading…')).toBeInTheDocument()
   expect(screen.queryByTestId('app-shell')).toBeNull()
 })
 
@@ -74,9 +75,9 @@ test('waits out a handshake that has not stalled yet', () => {
   convexAuth.isLoading = false
   convexAuth.isAuthenticated = false
 
-  render(<AppLayout />)
+  renderWithI18n(<AppLayout />)
 
-  expect(screen.getByText('Loading...')).toBeInTheDocument()
+  expect(screen.getByText('Loading…')).toBeInTheDocument()
 })
 
 test('offers a way out instead of an endless spinner once auth stalls', () => {
@@ -84,9 +85,9 @@ test('offers a way out instead of an endless spinner once auth stalls', () => {
   convexAuth.isAuthenticated = false
   stalled.value = true
 
-  render(<AppLayout />)
+  renderWithI18n(<AppLayout />)
 
-  expect(screen.queryByText('Loading...')).toBeNull()
+  expect(screen.queryByText('Loading…')).toBeNull()
   expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument()
 })
 
@@ -100,7 +101,7 @@ test('reloads the page when the user asks', () => {
     value: { ...window.location, reload: reloadMock },
   })
 
-  render(<AppLayout />)
+  renderWithI18n(<AppLayout />)
   fireEvent.click(screen.getByRole('button', { name: /reload/i }))
 
   expect(reloadMock).toHaveBeenCalledTimes(1)
@@ -110,7 +111,7 @@ test('sends signed-out visitors to the sign-in page', () => {
   clerk.isSignedIn = false
   convexAuth.isAuthenticated = false
 
-  render(<AppLayout />)
+  renderWithI18n(<AppLayout />)
 
   expect(navigateMock).toHaveBeenCalledWith({ to: '/sign-in' })
   expect(screen.queryByTestId('app-shell')).toBeNull()
@@ -121,8 +122,8 @@ test('waits for Clerk before deciding anything', () => {
   clerk.isSignedIn = undefined
   convexAuth.isAuthenticated = false
 
-  render(<AppLayout />)
+  renderWithI18n(<AppLayout />)
 
-  expect(screen.getByText('Loading...')).toBeInTheDocument()
+  expect(screen.getByText('Loading…')).toBeInTheDocument()
   expect(navigateMock).not.toHaveBeenCalled()
 })

--- a/src/routes/-group-gate.test.tsx
+++ b/src/routes/-group-gate.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { beforeEach, expect, test, vi } from 'vitest'
 import { GroupGate, useGroup } from '../components/app/GroupGate'
+import { renderWithI18n } from '../lib/i18n/testing'
 
 /**
  * The four states of the `/g/<slug>` gate, and nothing about how they look.
@@ -27,7 +28,7 @@ beforeEach(() => {
 })
 
 test('waits while the Group is still being resolved', () => {
-  render(
+  renderWithI18n(
     <GroupGate slug="jansen-household">
       <ShowGroup />
     </GroupGate>,
@@ -48,7 +49,7 @@ test('renders the page for a member, and tells it which Group it is in', () => {
     role: 'admin',
   }
 
-  render(
+  renderWithI18n(
     <GroupGate slug="jansen-household">
       <ShowGroup />
     </GroupGate>,
@@ -60,7 +61,7 @@ test('renders the page for a member, and tells it which Group it is in', () => {
 test('refuses a Group you are not a member of, and stays put', () => {
   resolution.value = { ok: false, reason: 'not-a-member' }
 
-  render(
+  renderWithI18n(
     <GroupGate slug="someone-elses">
       <ShowGroup />
     </GroupGate>,
@@ -75,7 +76,7 @@ test('refuses a Group you are not a member of, and stays put', () => {
 test('says plainly when no Group has that slug', () => {
   resolution.value = { ok: false, reason: 'unknown-slug' }
 
-  render(
+  renderWithI18n(
     <GroupGate slug="typo">
       <ShowGroup />
     </GroupGate>,
@@ -89,6 +90,6 @@ test('says plainly when no Group has that slug', () => {
 test('a Group-scoped page cannot render outside the gate', () => {
   // Keep React's own error logging out of the test output.
   const error = vi.spyOn(console, 'error').mockImplementation(() => {})
-  expect(() => render(<ShowGroup />)).toThrow(/useGroup/)
+  expect(() => renderWithI18n(<ShowGroup />)).toThrow(/useGroup/)
   error.mockRestore()
 })

--- a/src/routes/-public-pages.test.tsx
+++ b/src/routes/-public-pages.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../lib/i18n/testing'
 import { NotFoundPage } from './__root'
 import { AboutPage } from './about'
 
@@ -58,7 +59,7 @@ vi.mock('../integrations/tanstack-query/devtools', () => ({
 }))
 
 test('about page uses Gather-specific copy in the public frame', () => {
-  render(<AboutPage />)
+  renderWithI18n(<AboutPage />)
 
   expect(screen.getByText('Gather')).toBeDefined()
   expect(
@@ -69,7 +70,7 @@ test('about page uses Gather-specific copy in the public frame', () => {
 })
 
 test('not found page is styled and gives a recovery path', () => {
-  render(<NotFoundPage />)
+  renderWithI18n(<NotFoundPage />)
 
   expect(screen.getByText('Gather')).toBeDefined()
   expect(screen.getByRole('heading', { name: /page not found/i })).toBeDefined()

--- a/src/routes/-sign-in.test.tsx
+++ b/src/routes/-sign-in.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../lib/i18n/testing'
 import { SignInPage } from './sign-in'
 
 const authState = vi.hoisted(() => ({
@@ -52,7 +53,7 @@ test('renders one dev login button from the sign-in form', () => {
   authState.isLoaded = true
   authState.isSignedIn = false
 
-  render(<SignInPage />)
+  renderWithI18n(<SignInPage />)
 
   expect(
     screen.getAllByRole('button', { name: '▶ Dev: log in as test user' }),
@@ -64,7 +65,7 @@ test('redirects signed-in users away from the sign-in page', () => {
   authState.isSignedIn = true
   navigateMock.mockClear()
 
-  render(<SignInPage />)
+  renderWithI18n(<SignInPage />)
 
   expect(navigateMock).toHaveBeenCalledWith({ to: '/' })
 })
@@ -74,7 +75,7 @@ test('keeps form success navigation to the post-auth route', () => {
   authState.isSignedIn = false
   navigateMock.mockClear()
 
-  render(<SignInPage />)
+  renderWithI18n(<SignInPage />)
   fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
 
   expect(navigateMock).toHaveBeenCalledWith({ to: '/' })

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -18,6 +18,14 @@ import { PublicPageFrame } from '../components/app/PublicPageFrame'
 import ClerkProvider from '../integrations/clerk/provider'
 import ConvexProvider from '../integrations/convex/provider'
 import TanStackQueryDevtools from '../integrations/tanstack-query/devtools'
+import {
+  type Locale,
+  LocaleProvider,
+  readClientLocale,
+  useMessages,
+} from '../lib/i18n'
+import { LanguageSync } from '../lib/i18n/LanguageSync'
+import { getSsrLocale } from '../lib/i18n/server'
 import appCss from '../styles.css?url'
 
 interface MyRouterContext {
@@ -53,32 +61,48 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       { rel: 'apple-touch-icon', href: '/apple-touch-icon.png' },
     ],
   }),
+  /**
+   * Which language to draw the first paint in.
+   *
+   * Two branches rather than one server call: after hydration the cookie is
+   * already on this machine, so asking the server again would be a round-trip
+   * to learn something the browser can read synchronously — and a flash of the
+   * wrong language while it is in flight.
+   */
+  loader: async () => {
+    if (typeof document !== 'undefined') {
+      return { locale: readClientLocale() }
+    }
+    const { locale } = (await getSsrLocale()) as { locale: Locale }
+    return { locale }
+  },
   shellComponent: RootDocument,
   notFoundComponent: NotFoundPage,
 })
 
 export function NotFoundPage() {
+  const { notFound } = useMessages().shell
+
   return (
     <PublicPageFrame
-      eyebrow="Not found"
-      title="Page not found"
-      subtitle="Gather has no page at this address."
+      eyebrow={notFound.eyebrow}
+      title={notFound.title}
+      subtitle={notFound.subtitle}
       actions={
         <Link to="/sign-in" className="text-[var(--app-muted)] no-underline">
-          Sign in
+          {notFound.signIn}
         </Link>
       }
     >
       <div className="grid gap-4">
         <p className="m-0 text-sm leading-6 text-[var(--app-muted)]">
-          The page may have moved, or the link may point to a module that has
-          not been added yet.
+          {notFound.body}
         </p>
         <Link
           to="/"
           className="inline-flex min-h-10 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-3 text-sm font-semibold text-[var(--app-surface)] no-underline"
         >
-          Go to Gather
+          {notFound.goHome}
         </Link>
       </div>
     </PublicPageFrame>
@@ -86,6 +110,8 @@ export function NotFoundPage() {
 }
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  const { locale } = Route.useLoaderData()
+
   useEffect(() => {
     if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return
     navigator.serviceWorker.register('/sw.js').catch(() => {
@@ -94,31 +120,37 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   }, [])
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang={locale} suppressHydrationWarning>
       <head>
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: theme no-flash script must run before hydration; content is a static constant from @appelent/auth */}
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <HeadContent />
       </head>
       <body className="font-sans antialiased [overflow-wrap:anywhere]">
-        <ClerkProvider>
-          <ConvexProvider>
-            <AuthConfigProvider config={authConfig}>
-              <ThemeSync />
-              {children}
-              <TanStackDevtools
-                config={{ position: 'bottom-right' }}
-                plugins={[
-                  {
-                    name: 'Tanstack Router',
-                    render: <TanStackRouterDevtoolsPanel />,
-                  },
-                  TanStackQueryDevtools,
-                ]}
-              />
-            </AuthConfigProvider>
-          </ConvexProvider>
-        </ClerkProvider>
+        {/* Outermost, because every provider below it and every page inside
+            them may need a word from it. `LanguageSync` sits further in: it
+            mirrors the choice onto the signed-in user, so it needs Clerk. */}
+        <LocaleProvider initialLocale={locale}>
+          <ClerkProvider>
+            <ConvexProvider>
+              <AuthConfigProvider config={authConfig}>
+                <ThemeSync />
+                <LanguageSync />
+                {children}
+                <TanStackDevtools
+                  config={{ position: 'bottom-right' }}
+                  plugins={[
+                    {
+                      name: 'Tanstack Router',
+                      render: <TanStackRouterDevtoolsPanel />,
+                    },
+                    TanStackQueryDevtools,
+                  ]}
+                />
+              </AuthConfigProvider>
+            </ConvexProvider>
+          </ClerkProvider>
+        </LocaleProvider>
         <Scripts />
       </body>
     </html>

--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react'
 import { api } from '../../convex/_generated/api'
 import { AppShell } from '../components/app/AppShell'
 import { useConvexAuthStalled } from '../integrations/convex/useConvexAuthStalled'
+import { useMessages } from '../lib/i18n'
 
 export const Route = createFileRoute('/_app')({
   component: AppLayout,
@@ -23,6 +24,8 @@ export function AppLayout() {
   // on, so waiting on isAuthenticated alone used to leave the whole app on
   // "Loading..." until the user reloaded by hand. Offer that reload instead.
   const authStalled = useConvexAuthStalled()
+  const messages = useMessages()
+  const { session } = messages.shell
   const ensureUser = useMutation(api.users.ensureUser)
   const navigate = useNavigate()
 
@@ -42,7 +45,7 @@ export function AppLayout() {
     if (!authStalled) {
       return (
         <div className="app-shell grid min-h-svh place-items-center text-sm text-[var(--app-muted)]">
-          Loading...
+          {messages.common.errors.loading}
         </div>
       )
     }
@@ -51,18 +54,15 @@ export function AppLayout() {
       <div className="app-shell grid min-h-svh place-items-center px-6 text-sm text-[var(--app-muted)]">
         <div className="grid max-w-sm justify-items-center gap-3 text-center">
           <p className="m-0 text-base font-semibold text-[var(--app-fg)]">
-            Could not finish signing in
+            {session.stalledTitle}
           </p>
-          <p className="m-0 leading-6">
-            Gather could not connect your session to the backend. Reloading
-            usually fixes it.
-          </p>
+          <p className="m-0 leading-6">{session.stalledBody}</p>
           <button
             type="button"
             onClick={() => window.location.reload()}
             className="inline-flex min-h-10 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-3 text-sm font-semibold text-[var(--app-surface)]"
           >
-            Reload
+            {session.reload}
           </button>
         </div>
       </div>

--- a/src/routes/_app/g/$groupSlug/all.tsx
+++ b/src/routes/_app/g/$groupSlug/all.tsx
@@ -4,7 +4,10 @@ import { ArrowDown, ArrowUp } from 'lucide-react'
 import { api } from '../../../../../convex/_generated/api'
 import { Icon } from '../../../../components/app/Icon'
 import { Pill, SurfaceCard } from '../../../../components/app/ShellPrimitives'
+import type { NavMessages } from '../../../../lib/appNavigation'
+import { moduleText } from '../../../../lib/appNavigation'
 import { moduleLink } from '../../../../lib/groupPaths'
+import { fmt, useMessages } from '../../../../lib/i18n'
 import type { ModuleDef } from '../../../../lib/modules'
 import { MODULE_GROUPS, modulesByGroup } from '../../../../lib/modules'
 import {
@@ -28,10 +31,11 @@ export const Route = createFileRoute('/_app/g/$groupSlug/all')({
 
 /** Says who can see a Module's data, so nobody has to infer it from the URL. */
 function ScopeMark({ module }: { module: ModuleDef }) {
+  const { marks } = useMessages().shell
   if (module.scope !== 'personal') return null
   return (
-    <span title="Only you can see this. It is the same in every group.">
-      <Pill>Only you</Pill>
+    <span title={marks.onlyYouExplained}>
+      <Pill>{marks.onlyYou}</Pill>
     </span>
   )
 }
@@ -39,9 +43,11 @@ function ScopeMark({ module }: { module: ModuleDef }) {
 function ModuleFace({
   module,
   groupSlug,
+  messages,
 }: {
   module: ModuleDef
   groupSlug: string
+  messages: NavMessages
 }) {
   return (
     <Link
@@ -51,7 +57,7 @@ function ModuleFace({
       <span className="grid h-7 w-7 place-items-center rounded-[7px] border border-[var(--app-border)] bg-[var(--app-surface)] text-[var(--app-muted)]">
         <Icon name={module.icon} className="h-4 w-4" />
       </span>
-      <span className="truncate">{module.label}</span>
+      <span className="truncate">{moduleText(module, messages).label}</span>
     </Link>
   )
 }
@@ -64,6 +70,9 @@ const BUTTON =
 
 function AllModulesPage() {
   const { groupSlug } = Route.useParams()
+  const messages = useMessages()
+  const { allModules, marks } = messages.shell
+  const { loading } = messages.common.errors
   // This Group's pins, not the reader's everywhere-pins (ADR-0005) — the page
   // is inside a Group and every pin it shows or writes is about that one.
   const pins = useQuery(api.users.myPins, { groupSlug })
@@ -83,28 +92,30 @@ function AllModulesPage() {
   return (
     <div className="mx-auto grid max-w-4xl gap-4">
       <header>
-        <h1 className="m-0 text-2xl font-semibold">All modules</h1>
+        <h1 className="m-0 text-2xl font-semibold">{allModules.title}</h1>
         <p className="mt-1 mb-0 text-sm leading-6 text-[var(--app-muted)]">
-          Every module is available in this group. Pinning one keeps it in your
-          own navigation here — nobody else in the group sees your choices, and
-          your other groups keep their own.
+          {allModules.intro}
         </p>
       </header>
 
-      <SurfaceCard ariaLabel="Your pins">
-        <h2 className="m-0 mb-2 text-sm font-semibold">Your pins</h2>
+      <SurfaceCard ariaLabel={allModules.yourPins}>
+        <h2 className="m-0 mb-2 text-sm font-semibold">
+          {allModules.yourPins}
+        </h2>
         {pinned.length === 0 ? (
           <p className="m-0 text-sm text-[var(--app-muted)]">
-            {loaded
-              ? 'Nothing pinned. Pin a module below to keep it in your navigation.'
-              : 'Loading…'}
+            {loaded ? allModules.nothingPinned : loading}
           </p>
         ) : (
           <div className="grid">
             {pinned.map((module, index) => (
               <div key={module.id} className={ROW}>
                 <div className="flex min-w-0 items-center gap-2">
-                  <ModuleFace module={module} groupSlug={groupSlug} />
+                  <ModuleFace
+                    module={module}
+                    groupSlug={groupSlug}
+                    messages={messages}
+                  />
                   <ScopeMark module={module} />
                 </div>
                 <div className="flex shrink-0 items-center gap-1">
@@ -112,7 +123,9 @@ function AllModulesPage() {
                     type="button"
                     className={BUTTON}
                     disabled={index === 0}
-                    aria-label={`Move ${module.label} up`}
+                    aria-label={fmt(allModules.moveUp, {
+                      module: moduleText(module, messages).label,
+                    })}
                     onClick={() => write(movePin(ids, module.id, 'up'))}
                   >
                     <ArrowUp className="h-4 w-4" aria-hidden="true" />
@@ -121,7 +134,9 @@ function AllModulesPage() {
                     type="button"
                     className={BUTTON}
                     disabled={index === pinned.length - 1}
-                    aria-label={`Move ${module.label} down`}
+                    aria-label={fmt(allModules.moveDown, {
+                      module: moduleText(module, messages).label,
+                    })}
                     onClick={() => write(movePin(ids, module.id, 'down'))}
                   >
                     <ArrowDown className="h-4 w-4" aria-hidden="true" />
@@ -129,10 +144,12 @@ function AllModulesPage() {
                   <button
                     type="button"
                     className={BUTTON}
-                    aria-label={`Unpin ${module.label}`}
+                    aria-label={fmt(allModules.unpinModule, {
+                      module: moduleText(module, messages).label,
+                    })}
                     onClick={() => write(togglePin(ids, module.id))}
                   >
-                    Unpin
+                    {allModules.unpin}
                   </button>
                 </div>
               </div>
@@ -141,36 +158,47 @@ function AllModulesPage() {
         )}
       </SurfaceCard>
 
-      {MODULE_GROUPS.map((group) => (
-        <SurfaceCard key={group} ariaLabel={group}>
-          <h2 className="m-0 mb-2 text-sm font-semibold">{group}</h2>
-          <div className="grid">
-            {byGroup[group].map((module) => {
-              const isOn = ids.includes(module.id)
-              return (
-                <div key={module.id} className={ROW}>
-                  <div className="flex min-w-0 flex-wrap items-center gap-2">
-                    <ModuleFace module={module} groupSlug={groupSlug} />
-                    {module.status === 'placeholder' ? <Pill>Soon</Pill> : null}
-                    <ScopeMark module={module} />
+      {MODULE_GROUPS.map((group) => {
+        const heading = messages.modules.groups[group]
+        return (
+          <SurfaceCard key={group} ariaLabel={heading}>
+            <h2 className="m-0 mb-2 text-sm font-semibold">{heading}</h2>
+            <div className="grid">
+              {byGroup[group].map((module) => {
+                const isOn = ids.includes(module.id)
+                const name = moduleText(module, messages).label
+                return (
+                  <div key={module.id} className={ROW}>
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <ModuleFace
+                        module={module}
+                        groupSlug={groupSlug}
+                        messages={messages}
+                      />
+                      {module.status === 'placeholder' ? (
+                        <Pill>{marks.soon}</Pill>
+                      ) : null}
+                      <ScopeMark module={module} />
+                    </div>
+                    <button
+                      type="button"
+                      className={BUTTON}
+                      disabled={!loaded}
+                      aria-label={fmt(
+                        isOn ? allModules.unpinModule : allModules.pinModule,
+                        { module: name },
+                      )}
+                      onClick={() => write(togglePin(ids, module.id))}
+                    >
+                      {isOn ? allModules.unpin : allModules.pin}
+                    </button>
                   </div>
-                  <button
-                    type="button"
-                    className={BUTTON}
-                    disabled={!loaded}
-                    aria-label={
-                      isOn ? `Unpin ${module.label}` : `Pin ${module.label}`
-                    }
-                    onClick={() => write(togglePin(ids, module.id))}
-                  >
-                    {isOn ? 'Unpin' : 'Pin'}
-                  </button>
-                </div>
-              )
-            })}
-          </div>
-        </SurfaceCard>
-      ))}
+                )
+              })}
+            </div>
+          </SurfaceCard>
+        )
+      })}
     </div>
   )
 }

--- a/src/routes/_app/g/$groupSlug/bills.tsx
+++ b/src/routes/_app/g/$groupSlug/bills.tsx
@@ -1,15 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ModulePlaceholder } from '../../../../components/app/ModulePlaceholder'
-import { MODULES } from '../../../../lib/modules'
-
-const def = MODULES.find((m) => m.id === 'bills')!
 
 export const Route = createFileRoute('/_app/g/$groupSlug/bills')({
-  component: () => (
-    <ModulePlaceholder
-      label={def.label}
-      description={def.description}
-      icon={def.icon}
-    />
-  ),
+  component: () => <ModulePlaceholder moduleId="bills" />,
 })

--- a/src/routes/_app/g/$groupSlug/calendar.tsx
+++ b/src/routes/_app/g/$groupSlug/calendar.tsx
@@ -1,15 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ModulePlaceholder } from '../../../../components/app/ModulePlaceholder'
-import { MODULES } from '../../../../lib/modules'
-
-const def = MODULES.find((m) => m.id === 'calendar')!
 
 export const Route = createFileRoute('/_app/g/$groupSlug/calendar')({
-  component: () => (
-    <ModulePlaceholder
-      label={def.label}
-      description={def.description}
-      icon={def.icon}
-    />
-  ),
+  component: () => <ModulePlaceholder moduleId="calendar" />,
 })

--- a/src/routes/_app/g/$groupSlug/cheeses.tsx
+++ b/src/routes/_app/g/$groupSlug/cheeses.tsx
@@ -1,15 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ModulePlaceholder } from '../../../../components/app/ModulePlaceholder'
-import { MODULES } from '../../../../lib/modules'
-
-const def = MODULES.find((m) => m.id === 'cheeses')!
 
 export const Route = createFileRoute('/_app/g/$groupSlug/cheeses')({
-  component: () => (
-    <ModulePlaceholder
-      label={def.label}
-      description={def.description}
-      icon={def.icon}
-    />
-  ),
+  component: () => <ModulePlaceholder moduleId="cheeses" />,
 })

--- a/src/routes/_app/g/$groupSlug/finances.tsx
+++ b/src/routes/_app/g/$groupSlug/finances.tsx
@@ -1,15 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ModulePlaceholder } from '../../../../components/app/ModulePlaceholder'
-import { MODULES } from '../../../../lib/modules'
-
-const def = MODULES.find((m) => m.id === 'finances')!
 
 export const Route = createFileRoute('/_app/g/$groupSlug/finances')({
-  component: () => (
-    <ModulePlaceholder
-      label={def.label}
-      description={def.description}
-      icon={def.icon}
-    />
-  ),
+  component: () => <ModulePlaceholder moduleId="finances" />,
 })

--- a/src/routes/_app/g/$groupSlug/groceries.tsx
+++ b/src/routes/_app/g/$groupSlug/groceries.tsx
@@ -1,15 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ModulePlaceholder } from '../../../../components/app/ModulePlaceholder'
-import { MODULES } from '../../../../lib/modules'
-
-const def = MODULES.find((m) => m.id === 'groceries')!
 
 export const Route = createFileRoute('/_app/g/$groupSlug/groceries')({
-  component: () => (
-    <ModulePlaceholder
-      label={def.label}
-      description={def.description}
-      icon={def.icon}
-    />
-  ),
+  component: () => <ModulePlaceholder moduleId="groceries" />,
 })

--- a/src/routes/_app/g/$groupSlug/meal-planner.tsx
+++ b/src/routes/_app/g/$groupSlug/meal-planner.tsx
@@ -1,15 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ModulePlaceholder } from '../../../../components/app/ModulePlaceholder'
-import { MODULES } from '../../../../lib/modules'
-
-const def = MODULES.find((m) => m.id === 'meal-planner')!
 
 export const Route = createFileRoute('/_app/g/$groupSlug/meal-planner')({
-  component: () => (
-    <ModulePlaceholder
-      label={def.label}
-      description={def.description}
-      icon={def.icon}
-    />
-  ),
+  component: () => <ModulePlaceholder moduleId="meal-planner" />,
 })

--- a/src/routes/_app/g/$groupSlug/notes.tsx
+++ b/src/routes/_app/g/$groupSlug/notes.tsx
@@ -1,15 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ModulePlaceholder } from '../../../../components/app/ModulePlaceholder'
-import { MODULES } from '../../../../lib/modules'
-
-const def = MODULES.find((m) => m.id === 'notes')!
 
 export const Route = createFileRoute('/_app/g/$groupSlug/notes')({
-  component: () => (
-    <ModulePlaceholder
-      label={def.label}
-      description={def.description}
-      icon={def.icon}
-    />
-  ),
+  component: () => <ModulePlaceholder moduleId="notes" />,
 })

--- a/src/routes/_app/g/$groupSlug/pantry.tsx
+++ b/src/routes/_app/g/$groupSlug/pantry.tsx
@@ -1,15 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ModulePlaceholder } from '../../../../components/app/ModulePlaceholder'
-import { MODULES } from '../../../../lib/modules'
-
-const def = MODULES.find((m) => m.id === 'pantry')!
 
 export const Route = createFileRoute('/_app/g/$groupSlug/pantry')({
-  component: () => (
-    <ModulePlaceholder
-      label={def.label}
-      description={def.description}
-      icon={def.icon}
-    />
-  ),
+  component: () => <ModulePlaceholder moduleId="pantry" />,
 })

--- a/src/routes/_app/g/$groupSlug/settings.tsx
+++ b/src/routes/_app/g/$groupSlug/settings.tsx
@@ -3,6 +3,7 @@ import { useGroup } from '../../../../components/app/GroupGate'
 import { ConnectionsSettings } from '../../../../components/settings/ConnectionsSettings'
 import { GroupIdentitySettings } from '../../../../components/settings/GroupIdentitySettings'
 import { GroupMembersSettings } from '../../../../components/settings/GroupMembersSettings'
+import { fmt, useMessages } from '../../../../lib/i18n'
 
 /**
  * A Group's own settings, as against `/settings`, which is yours.
@@ -27,6 +28,7 @@ function GroupSettings() {
   // The gate has already resolved this Group and refused anyone who is not a
   // Member, so the name is here to be read rather than queried for again.
   const group = useGroup()
+  const { groupPage } = useMessages().settings
 
   return (
     // See `GroupHome` for why the track is `minmax(0,1fr)` and the heading is
@@ -35,11 +37,10 @@ function GroupSettings() {
     <div className="mx-auto grid max-w-2xl grid-cols-[minmax(0,1fr)] gap-4">
       <header>
         <h1 className="m-0 text-xl font-semibold wrap-anywhere">
-          {group.name} settings
+          {fmt(groupPage.title, { group: group.name })}
         </h1>
         <p className="mt-1 mb-0 text-sm leading-6 text-[var(--app-muted)]">
-          Settings shared by everyone in this group. Your own appearance and
-          account settings are in Settings, and are the same in every group.
+          {groupPage.intro}
         </p>
       </header>
       <GroupIdentitySettings group={group} />

--- a/src/routes/_app/g/$groupSlug/wines.tsx
+++ b/src/routes/_app/g/$groupSlug/wines.tsx
@@ -1,15 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ModulePlaceholder } from '../../../../components/app/ModulePlaceholder'
-import { MODULES } from '../../../../lib/modules'
-
-const def = MODULES.find((m) => m.id === 'wines')!
 
 export const Route = createFileRoute('/_app/g/$groupSlug/wines')({
-  component: () => (
-    <ModulePlaceholder
-      label={def.label}
-      description={def.description}
-      icon={def.icon}
-    />
-  ),
+  component: () => <ModulePlaceholder moduleId="wines" />,
 })

--- a/src/routes/_app/groups.tsx
+++ b/src/routes/_app/groups.tsx
@@ -6,6 +6,7 @@ import { api } from '../../../convex/_generated/api'
 import { Pill, SurfaceCard } from '../../components/app/ShellPrimitives'
 import { errorMessage } from '../../lib/errorMessage'
 import { groupLink } from '../../lib/groupPaths'
+import { useMessages } from '../../lib/i18n'
 
 export const Route = createFileRoute('/_app/groups')({ component: GroupsPage })
 
@@ -38,14 +39,14 @@ function GroupsPage() {
   const [name, setName] = useState('')
   const [code, setCode] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const { groups: text } = useMessages().shell
 
   return (
     <div className="mx-auto grid max-w-2xl grid-cols-[minmax(0,1fr)] gap-4">
       <header>
-        <h1 className="m-0 text-2xl font-semibold">Groups</h1>
+        <h1 className="m-0 text-2xl font-semibold">{text.title}</h1>
         <p className="mt-1 mb-0 text-sm leading-6 text-[var(--app-muted)]">
-          The households you are in. Open one to change its name, share its
-          invite code, or leave it.
+          {text.intro}
         </p>
       </header>
 
@@ -61,7 +62,7 @@ function GroupsPage() {
       {groups === undefined ? (
         <div className="h-24 animate-pulse rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface-muted)]" />
       ) : (
-        <SurfaceCard ariaLabel="Your groups">
+        <SurfaceCard ariaLabel={text.yours}>
           <ul className="m-0 grid list-none gap-1 p-0">
             {groups.map((g) => (
               <li key={g._id}>
@@ -78,7 +79,7 @@ function GroupsPage() {
                       word; `minmax(0,1fr)` above is what lets it truncate
                       instead of widening the page. */}
                   <span className="truncate">{g.name}</span>
-                  {g.isPersonal ? <Pill>Personal</Pill> : null}
+                  {g.isPersonal ? <Pill>{text.personal}</Pill> : null}
                   <ChevronRight
                     className="h-4 w-4 shrink-0 text-[var(--app-muted)]"
                     aria-hidden="true"
@@ -101,24 +102,24 @@ function GroupsPage() {
                 void createGroup({ name: name.trim() })
                   .then(() => setName(''))
                   .catch((err) =>
-                    setError(errorMessage(err, 'Could not create that group.')),
+                    setError(errorMessage(err, text.createFailed)),
                   )
             }}
           >
-            <h2 className="m-0 text-base font-semibold">New group</h2>
+            <h2 className="m-0 text-base font-semibold">{text.createTitle}</h2>
             <p className="m-0 text-sm text-[var(--app-muted)]">
-              A household of your own. You start as its admin.
+              {text.createBody}
             </p>
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="e.g. Wine club"
-              aria-label="New group name"
+              placeholder={text.createPlaceholder}
+              aria-label={text.createLabel}
               className={INPUT}
             />
             <div>
               <button type="submit" className={BUTTON}>
-                Create
+                {text.create}
               </button>
             </div>
           </form>
@@ -133,27 +134,23 @@ function GroupsPage() {
               if (code.trim())
                 void joinByInvite({ inviteCode: code.trim() })
                   .then(() => setCode(''))
-                  .catch((err) =>
-                    setError(
-                      errorMessage(err, 'Could not join with that code.'),
-                    ),
-                  )
+                  .catch((err) => setError(errorMessage(err, text.joinFailed)))
             }}
           >
-            <h2 className="m-0 text-base font-semibold">Join with a code</h2>
+            <h2 className="m-0 text-base font-semibold">{text.joinTitle}</h2>
             <p className="m-0 text-sm text-[var(--app-muted)]">
-              Somebody in the group finds it in that group's settings.
+              {text.joinBody}
             </p>
             <input
               value={code}
               onChange={(e) => setCode(e.target.value)}
-              placeholder="8-char code"
-              aria-label="Invite code"
+              placeholder={text.joinPlaceholder}
+              aria-label={text.joinLabel}
               className={INPUT}
             />
             <div>
               <button type="submit" className={BUTTON}>
-                Join
+                {text.join}
               </button>
             </div>
           </form>

--- a/src/routes/_app/integrations.callback.tsx
+++ b/src/routes/_app/integrations.callback.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import { SurfaceCard } from '../../components/app/ShellPrimitives'
 import { errorMessage } from '../../lib/errorMessage'
+import { useMessages } from '../../lib/i18n'
 import { consumeOAuthState, oauthRedirectUri } from '../../lib/oauth'
 
 export const Route = createFileRoute('/_app/integrations/callback')({
@@ -15,11 +16,22 @@ export const Route = createFileRoute('/_app/integrations/callback')({
   component: OAuthCallback,
 })
 
+/**
+ * Why the round-trip failed, as a key — except for a server error, which
+ * carries its own sentence. This effect must run exactly once (it consumes the
+ * one-time OAuth state), so it cannot depend on the message tree; the words are
+ * chosen at render instead (ADR-0011).
+ */
+type Failure =
+  | { kind: 'cancelled' | 'invalid' | 'noGroup' }
+  | { kind: 'error'; message: string }
+
 function OAuthCallback() {
   const { code, state, error } = Route.useSearch()
   const completeOAuth = useAction(api.integrations.completeOAuth)
   const navigate = useNavigate()
-  const [failure, setFailure] = useState<string | null>(null)
+  const [failure, setFailure] = useState<Failure | null>(null)
+  const { oauthCallback } = useMessages().shell
   const started = useRef(false)
 
   useEffect(() => {
@@ -27,11 +39,11 @@ function OAuthCallback() {
     started.current = true
     const consumed = consumeOAuthState(state)
     if (error) {
-      setFailure('The connection was cancelled or refused.')
+      setFailure({ kind: 'cancelled' })
       return
     }
     if (!code || !consumed) {
-      setFailure('Invalid connection response — try connecting again.')
+      setFailure({ kind: 'invalid' })
       return
     }
     // A connection belongs to a Group, and this page is not inside one: the
@@ -39,9 +51,7 @@ function OAuthCallback() {
     // it there is nowhere to store the token, and picking a Group on the
     // caller's behalf is the guess ADR-0002 exists to stop — so this fails.
     if (!consumed.groupSlug) {
-      setFailure(
-        'That connection came back without a group — start it again from the group’s settings page.',
-      )
+      setFailure({ kind: 'noGroup' })
       return
     }
     completeOAuth({
@@ -51,9 +61,7 @@ function OAuthCallback() {
       redirectUri: oauthRedirectUri(),
     })
       .then(() => navigate({ to: consumed.returnTo as '/settings' }))
-      .catch((e) =>
-        setFailure(errorMessage(e, 'Connecting failed — try again.')),
-      )
+      .catch((e) => setFailure({ kind: 'error', message: errorMessage(e, '') }))
   }, [code, state, error, completeOAuth, navigate])
 
   return (
@@ -61,15 +69,21 @@ function OAuthCallback() {
       <SurfaceCard>
         {failure ? (
           <div className="grid gap-2">
-            <h2 className="m-0 text-base font-semibold">Connection failed</h2>
-            <p className="m-0 text-sm text-[var(--app-muted)]">{failure}</p>
+            <h2 className="m-0 text-base font-semibold">
+              {oauthCallback.failedTitle}
+            </h2>
+            <p className="m-0 text-sm text-[var(--app-muted)]">
+              {failure.kind === 'error'
+                ? failure.message || oauthCallback.failed
+                : oauthCallback[failure.kind]}
+            </p>
             <Link to="/settings" className="text-sm font-semibold">
-              Back to settings
+              {oauthCallback.backToSettings}
             </Link>
           </div>
         ) : (
           <p className="m-0 text-sm text-[var(--app-muted)]">
-            Finishing the connection…
+            {oauthCallback.finishing}
           </p>
         )}
       </SurfaceCard>

--- a/src/routes/_app/settings.tsx
+++ b/src/routes/_app/settings.tsx
@@ -1,7 +1,9 @@
 import { AppearanceSettings } from '@appelent/auth'
 import { createFileRoute } from '@tanstack/react-router'
 import { GroupSettingsLinks } from '../../components/settings/GroupSettingsLinks'
+import { LanguageSettings } from '../../components/settings/LanguageSettings'
 import { SampleDataSettings } from '../../components/settings/SampleDataSettings'
+import { useMessages } from '../../lib/i18n'
 
 /**
  * Your settings: the ones that are about you and read the same in every Group.
@@ -11,9 +13,18 @@ import { SampleDataSettings } from '../../components/settings/SampleDataSettings
  * a way to get to each of your Groups' settings from where they used to be.
  */
 export const Route = createFileRoute('/_app/settings')({
-  component: () => (
+  component: SettingsPage,
+})
+
+function SettingsPage() {
+  const { settings } = useMessages()
+
+  return (
     <div className="mx-auto grid max-w-2xl gap-4">
-      <h1 className="m-0 mb-4 text-xl font-semibold">Settings</h1>
+      <h1 className="m-0 mb-4 text-xl font-semibold">{settings.title}</h1>
+      {/* Language above appearance: it is the setting that changes the words
+          of every other setting on this page, including its own. */}
+      <LanguageSettings />
       <AppearanceSettings />
       <GroupSettingsLinks />
       {/* Renders nothing unless this build enabled sample data. Stays here
@@ -22,5 +33,5 @@ export const Route = createFileRoute('/_app/settings')({
           whichever Group you happen to be standing in. */}
       <SampleDataSettings />
     </div>
-  ),
-})
+  )
+}

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,29 +1,23 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { PublicPageFrame } from '../components/app/PublicPageFrame'
+import { useMessages } from '../lib/i18n'
 
 export const Route = createFileRoute('/about')({
   component: AboutPage,
 })
 
 export function AboutPage() {
+  const { about } = useMessages().shell
+
   return (
     <PublicPageFrame
-      eyebrow="About Gather"
-      title="One shared group for everyday coordination"
-      subtitle="Gather keeps shared recipes, plans, lists, tasks, notes, and tasting logs in one place, for the people who share a household."
+      eyebrow={about.eyebrow}
+      title={about.title}
+      subtitle={about.subtitle}
     >
       <div className="grid gap-3 text-sm leading-6 text-[var(--app-muted)]">
-        <p className="m-0">
-          Recipes and Nutrition are live today, and the surrounding modules are
-          staged so a group can grow into meal planning, groceries, pantry
-          tracking, finances, bills, tasks, calendar, notes, cheeses, and wines
-          without changing products.
-        </p>
-        <p className="m-0">
-          Every module is available in every group. You pin the ones you use to
-          your own navigation, and the rest stay one click away — your choices
-          are yours alone and never move anybody else's.
-        </p>
+        <p className="m-0">{about.modules}</p>
+        <p className="m-0">{about.pins}</p>
       </div>
     </PublicPageFrame>
   )


### PR DESCRIPTION
Applies the Appelent **i18n** feature to gather: `@appelent/i18n` for the engine, and gather's own `src/lib/i18n/` for the message trees, root-route wiring and switchers. Recorded in `appelent.json` as `i18n@1` with locales `["en", "nl"]`.

English is the source language; Dutch `satisfies` it, so a missing key is a typecheck failure rather than a hole somebody finds in production.

Two commits: the first wires the engine and converts the shell, the second converts every Module. Reviewing them separately is easier than reading the diff whole.

## Scope

**Translated: everything gather renders.** The shell (navigation, topbar, Group switcher, Home, All, placeholder pages, not-found, `/settings`, the Ask Gather and Report-an-issue panels) and every Module — Recipes, Nutrition, Foods, Tasks, the Baby log, a Group's own settings — plus the Groups page, About, the OAuth callback and the auth-stalled screen.

**Never translated: content.** Recipe titles, tags, ingredients and steps; task titles and list names; Group and Member names; a child's name and the notes written about them; everything Open Food Facts returns; every fixture in `convex/lib/seed/`. Getting this line wrong in one direction bleeds translations into the database and in the other leaves half the interface English, so it is what ADR-0011 spends most of its words on.

**Out of reach:** `@appelent/auth`'s own strings — the sign-in forms, the account panel, `AppearanceSettings` — belong to that package.

## Display strings left the files that could not translate them

This is the part worth reviewing carefully, because it moved data rather than just wrapping literals.

Four records of English lived where no message tree could reach: `NUTRIENT_LABELS` and `MEAL_LABELS` in `convex/lib/`, `BABY_EVENT_LABELS` in `convex/lib/babyEvents.ts`, and the baby-log option labels in `src/lib/babyEventFields.ts`. Same for a Module's `label`/`description` in `lib/modules.ts`. All of them moved to the message tree keyed by the union the schema already defines — `ModuleId`, `NutrientKey`, `MealName`, `BabyEventType` — so **adding a Module or an event type without naming it is now a compile error**.

`BABY_EVENT_LABELS` was the one with a server-side reader: `activity.ts` used it to title a baby-log entry, which is the backend choosing a display word. It sends the type key now, so `GroupActivityEntry.title` means content for a recipe or a task and a type key for a baby event. The field's comment spells that out, and `convex/activity.test.ts` asserts the key.

## Two rules that fell out of doing this at scale

- **A validator returns a key, not a sentence.** `buildEventInput` reports `'enterVaccineName'`; the form that shows the complaint resolves it. The validator stays a pure function nobody has to hand a message tree to.
- **A message read inside a `useEffect` puts the locale in that effect's dependencies.** Wrong for the camera stream in `BarcodeScanner` (it would tear down and restart the camera on a language switch) and for the once-only OAuth callback (it must not re-run at all). Both hold a key in state and choose the words at render. Biome's `useExhaustiveDependencies` catches this; adding the dependency is usually the wrong fix.

Non-React code takes messages as a trailing parameter — `navItems`, `getRouteContext`, `formatActivityTime`, `formatAge`, `summarizeEvent` — rather than importing the context, which is what keeps `lib/` callable from a test with no React tree.

## A bug worth reading about

`@appelent/i18n` exports a `createGetSsrLocale` factory. It cannot work, in any app: TanStack Start's Vite plugin rewrites `createServerFn(...).handler(...)` calls it finds in **app source** into registered endpoints, and never looks inside a pre-bundled dependency. The packaged server fn is therefore never registered, and calling it returns `undefined` rather than running the handler — silently, until SSR tried to destructure the result.

`src/lib/i18n/server.ts` declares the server function itself and takes only the pure `resolveLocale` from the package. ADR-0011 says so where somebody would otherwise "simplify" it back. The package and the `i18n` skill both need fixing in the catalog repo; that is filed separately.

Typecheck and 805 tests were green while this bug was live — it only surfaced in the browser, which is the argument for the verification below.

## Verification

`pnpm typecheck`, `pnpm check` and `pnpm test` (805 passing) are green. `assertMessageParity` was confirmed to actually fail on an empty string and on a dropped `{placeholder}`, rather than passing vacuously.

Driven in the running app, in Dutch, across every module:

- `Accept-Language: nl` alone renders Dutch with no cookie set; the toggle flips everything; `<html lang>` and the `lang` cookie follow.
- **The server-rendered HTML itself** carries `lang="nl"` with `{locale:"nl"}` in the root loader data — no flash of English before hydration.
- Recipes, Tasks, Nutrition, Foods, Baby log (list, detail, an entry form, the timeline), All modules, a placeholder page, Groups, `/settings` and a Group's settings all render Dutch, with content untouched beside it.
- Dates and relative times follow the locale: `di 4 aug, 13:30`, `1 minuut geleden`, `5 maanden oud`.
- The `/settings` panel and the topbar toggle read and write the same state; Clerk's `unsafeMetadata.language` mirrors the choice, and a signed-in user's saved language wins over the browser's guess.
- No console errors on any surface; mobile dock labels fit without clipping or horizontal overflow.

## Notes

- Every English string is byte-identical to the literal it replaced, which is why the existing `getByText`/`getByRole({name})` assertions are untouched. Tests that render an i18n component now go through `renderWithI18n`; `useI18n` throws outside `LocaleProvider` rather than quietly falling back, which is the right call and the reason the helper exists.
- **One string changed rather than moved:** the app layout said `Loading...` where every other loading state said `Loading…`. They are one message now, and four assertions in `-app-layout.test.tsx` follow it.
- Durations inside a summary (`1h 15m`) are not localised. They are compact enough to read either way, and doing it properly means a duration formatter rather than a message — noted in ADR-0011 rather than half-done.
- `convex/_generated/api.d.ts` is deliberately **not** in this PR. `convex dev` regenerated it for `lib/groupAccess` and `lib/stableDigest`, two modules already committed on `main` whose generated types were stale. Unrelated drift, left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
