### PR TITLE
feat: prepare photos before storing them

### DIFF
--- a/src/components/app/ImageUploadField.test.tsx
+++ b/src/components/app/ImageUploadField.test.tsx
@@ -114,6 +114,28 @@ describe('choosing a photo', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
+  test('cancelling during a slow prepare still uploads nothing', async () => {
+    // Preparing is not instant on a phone with a 4032x3024 photo, and the
+    // person can leave while it runs. What finishes afterwards is not theirs
+    // to upload — they abandoned it.
+    const pipeline = stubImagePipeline({ width: 4032, height: 3024 })
+    const finishEncoding = pipeline.deferEncoding()
+    const { onChange } = renderField()
+    choose()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Use photo' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+    finishEncoding()
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: 'Frame your photo' }),
+      ).not.toBeInTheDocument(),
+    )
+    expect(uploaded).toHaveLength(0)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   test('the same file can be chosen again after cancelling', async () => {
     renderField()
     choose()

--- a/src/components/app/ImageUploadField.test.tsx
+++ b/src/components/app/ImageUploadField.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { stubImagePipeline } from '../../test/imagePipeline'
 import { ImageUploadField } from './ImageUploadField'
 
 /**
@@ -18,21 +19,14 @@ const CHOSEN = new File(['original bytes'], 'IMG_4021.HEIC', {
 })
 
 const uploaded: Array<{ body: unknown; headers: Record<string, string> }> = []
-let decode: () => Promise<{ width: number; height: number; close: () => void }>
 
-function stubImagePipeline() {
-  vi.stubGlobal(
-    'createImageBitmap',
-    vi.fn(() => decode()),
-  )
-  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
-    drawImage: vi.fn(),
-  } as unknown as CanvasRenderingContext2D)
-  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(
-    (callback, type) => {
-      callback(new Blob(['prepared jpeg'], { type: type ?? 'image/png' }))
+/** Stub a browser that cannot read the chosen file. */
+function givenAnUnreadablePhoto() {
+  stubImagePipeline({
+    decode: async () => {
+      throw new Error('unsupported image type')
     },
-  )
+  })
 }
 
 function renderField(preset: 'childPhoto' | 'recipePhoto' = 'childPhoto') {
@@ -55,8 +49,7 @@ function choose(file: File = CHOSEN) {
 
 beforeEach(() => {
   uploaded.length = 0
-  decode = async () => ({ width: 4032, height: 3024, close: vi.fn() })
-  stubImagePipeline()
+  stubImagePipeline({ width: 4032, height: 3024 })
   vi.stubGlobal(
     'fetch',
     vi.fn(async (_url: string, init: RequestInit) => {
@@ -136,9 +129,7 @@ describe('choosing a photo', () => {
 
 describe('an image this browser cannot read', () => {
   test('says so, and uploads nothing', async () => {
-    decode = async () => {
-      throw new Error('unsupported image type')
-    }
+    givenAnUnreadablePhoto()
     const { onChange } = renderField()
 
     choose()
@@ -151,9 +142,7 @@ describe('an image this browser cannot read', () => {
   })
 
   test('offers no way to confirm a frame it never drew', async () => {
-    decode = async () => {
-      throw new Error('unsupported image type')
-    }
+    givenAnUnreadablePhoto()
     renderField()
     choose()
 

--- a/src/components/app/ImageUploadField.test.tsx
+++ b/src/components/app/ImageUploadField.test.tsx
@@ -1,0 +1,197 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { ImageUploadField } from './ImageUploadField'
+
+/**
+ * The upload field, driven the way a person drives it: choose a file, frame it,
+ * confirm — or don't.
+ *
+ * These run through the real crop editor and the real prepare step, with only
+ * the browser's image pipeline and the network stubbed, because the guarantee
+ * this feature exists to make is about *when* an upload happens as much as
+ * about what is in it. A test that mocked preparing would still pass if
+ * choosing a file uploaded the original.
+ */
+
+const CHOSEN = new File(['original bytes'], 'IMG_4021.HEIC', {
+  type: 'image/jpeg',
+})
+
+const uploaded: Array<{ body: unknown; headers: Record<string, string> }> = []
+let decode: () => Promise<{ width: number; height: number; close: () => void }>
+
+function stubImagePipeline() {
+  vi.stubGlobal(
+    'createImageBitmap',
+    vi.fn(() => decode()),
+  )
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+    drawImage: vi.fn(),
+  } as unknown as CanvasRenderingContext2D)
+  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(
+    (callback, type) => {
+      callback(new Blob(['prepared jpeg'], { type: type ?? 'image/png' }))
+    },
+  )
+}
+
+function renderField(preset: 'childPhoto' | 'recipePhoto' = 'childPhoto') {
+  const onChange = vi.fn()
+  render(
+    <ImageUploadField
+      imageUrl={null}
+      preset={preset}
+      onChange={onChange}
+      generateUploadUrl={async () => 'https://convex.example/upload'}
+    />,
+  )
+  return { onChange }
+}
+
+function choose(file: File = CHOSEN) {
+  const input = screen.getByLabelText('Photo')
+  fireEvent.change(input, { target: { files: [file] } })
+}
+
+beforeEach(() => {
+  uploaded.length = 0
+  decode = async () => ({ width: 4032, height: 3024, close: vi.fn() })
+  stubImagePipeline()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init: RequestInit) => {
+      uploaded.push({
+        body: init.body,
+        headers: init.headers as Record<string, string>,
+      })
+      return {
+        ok: true,
+        json: async () => ({ storageId: 'kg2stored' }),
+      } as Response
+    }),
+  )
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('choosing a photo', () => {
+  test('uploads nothing until the person confirms the frame', async () => {
+    const { onChange } = renderField()
+
+    choose()
+
+    await screen.findByRole('dialog', { name: 'Frame your photo' })
+    expect(uploaded).toHaveLength(0)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('uploads the prepared photo once, as a JPEG, on confirming', async () => {
+    const { onChange } = renderField()
+    choose()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Use photo' }))
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('kg2stored'))
+    expect(uploaded).toHaveLength(1)
+    expect(uploaded[0].headers).toEqual({ 'Content-Type': 'image/jpeg' })
+    expect(uploaded[0].body).toBeInstanceOf(Blob)
+    // The file the person chose is not what went up.
+    expect((uploaded[0].body as Blob).type).toBe('image/jpeg')
+    expect(await (uploaded[0].body as Blob).text()).toBe('prepared jpeg')
+    expect(
+      screen.queryByRole('dialog', { name: 'Frame your photo' }),
+    ).not.toBeInTheDocument()
+  })
+
+  test('abandoning the frame uploads nothing at all', async () => {
+    const { onChange } = renderField()
+    choose()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: 'Frame your photo' }),
+      ).not.toBeInTheDocument(),
+    )
+    expect(uploaded).toHaveLength(0)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('the same file can be chosen again after cancelling', async () => {
+    renderField()
+    choose()
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }))
+
+    choose()
+
+    expect(
+      await screen.findByRole('dialog', { name: 'Frame your photo' }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe('an image this browser cannot read', () => {
+  test('says so, and uploads nothing', async () => {
+    decode = async () => {
+      throw new Error('unsupported image type')
+    }
+    const { onChange } = renderField()
+
+    choose()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toMatch(/could not be opened/i)
+    expect(alert.textContent).toMatch(/JPEG/)
+    expect(uploaded).toHaveLength(0)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('offers no way to confirm a frame it never drew', async () => {
+    decode = async () => {
+      throw new Error('unsupported image type')
+    }
+    renderField()
+    choose()
+
+    await screen.findByRole('alert')
+    expect(screen.getByRole('button', { name: 'Use photo' })).toBeDisabled()
+  })
+})
+
+describe('what the preset decides', () => {
+  test("a child's photo is stored as a 512px square", async () => {
+    renderField('childPhoto')
+    choose()
+
+    expect(await screen.findByText(/Stored as 512 × 512/)).toBeInTheDocument()
+  })
+
+  test('a recipe photo keeps the whole frame at 1600px', async () => {
+    renderField('recipePhoto')
+    choose()
+
+    expect(await screen.findByText(/Stored as 1600 × 1200/)).toBeInTheDocument()
+  })
+})
+
+describe('when the upload itself fails', () => {
+  test('says so and reports no storage id', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false }) as Response),
+    )
+    const { onChange } = renderField()
+    choose()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Use photo' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not upload that image',
+    )
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/app/ImageUploadField.tsx
+++ b/src/components/app/ImageUploadField.tsx
@@ -1,10 +1,36 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { Id } from '../../../convex/_generated/dataModel'
+import type { PhotoPresetName } from '../../lib/photoPresets'
+import type { PreparedPhoto } from '../../lib/preparePhoto'
+import { PREPARED_PHOTO_TYPE } from '../../lib/preparePhoto'
+import { PhotoPrepareDialog } from './PhotoPrepareDialog'
+
+/**
+ * The one place in Gather a person's photo becomes a stored blob.
+ *
+ * Choosing a file starts the framing step and nothing else: no request is made
+ * until the person confirms, and abandoning the step uploads nothing at all.
+ * What is uploaded is the prepared photo — cropped, shrunk, re-encoded as JPEG,
+ * stripped of the EXIF that carried where it was taken — and never the file
+ * that was chosen (ADR-0010).
+ *
+ * How preparing behaves is the preset's business, not this component's and not
+ * the call site's. This is handed a preset name and never a dimension, which is
+ * what stops four upload sites from becoming four answers.
+ *
+ * The timing contract with the parent is unchanged and worth restating, because
+ * the framing step is a new chance to break it: `onChange` fires with a storage
+ * id only once that id exists in Convex, and with `undefined` only when the
+ * person clears the photo. A form is never holding an id for a blob that was
+ * never uploaded.
+ */
 
 interface ImageUploadFieldProps {
   imageUrl: string | null
   onChange: (imageId: Id<'_storage'> | undefined) => void
   generateUploadUrl: () => Promise<string>
+  /** Which preparing rules apply — see `photoPresets.ts`. */
+  preset: PhotoPresetName
   label?: string
   fieldId?: string
 }
@@ -13,30 +39,38 @@ export function ImageUploadField({
   imageUrl,
   onChange,
   generateUploadUrl,
+  preset,
   label = 'Photo',
   fieldId = 'image-upload',
 }: ImageUploadFieldProps) {
   const [uploading, setUploading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [choosing, setChoosing] = useState<File | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const handleFile = async (file: File) => {
+  // One owner for the preview's object URL: it is released when it is replaced
+  // and when the field goes away, and nowhere else.
+  useEffect(() => {
+    if (!previewUrl) return
+    return () => URL.revokeObjectURL(previewUrl)
+  }, [previewUrl])
+
+  const upload = async (prepared: PreparedPhoto) => {
     setUploading(true)
     setError(null)
     try {
       const uploadUrl = await generateUploadUrl()
       const res = await fetch(uploadUrl, {
         method: 'POST',
-        headers: { 'Content-Type': file.type },
-        body: file,
+        headers: { 'Content-Type': PREPARED_PHOTO_TYPE },
+        body: prepared.blob,
       })
       if (!res.ok) throw new Error('Upload failed')
       const { storageId } = (await res.json()) as { storageId: Id<'_storage'> }
-      setPreviewUrl((prev) => {
-        if (prev) URL.revokeObjectURL(prev)
-        return URL.createObjectURL(file)
-      })
+      // The preview is the blob that was stored, so what the person sees after
+      // saving is what they will see when the page is loaded again.
+      setPreviewUrl(URL.createObjectURL(prepared.blob))
       onChange(storageId)
     } catch {
       setError('Could not upload that image')
@@ -72,20 +106,27 @@ export function ImageUploadField({
             disabled={uploading}
             onChange={(e) => {
               const file = e.target.files?.[0]
-              if (file) handleFile(file)
+              // Cleared straight away so that choosing the same file again
+              // after cancelling still counts as a change.
+              e.target.value = ''
+              if (file) {
+                setError(null)
+                setChoosing(file)
+              }
             }}
           />
           {uploading && <p className="text-xs opacity-60">Uploading…</p>}
-          {error && <p className="text-xs text-red-800">{error}</p>}
+          {error && (
+            <p role="alert" className="text-xs text-red-800">
+              {error}
+            </p>
+          )}
           {displayUrl && !uploading && (
             <button
               type="button"
               className="mt-1 block text-xs underline"
               onClick={() => {
-                setPreviewUrl((prev) => {
-                  if (prev) URL.revokeObjectURL(prev)
-                  return null
-                })
+                setPreviewUrl(null)
                 onChange(undefined)
                 if (inputRef.current) inputRef.current.value = ''
               }}
@@ -95,6 +136,17 @@ export function ImageUploadField({
           )}
         </div>
       </div>
+      {choosing ? (
+        <PhotoPrepareDialog
+          file={choosing}
+          preset={preset}
+          onCancel={() => setChoosing(null)}
+          onConfirm={(prepared) => {
+            setChoosing(null)
+            void upload(prepared)
+          }}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/components/app/ImageUploadField.tsx
+++ b/src/components/app/ImageUploadField.tsx
@@ -46,7 +46,7 @@ export function ImageUploadField({
   const [uploading, setUploading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
-  const [choosing, setChoosing] = useState<File | null>(null)
+  const [chosenFile, setChosenFile] = useState<File | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   // One owner for the preview's object URL: it is released when it is replaced
@@ -111,7 +111,7 @@ export function ImageUploadField({
               e.target.value = ''
               if (file) {
                 setError(null)
-                setChoosing(file)
+                setChosenFile(file)
               }
             }}
           />
@@ -136,13 +136,13 @@ export function ImageUploadField({
           )}
         </div>
       </div>
-      {choosing ? (
+      {chosenFile ? (
         <PhotoPrepareDialog
-          file={choosing}
+          file={chosenFile}
           preset={preset}
-          onCancel={() => setChoosing(null)}
+          onCancel={() => setChosenFile(null)}
           onConfirm={(prepared) => {
-            setChoosing(null)
+            setChosenFile(null)
             void upload(prepared)
           }}
         />

--- a/src/components/app/PhotoPrepareDialog.test.tsx
+++ b/src/components/app/PhotoPrepareDialog.test.tsx
@@ -1,0 +1,206 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { PhotoPrepareDialog } from './PhotoPrepareDialog'
+
+/**
+ * The framing step, checked at the only place its result is observable from a
+ * test: the region it hands to `drawImage`.
+ *
+ * Dragging is not exercised here — jsdom gives every element a zero-sized box,
+ * so a pointer drag has no pixels to convert — and it does not need to be. The
+ * geometry a drag runs through is `cropFrame`, tested there against the cases
+ * that matter; what is left for this file is that the dialog opens on the right
+ * frame, keeps a locked frame locked through the controls a person actually
+ * has, and hands over only what was framed.
+ */
+
+const drawImage = vi.fn()
+
+/** The crop region passed to `drawImage`, in source pixels. */
+function drawnRegion() {
+  const [, x, y, width, height] = drawImage.mock.calls[0] as number[]
+  return { x, y, width, height }
+}
+
+function stubImagePipeline(width: number, height: number) {
+  vi.stubGlobal(
+    'createImageBitmap',
+    vi.fn(async () => ({ width, height, close: vi.fn() })),
+  )
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+    drawImage,
+  } as unknown as CanvasRenderingContext2D)
+  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(
+    (callback, type) => callback(new Blob(['jpeg'], { type: type ?? '' })),
+  )
+}
+
+function renderDialog(preset: 'childPhoto' | 'recipePhoto') {
+  const onConfirm = vi.fn()
+  const onCancel = vi.fn()
+  render(
+    <PhotoPrepareDialog
+      file={new File(['bytes'], 'photo.jpg', { type: 'image/jpeg' })}
+      preset={preset}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />,
+  )
+  return { onConfirm, onCancel }
+}
+
+async function confirm() {
+  const button = await screen.findByRole('button', { name: 'Use photo' })
+  await waitFor(() => expect(button).toBeEnabled())
+  fireEvent.click(button)
+}
+
+beforeEach(() => {
+  drawImage.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('the frame a photo opens with', () => {
+  test('a recipe photo opens on the whole image, so confirming crops nothing', async () => {
+    stubImagePipeline(4032, 3024)
+    const { onConfirm } = renderDialog('recipePhoto')
+
+    await confirm()
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled())
+    expect(drawnRegion()).toEqual({ x: 0, y: 0, width: 4032, height: 3024 })
+  })
+
+  test("a child's photo opens on the largest square, centred", async () => {
+    stubImagePipeline(4032, 3024)
+    const { onConfirm } = renderDialog('childPhoto')
+
+    await confirm()
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled())
+    expect(drawnRegion()).toEqual({ x: 504, y: 0, width: 3024, height: 3024 })
+  })
+
+  test('a portrait photo is framed against its upright dimensions', async () => {
+    // What `createImageBitmap` returns here is already rotated, because it is
+    // asked for `imageOrientation: 'from-image'`. The frame follows the
+    // upright shape rather than the shape the pixels are stored in.
+    stubImagePipeline(3024, 4032)
+    renderDialog('childPhoto')
+
+    expect(await screen.findByText(/Stored as 512 × 512/)).toBeInTheDocument()
+    await confirm()
+    await waitFor(() => expect(drawImage).toHaveBeenCalled())
+    expect(drawnRegion()).toEqual({ x: 0, y: 504, width: 3024, height: 3024 })
+  })
+})
+
+describe("a child's frame cannot be made non-square", () => {
+  test('not with the size slider', async () => {
+    stubImagePipeline(4032, 3024)
+    const { onConfirm } = renderDialog('childPhoto')
+
+    const slider = await screen.findByLabelText('Frame size')
+    fireEvent.change(slider, { target: { value: '37' } })
+    await confirm()
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled())
+    const region = drawnRegion()
+    expect(region.width).toBe(region.height)
+    expect(region.width).toBeLessThan(3024)
+  })
+
+  test('not with the resize handle', async () => {
+    stubImagePipeline(4032, 3024)
+    const { onConfirm } = renderDialog('childPhoto')
+
+    const handle = await screen.findByRole('button', { name: 'Resize frame' })
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' })
+    fireEvent.keyDown(handle, { key: 'ArrowUp' })
+    await confirm()
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled())
+    const region = drawnRegion()
+    expect(region.width).toBe(region.height)
+  })
+
+  test('and the photo it hands back is square', async () => {
+    stubImagePipeline(4032, 3024)
+    const { onConfirm } = renderDialog('childPhoto')
+
+    const slider = await screen.findByLabelText('Frame size')
+    fireEvent.change(slider, { target: { value: '63' } })
+    await confirm()
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled())
+    const prepared = onConfirm.mock.calls[0][0]
+    expect(prepared.width).toBe(prepared.height)
+    expect(prepared.width).toBeLessThanOrEqual(512)
+  })
+})
+
+describe('moving the frame', () => {
+  test('arrow keys move it, for anyone who cannot drag', async () => {
+    stubImagePipeline(4032, 3024)
+    const { onConfirm } = renderDialog('childPhoto')
+
+    const frame = await screen.findByRole('button', { name: 'Move frame' })
+    fireEvent.keyDown(frame, { key: 'ArrowLeft' })
+    await confirm()
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled())
+    expect(drawnRegion()).toMatchObject({ x: 423, width: 3024 })
+  })
+
+  test('never past the edge of the image', async () => {
+    stubImagePipeline(4032, 3024)
+    const { onConfirm } = renderDialog('childPhoto')
+
+    const frame = await screen.findByRole('button', { name: 'Move frame' })
+    for (let i = 0; i < 40; i++) {
+      fireEvent.keyDown(frame, { key: 'ArrowRight' })
+    }
+    await confirm()
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled())
+    const region = drawnRegion()
+    expect(region.x + region.width).toBe(4032)
+  })
+})
+
+describe('leaving without a photo', () => {
+  test('Escape cancels', async () => {
+    stubImagePipeline(4032, 3024)
+    const { onCancel, onConfirm } = renderDialog('childPhoto')
+    await screen.findByRole('button', { name: 'Move frame' })
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(onCancel).toHaveBeenCalled()
+    expect(onConfirm).not.toHaveBeenCalled()
+    expect(drawImage).not.toHaveBeenCalled()
+  })
+
+  test('a failed prepare keeps the dialog open and hands back nothing', async () => {
+    stubImagePipeline(4032, 3024)
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(
+      // The silent PNG substitution `canvas.toBlob` is specified to make.
+      (callback) => callback(new Blob(['png'], { type: 'image/png' })),
+    )
+    const { onConfirm } = renderDialog('recipePhoto')
+
+    await confirm()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /could not be prepared/i,
+    )
+    expect(onConfirm).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole('dialog', { name: 'Frame your photo' }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/app/PhotoPrepareDialog.test.tsx
+++ b/src/components/app/PhotoPrepareDialog.test.tsx
@@ -1,5 +1,9 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import {
+  type StubbedImagePipeline,
+  stubImagePipeline,
+} from '../../test/imagePipeline'
 import { PhotoPrepareDialog } from './PhotoPrepareDialog'
 
 /**
@@ -14,25 +18,11 @@ import { PhotoPrepareDialog } from './PhotoPrepareDialog'
  * has, and hands over only what was framed.
  */
 
-const drawImage = vi.fn()
+let pipeline: StubbedImagePipeline
 
-/** The crop region passed to `drawImage`, in source pixels. */
-function drawnRegion() {
-  const [, x, y, width, height] = drawImage.mock.calls[0] as number[]
-  return { x, y, width, height }
-}
-
-function stubImagePipeline(width: number, height: number) {
-  vi.stubGlobal(
-    'createImageBitmap',
-    vi.fn(async () => ({ width, height, close: vi.fn() })),
-  )
-  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
-    drawImage,
-  } as unknown as CanvasRenderingContext2D)
-  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(
-    (callback, type) => callback(new Blob(['jpeg'], { type: type ?? '' })),
-  )
+/** Stub the browser's image pipeline for a photo of the given upright size. */
+function givenPhoto(width: number, height: number) {
+  pipeline = stubImagePipeline({ width, height })
 }
 
 function renderDialog(preset: 'childPhoto' | 'recipePhoto') {
@@ -55,10 +45,6 @@ async function confirm() {
   fireEvent.click(button)
 }
 
-beforeEach(() => {
-  drawImage.mockReset()
-})
-
 afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
@@ -66,42 +52,57 @@ afterEach(() => {
 
 describe('the frame a photo opens with', () => {
   test('a recipe photo opens on the whole image, so confirming crops nothing', async () => {
-    stubImagePipeline(4032, 3024)
+    givenPhoto(4032, 3024)
     const { onConfirm } = renderDialog('recipePhoto')
 
     await confirm()
 
     await waitFor(() => expect(onConfirm).toHaveBeenCalled())
-    expect(drawnRegion()).toEqual({ x: 0, y: 0, width: 4032, height: 3024 })
+    expect(pipeline.drawnRegion()).toEqual({
+      x: 0,
+      y: 0,
+      width: 4032,
+      height: 3024,
+    })
   })
 
   test("a child's photo opens on the largest square, centred", async () => {
-    stubImagePipeline(4032, 3024)
+    givenPhoto(4032, 3024)
     const { onConfirm } = renderDialog('childPhoto')
 
     await confirm()
 
     await waitFor(() => expect(onConfirm).toHaveBeenCalled())
-    expect(drawnRegion()).toEqual({ x: 504, y: 0, width: 3024, height: 3024 })
+    expect(pipeline.drawnRegion()).toEqual({
+      x: 504,
+      y: 0,
+      width: 3024,
+      height: 3024,
+    })
   })
 
   test('a portrait photo is framed against its upright dimensions', async () => {
     // What `createImageBitmap` returns here is already rotated, because it is
     // asked for `imageOrientation: 'from-image'`. The frame follows the
     // upright shape rather than the shape the pixels are stored in.
-    stubImagePipeline(3024, 4032)
+    givenPhoto(3024, 4032)
     renderDialog('childPhoto')
 
     expect(await screen.findByText(/Stored as 512 × 512/)).toBeInTheDocument()
     await confirm()
-    await waitFor(() => expect(drawImage).toHaveBeenCalled())
-    expect(drawnRegion()).toEqual({ x: 0, y: 504, width: 3024, height: 3024 })
+    await waitFor(() => expect(pipeline.drawImage).toHaveBeenCalled())
+    expect(pipeline.drawnRegion()).toEqual({
+      x: 0,
+      y: 504,
+      width: 3024,
+      height: 3024,
+    })
   })
 })
 
 describe("a child's frame cannot be made non-square", () => {
   test('not with the size slider', async () => {
-    stubImagePipeline(4032, 3024)
+    givenPhoto(4032, 3024)
     const { onConfirm } = renderDialog('childPhoto')
 
     const slider = await screen.findByLabelText('Frame size')
@@ -109,13 +110,13 @@ describe("a child's frame cannot be made non-square", () => {
     await confirm()
 
     await waitFor(() => expect(onConfirm).toHaveBeenCalled())
-    const region = drawnRegion()
+    const region = pipeline.drawnRegion()
     expect(region.width).toBe(region.height)
     expect(region.width).toBeLessThan(3024)
   })
 
   test('not with the resize handle', async () => {
-    stubImagePipeline(4032, 3024)
+    givenPhoto(4032, 3024)
     const { onConfirm } = renderDialog('childPhoto')
 
     const handle = await screen.findByRole('button', { name: 'Resize frame' })
@@ -124,12 +125,12 @@ describe("a child's frame cannot be made non-square", () => {
     await confirm()
 
     await waitFor(() => expect(onConfirm).toHaveBeenCalled())
-    const region = drawnRegion()
+    const region = pipeline.drawnRegion()
     expect(region.width).toBe(region.height)
   })
 
   test('and the photo it hands back is square', async () => {
-    stubImagePipeline(4032, 3024)
+    givenPhoto(4032, 3024)
     const { onConfirm } = renderDialog('childPhoto')
 
     const slider = await screen.findByLabelText('Frame size')
@@ -145,7 +146,7 @@ describe("a child's frame cannot be made non-square", () => {
 
 describe('moving the frame', () => {
   test('arrow keys move it, for anyone who cannot drag', async () => {
-    stubImagePipeline(4032, 3024)
+    givenPhoto(4032, 3024)
     const { onConfirm } = renderDialog('childPhoto')
 
     const frame = await screen.findByRole('button', { name: 'Move frame' })
@@ -153,11 +154,11 @@ describe('moving the frame', () => {
     await confirm()
 
     await waitFor(() => expect(onConfirm).toHaveBeenCalled())
-    expect(drawnRegion()).toMatchObject({ x: 423, width: 3024 })
+    expect(pipeline.drawnRegion()).toMatchObject({ x: 423, width: 3024 })
   })
 
   test('never past the edge of the image', async () => {
-    stubImagePipeline(4032, 3024)
+    givenPhoto(4032, 3024)
     const { onConfirm } = renderDialog('childPhoto')
 
     const frame = await screen.findByRole('button', { name: 'Move frame' })
@@ -167,14 +168,36 @@ describe('moving the frame', () => {
     await confirm()
 
     await waitFor(() => expect(onConfirm).toHaveBeenCalled())
-    const region = drawnRegion()
+    const region = pipeline.drawnRegion()
     expect(region.x + region.width).toBe(4032)
+  })
+})
+
+describe('focus', () => {
+  test('lands on the frame, which is the control the dialog is for', async () => {
+    givenPhoto(4032, 3024)
+    renderDialog('childPhoto')
+
+    const frame = await screen.findByRole('button', { name: 'Move frame' })
+    await waitFor(() => expect(frame).toHaveFocus())
+  })
+
+  test('is not snatched back off the slider while it is being used', async () => {
+    givenPhoto(4032, 3024)
+    renderDialog('childPhoto')
+
+    const slider = await screen.findByLabelText('Frame size')
+    slider.focus()
+    fireEvent.change(slider, { target: { value: '60' } })
+    fireEvent.change(slider, { target: { value: '55' } })
+
+    await waitFor(() => expect(slider).toHaveFocus())
   })
 })
 
 describe('leaving without a photo', () => {
   test('Escape cancels', async () => {
-    stubImagePipeline(4032, 3024)
+    givenPhoto(4032, 3024)
     const { onCancel, onConfirm } = renderDialog('childPhoto')
     await screen.findByRole('button', { name: 'Move frame' })
 
@@ -182,15 +205,13 @@ describe('leaving without a photo', () => {
 
     expect(onCancel).toHaveBeenCalled()
     expect(onConfirm).not.toHaveBeenCalled()
-    expect(drawImage).not.toHaveBeenCalled()
+    expect(pipeline.drawImage).not.toHaveBeenCalled()
   })
 
   test('a failed prepare keeps the dialog open and hands back nothing', async () => {
-    stubImagePipeline(4032, 3024)
-    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(
-      // The silent PNG substitution `canvas.toBlob` is specified to make.
-      (callback) => callback(new Blob(['png'], { type: 'image/png' })),
-    )
+    givenPhoto(4032, 3024)
+    // The silent PNG substitution `canvas.toBlob` is specified to make.
+    pipeline.encodesTo(new Blob(['png'], { type: 'image/png' }))
     const { onConfirm } = renderDialog('recipePhoto')
 
     await confirm()

--- a/src/components/app/PhotoPrepareDialog.test.tsx
+++ b/src/components/app/PhotoPrepareDialog.test.tsx
@@ -208,6 +208,19 @@ describe('leaving without a photo', () => {
     expect(pipeline.drawImage).not.toHaveBeenCalled()
   })
 
+  test('Escape during a slow prepare drops what finishes afterwards', async () => {
+    givenPhoto(4032, 3024)
+    const finishEncoding = pipeline.deferEncoding()
+    const { onCancel, onConfirm } = renderDialog('recipePhoto')
+
+    await confirm()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    finishEncoding()
+
+    await waitFor(() => expect(onCancel).toHaveBeenCalled())
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
   test('a failed prepare keeps the dialog open and hands back nothing', async () => {
     givenPhoto(4032, 3024)
     // The silent PNG substitution `canvas.toBlob` is specified to make.

--- a/src/components/app/PhotoPrepareDialog.tsx
+++ b/src/components/app/PhotoPrepareDialog.tsx
@@ -1,0 +1,333 @@
+import {
+  type PointerEvent as ReactPointerEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import {
+  type CropRect,
+  cropFraction,
+  initialCrop,
+  moveCrop,
+  resizeCrop,
+  scaleCrop,
+} from '../../lib/cropFrame'
+import { errorMessage } from '../../lib/errorMessage'
+import { type PhotoPresetName, photoPreset } from '../../lib/photoPresets'
+import {
+  type DecodedPhoto,
+  decodePhoto,
+  outputSize,
+  PHOTO_PREPARE_ERROR,
+  type PreparedPhoto,
+  preparePhoto,
+} from '../../lib/preparePhoto'
+import { SurfaceCard } from './ShellPrimitives'
+
+/**
+ * The framing step: the whole of what "prepare" looks like to a person
+ * (ADR-0010).
+ *
+ * It is shown on every upload rather than behind an "adjust" affordance,
+ * because mis-framing is permanent here — there is no original to re-crop from,
+ * only the stored square — and a step nobody finds is a step that never
+ * corrects anything. Nothing is uploaded while this is open, and closing it
+ * uploads nothing at all: the caller is handed prepared bytes exactly once, on
+ * confirm.
+ *
+ * Two pixel spaces meet here and must not be confused. The frame lives in the
+ * decoded image's own pixels; the preview is however many CSS pixels the box
+ * happens to be. Drags convert from the second to the first on the way in, and
+ * the overlay is positioned as a percentage on the way out, so nothing between
+ * them depends on the size of the screen.
+ *
+ * The preview is the chosen file drawn by the browser, while the bytes come
+ * from a bitmap decoded with `imageOrientation: 'from-image'`. Those agree:
+ * both apply the EXIF orientation, which is what makes framing a portrait photo
+ * mean the same thing on screen as it does on the canvas.
+ */
+
+interface PhotoPrepareDialogProps {
+  file: File
+  preset: PhotoPresetName
+  onCancel: () => void
+  onConfirm: (prepared: PreparedPhoto) => void
+}
+
+export function PhotoPrepareDialog({
+  file,
+  preset,
+  onCancel,
+  onConfirm,
+}: PhotoPrepareDialogProps) {
+  const { aspect, maxEdge } = photoPreset(preset)
+  const [photo, setPhoto] = useState<DecodedPhoto | null>(null)
+  const [crop, setCrop] = useState<CropRect | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [preparing, setPreparing] = useState(false)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const imageRef = useRef<HTMLImageElement>(null)
+
+  useEffect(() => {
+    const url = URL.createObjectURL(file)
+    setPreviewUrl(url)
+    return () => URL.revokeObjectURL(url)
+  }, [file])
+
+  // Decoding is where "this browser cannot read this image" is found out, so it
+  // happens before any framing is offered rather than after it is done.
+  useEffect(() => {
+    let decodedPhoto: DecodedPhoto | null = null
+    let abandoned = false
+    setError(null)
+    decodePhoto(file)
+      .then((next) => {
+        decodedPhoto = next
+        if (abandoned) {
+          next.close()
+          return
+        }
+        setPhoto(next)
+        setCrop(initialCrop(next, aspect))
+      })
+      .catch((e: unknown) => {
+        if (!abandoned) setError(errorMessage(e, PHOTO_PREPARE_ERROR))
+      })
+    return () => {
+      abandoned = true
+      decodedPhoto?.close()
+      setPhoto(null)
+      setCrop(null)
+    }
+  }, [file, aspect])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onCancel()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onCancel])
+
+  /**
+   * A drag in progress, frozen at the moment it started.
+   *
+   * Deltas are measured from the frame the drag began with rather than
+   * accumulated onto the current one, so a drag that is clamped at an edge and
+   * then dragged back returns to where it was instead of drifting.
+   */
+  const dragRef = useRef<{
+    startX: number
+    startY: number
+    from: CropRect
+    mode: 'move' | 'resize'
+    /** Source pixels per CSS pixel of the preview. */
+    scale: number
+  } | null>(null)
+
+  const beginDrag =
+    (mode: 'move' | 'resize') => (event: ReactPointerEvent<HTMLElement>) => {
+      if (!photo || !crop) return
+      const box = imageRef.current?.getBoundingClientRect()
+      if (!box || box.width === 0) return
+      event.preventDefault()
+      event.stopPropagation()
+      dragRef.current = {
+        startX: event.clientX,
+        startY: event.clientY,
+        from: crop,
+        mode,
+        scale: photo.width / box.width,
+      }
+      event.currentTarget.setPointerCapture?.(event.pointerId)
+    }
+
+  const onPointerMove = (event: ReactPointerEvent<HTMLElement>) => {
+    const drag = dragRef.current
+    if (!drag || !photo) return
+    const dx = (event.clientX - drag.startX) * drag.scale
+    const dy = (event.clientY - drag.startY) * drag.scale
+    setCrop(
+      drag.mode === 'move'
+        ? moveCrop(drag.from, photo, dx, dy)
+        : resizeCrop(drag.from, photo, aspect, dx, dy),
+    )
+  }
+
+  const endDrag = (event: ReactPointerEvent<HTMLElement>) => {
+    if (!dragRef.current) return
+    dragRef.current = null
+    event.currentTarget.releasePointerCapture?.(event.pointerId)
+  }
+
+  /** Arrow keys, for the people a pointer drag leaves with no way to frame. */
+  const nudge =
+    (mode: 'move' | 'resize') => (event: React.KeyboardEvent<HTMLElement>) => {
+      if (!photo || !crop) return
+      const step = Math.max(1, Math.round(photo.width / 50))
+      const deltas: Record<string, [number, number]> = {
+        ArrowLeft: [-step, 0],
+        ArrowRight: [step, 0],
+        ArrowUp: [0, -step],
+        ArrowDown: [0, step],
+      }
+      const delta = deltas[event.key]
+      if (!delta) return
+      event.preventDefault()
+      event.stopPropagation()
+      setCrop(
+        mode === 'move'
+          ? moveCrop(crop, photo, delta[0], delta[1])
+          : resizeCrop(crop, photo, aspect, delta[0], delta[1]),
+      )
+    }
+
+  const confirm = async () => {
+    if (!photo || !crop || preparing) return
+    setPreparing(true)
+    setError(null)
+    try {
+      onConfirm(await preparePhoto(photo, crop, photoPreset(preset)))
+    } catch (e: unknown) {
+      setError(errorMessage(e, PHOTO_PREPARE_ERROR))
+      setPreparing(false)
+    }
+  }
+
+  const stored = crop ? outputSize(crop, maxEdge) : null
+
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-black/40 p-4">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Frame your photo"
+        className="w-[min(36rem,100%)]"
+      >
+        <SurfaceCard>
+          <div className="grid gap-3">
+            <div>
+              <h2 className="m-0 text-base font-semibold">Frame your photo</h2>
+              <p className="m-0 text-sm text-[var(--app-muted)]">
+                {aspect === null
+                  ? 'Drag to move the frame, or drag its corner to resize. Gather stores what is inside it.'
+                  : 'Drag to move the square, or drag its corner to resize. Gather stores what is inside it.'}
+              </p>
+            </div>
+
+            {error ? (
+              <p
+                role="alert"
+                className="m-0 rounded-[var(--app-radius)] border border-[color-mix(in_oklch,var(--app-danger)_45%,var(--app-border))] px-3 py-2 text-sm text-[var(--app-danger)]"
+              >
+                {error}
+              </p>
+            ) : null}
+
+            {!error && previewUrl ? (
+              <div className="grid justify-items-center overflow-hidden">
+                <div className="relative inline-block leading-none">
+                  {/* Decorative: the person chose this image a moment ago, and
+                      the frame over it is what carries the label. */}
+                  <img
+                    ref={imageRef}
+                    src={previewUrl}
+                    alt=""
+                    className="block max-h-[50vh] max-w-full select-none"
+                    draggable={false}
+                  />
+                  {/*
+                    The frame and its handle are siblings rather than nested,
+                    because both are things a person grabs — with a pointer or
+                    with the arrow keys once focused — and a control inside a
+                    control is neither valid HTML nor reachable by keyboard.
+                  */}
+                  {crop && photo ? (
+                    <>
+                      <button
+                        type="button"
+                        aria-label="Move frame"
+                        onPointerDown={beginDrag('move')}
+                        onPointerMove={onPointerMove}
+                        onPointerUp={endDrag}
+                        onPointerCancel={endDrag}
+                        onKeyDown={nudge('move')}
+                        className="absolute cursor-move touch-none border-2 border-white bg-transparent p-0 shadow-[0_0_0_9999px_rgba(0,0,0,0.45)] outline-offset-2"
+                        style={{
+                          left: `${(crop.x / photo.width) * 100}%`,
+                          top: `${(crop.y / photo.height) * 100}%`,
+                          width: `${(crop.width / photo.width) * 100}%`,
+                          height: `${(crop.height / photo.height) * 100}%`,
+                        }}
+                      />
+                      <button
+                        type="button"
+                        aria-label="Resize frame"
+                        onPointerDown={beginDrag('resize')}
+                        onPointerMove={onPointerMove}
+                        onPointerUp={endDrag}
+                        onPointerCancel={endDrag}
+                        onKeyDown={nudge('resize')}
+                        className="absolute h-5 w-5 -translate-x-1/2 -translate-y-1/2 cursor-nwse-resize touch-none rounded-full border-2 border-white bg-[var(--app-accent,#0f766e)]"
+                        style={{
+                          left: `${((crop.x + crop.width) / photo.width) * 100}%`,
+                          top: `${((crop.y + crop.height) / photo.height) * 100}%`,
+                        }}
+                      />
+                    </>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
+
+            {crop && photo ? (
+              <label className="grid gap-1 text-sm">
+                <span className="font-medium">Frame size</span>
+                <input
+                  type="range"
+                  min={5}
+                  max={100}
+                  value={Math.round(cropFraction(crop, photo, aspect) * 100)}
+                  onChange={(event) =>
+                    setCrop(
+                      scaleCrop(
+                        crop,
+                        photo,
+                        aspect,
+                        Number(event.target.value) / 100,
+                      ),
+                    )
+                  }
+                />
+              </label>
+            ) : null}
+
+            <p className="m-0 text-xs text-[var(--app-muted)]">
+              {stored
+                ? `Stored as ${stored.width} × ${stored.height} — the photo on your phone is untouched.`
+                : 'Opening photo…'}
+            </p>
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onCancel}
+                className="inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={!crop || preparing}
+                onClick={() => void confirm()}
+                className="inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold disabled:opacity-60"
+              >
+                {preparing ? 'Preparing…' : 'Use photo'}
+              </button>
+            </div>
+          </div>
+        </SurfaceCard>
+      </div>
+    </div>
+  )
+}

--- a/src/components/app/PhotoPrepareDialog.tsx
+++ b/src/components/app/PhotoPrepareDialog.tsx
@@ -10,6 +10,7 @@ import {
   initialCrop,
   moveCrop,
   resizeCrop,
+  type Size,
   scaleCrop,
 } from '../../lib/cropFrame'
 import { errorMessage } from '../../lib/errorMessage'
@@ -60,13 +61,17 @@ export function PhotoPrepareDialog({
   onCancel,
   onConfirm,
 }: PhotoPrepareDialogProps) {
-  const { aspect, maxEdge } = photoPreset(preset)
+  const rules = photoPreset(preset)
+  const { aspect, maxEdge } = rules
   const [photo, setPhoto] = useState<DecodedPhoto | null>(null)
   const [crop, setCrop] = useState<CropRect | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [preparing, setPreparing] = useState(false)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const imageRef = useRef<HTMLImageElement>(null)
+  const frameRef = useRef<HTMLButtonElement>(null)
+  const openerRef = useRef<HTMLElement | null>(null)
+  const framePlacedRef = useRef(false)
 
   useEffect(() => {
     const url = URL.createObjectURL(file)
@@ -109,6 +114,50 @@ export function PhotoPrepareDialog({
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [onCancel])
 
+  // Focus goes to the frame and comes back to the file input afterwards, the
+  // same way `ConfirmAction` treats the question it opens. It matters more
+  // here: the frame is the control, and someone working by keyboard would
+  // otherwise have to tab into a dialog to reach the only thing in it that
+  // does anything.
+  useEffect(() => {
+    openerRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
+    return () => {
+      const opener = openerRef.current
+      if (opener?.isConnected) opener.focus()
+    }
+  }, [])
+
+  // Once, when the frame first appears — not on every adjustment, which would
+  // snatch focus back off the size slider as someone was using it.
+  useEffect(() => {
+    if (!crop || framePlacedRef.current) return
+    framePlacedRef.current = true
+    frameRef.current?.focus()
+  }, [crop])
+
+  /** Tab stays inside the framing step until it is answered one way or another. */
+  const keepFocusInside = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') return
+    const focusable = Array.from(
+      event.currentTarget.querySelectorAll<HTMLElement>(
+        'button:not(:disabled), [href], input:not(:disabled), [tabindex]:not([tabindex="-1"])',
+      ),
+    )
+    const first = focusable[0]
+    const last = focusable.at(-1)
+    if (!first || !last) return
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
   /**
    * A drag in progress, frozen at the moment it started.
    *
@@ -142,15 +191,35 @@ export function PhotoPrepareDialog({
       event.currentTarget.setPointerCapture?.(event.pointerId)
     }
 
+  /**
+   * What a grab of each handle means, in one place.
+   *
+   * A pointer drag and an arrow key are the same two gestures arriving by
+   * different routes, so they resolve to the same pair of functions here
+   * rather than each branching on the mode for itself.
+   */
+  const dragged = (
+    mode: 'move' | 'resize',
+    from: CropRect,
+    image: Size,
+    dx: number,
+    dy: number,
+  ): CropRect =>
+    mode === 'move'
+      ? moveCrop(from, image, dx, dy)
+      : resizeCrop(from, image, aspect, dx, dy)
+
   const onPointerMove = (event: ReactPointerEvent<HTMLElement>) => {
     const drag = dragRef.current
     if (!drag || !photo) return
-    const dx = (event.clientX - drag.startX) * drag.scale
-    const dy = (event.clientY - drag.startY) * drag.scale
     setCrop(
-      drag.mode === 'move'
-        ? moveCrop(drag.from, photo, dx, dy)
-        : resizeCrop(drag.from, photo, aspect, dx, dy),
+      dragged(
+        drag.mode,
+        drag.from,
+        photo,
+        (event.clientX - drag.startX) * drag.scale,
+        (event.clientY - drag.startY) * drag.scale,
+      ),
     )
   }
 
@@ -175,11 +244,7 @@ export function PhotoPrepareDialog({
       if (!delta) return
       event.preventDefault()
       event.stopPropagation()
-      setCrop(
-        mode === 'move'
-          ? moveCrop(crop, photo, delta[0], delta[1])
-          : resizeCrop(crop, photo, aspect, delta[0], delta[1]),
-      )
+      setCrop(dragged(mode, crop, photo, delta[0], delta[1]))
     }
 
   const confirm = async () => {
@@ -187,14 +252,14 @@ export function PhotoPrepareDialog({
     setPreparing(true)
     setError(null)
     try {
-      onConfirm(await preparePhoto(photo, crop, photoPreset(preset)))
+      onConfirm(await preparePhoto(photo, crop, rules))
     } catch (e: unknown) {
       setError(errorMessage(e, PHOTO_PREPARE_ERROR))
       setPreparing(false)
     }
   }
 
-  const stored = crop ? outputSize(crop, maxEdge) : null
+  const storedSize = crop ? outputSize(crop, maxEdge) : null
 
   return (
     <div className="fixed inset-0 z-50 grid place-items-center bg-black/40 p-4">
@@ -202,6 +267,7 @@ export function PhotoPrepareDialog({
         role="dialog"
         aria-modal="true"
         aria-label="Frame your photo"
+        onKeyDown={keepFocusInside}
         className="w-[min(36rem,100%)]"
       >
         <SurfaceCard>
@@ -245,6 +311,7 @@ export function PhotoPrepareDialog({
                   {crop && photo ? (
                     <>
                       <button
+                        ref={frameRef}
                         type="button"
                         aria-label="Move frame"
                         onPointerDown={beginDrag('move')}
@@ -303,8 +370,8 @@ export function PhotoPrepareDialog({
             ) : null}
 
             <p className="m-0 text-xs text-[var(--app-muted)]">
-              {stored
-                ? `Stored as ${stored.width} × ${stored.height} — the photo on your phone is untouched.`
+              {storedSize
+                ? `Stored as ${storedSize.width} × ${storedSize.height} — the photo on your phone is untouched.`
                 : 'Opening photo…'}
             </p>
 

--- a/src/components/app/PhotoPrepareDialog.tsx
+++ b/src/components/app/PhotoPrepareDialog.tsx
@@ -1,5 +1,6 @@
 import {
   type PointerEvent as ReactPointerEvent,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -72,6 +73,7 @@ export function PhotoPrepareDialog({
   const frameRef = useRef<HTMLButtonElement>(null)
   const openerRef = useRef<HTMLElement | null>(null)
   const framePlacedRef = useRef(false)
+  const abandonedRef = useRef(false)
 
   useEffect(() => {
     const url = URL.createObjectURL(file)
@@ -106,13 +108,27 @@ export function PhotoPrepareDialog({
     }
   }, [file, aspect])
 
+  // Leaving is final, and it is recorded the moment the person goes rather
+  // than whenever the unmount lands, so nothing in flight can outlive it.
+  useEffect(() => {
+    abandonedRef.current = false
+    return () => {
+      abandonedRef.current = true
+    }
+  }, [])
+
+  const abandon = useCallback(() => {
+    abandonedRef.current = true
+    onCancel()
+  }, [onCancel])
+
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onCancel()
+      if (event.key === 'Escape') abandon()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [onCancel])
+  }, [abandon])
 
   // Focus goes to the frame and comes back to the file input afterwards, the
   // same way `ConfirmAction` treats the question it opens. It matters more
@@ -252,8 +268,15 @@ export function PhotoPrepareDialog({
     setPreparing(true)
     setError(null)
     try {
-      onConfirm(await preparePhoto(photo, crop, rules))
+      const prepared = await preparePhoto(photo, crop, rules)
+      // Preparing is not instant, and the person can leave while it runs.
+      // Bytes that arrive after they did are not theirs to upload: "abandoning
+      // the prepare step uploads nothing at all" has to hold in this gap too,
+      // which is the only place the guarantee is racy.
+      if (abandonedRef.current) return
+      onConfirm(prepared)
     } catch (e: unknown) {
+      if (abandonedRef.current) return
       setError(errorMessage(e, PHOTO_PREPARE_ERROR))
       setPreparing(false)
     }
@@ -378,7 +401,7 @@ export function PhotoPrepareDialog({
             <div className="flex justify-end gap-2">
               <button
                 type="button"
-                onClick={onCancel}
+                onClick={abandon}
                 className="inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold"
               >
                 Cancel

--- a/src/components/baby/EditBabyPage.tsx
+++ b/src/components/baby/EditBabyPage.tsx
@@ -84,6 +84,7 @@ function EditBabyForm({
 
       <ImageUploadField
         imageUrl={photoUrl}
+        preset="childPhoto"
         generateUploadUrl={generateUploadUrl}
         fieldId="baby-photo-upload"
         onChange={(id) => {

--- a/src/components/baby/NewBabyPage.tsx
+++ b/src/components/baby/NewBabyPage.tsx
@@ -41,6 +41,7 @@ export function NewBabyPage({ groupSlug, nav }: NewBabyPageProps) {
 
       <ImageUploadField
         imageUrl={null}
+        preset="childPhoto"
         generateUploadUrl={generateUploadUrl}
         onChange={setPhotoId}
         fieldId="baby-photo-upload"

--- a/src/components/recipes/EditRecipePage.tsx
+++ b/src/components/recipes/EditRecipePage.tsx
@@ -70,6 +70,7 @@ function EditRecipeForm({
 
       <ImageUploadField
         imageUrl={imageUrl}
+        preset="recipePhoto"
         generateUploadUrl={generateUploadUrl}
         onChange={(id) => {
           setImageId(id)

--- a/src/components/recipes/NewRecipePage.tsx
+++ b/src/components/recipes/NewRecipePage.tsx
@@ -162,6 +162,7 @@ export function NewRecipePage({
       <ImageUploadField
         key={`image-${imported?.version ?? 'blank'}`}
         imageUrl={imageUrl}
+        preset="recipePhoto"
         generateUploadUrl={generateUploadUrl}
         onChange={(id) => {
           setImageId(id)

--- a/src/lib/cropFrame.test.ts
+++ b/src/lib/cropFrame.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from 'vitest'
+import {
+  cropFraction,
+  initialCrop,
+  moveCrop,
+  resizeCrop,
+  scaleCrop,
+} from './cropFrame'
+
+/**
+ * A phone photo, the shape every one of these cases is really about.
+ */
+const PHONE = { width: 4032, height: 3024 }
+
+describe('initialCrop', () => {
+  test('a free frame encloses the whole image, so confirming crops nothing', () => {
+    expect(initialCrop(PHONE, null)).toEqual({
+      x: 0,
+      y: 0,
+      width: 4032,
+      height: 3024,
+    })
+  })
+
+  test('a locked frame is the largest that fits, centred', () => {
+    expect(initialCrop(PHONE, 1)).toEqual({
+      x: 504,
+      y: 0,
+      width: 3024,
+      height: 3024,
+    })
+  })
+
+  test('a locked frame on a portrait photo is bounded by the width', () => {
+    expect(initialCrop({ width: 3024, height: 4032 }, 1)).toEqual({
+      x: 0,
+      y: 504,
+      width: 3024,
+      height: 3024,
+    })
+  })
+})
+
+describe('moveCrop', () => {
+  test('slides the frame by a delta in source pixels', () => {
+    const crop = initialCrop(PHONE, 1)
+    expect(moveCrop(crop, PHONE, -200, 0)).toMatchObject({ x: 304, y: 0 })
+  })
+
+  test('stops at the edges rather than leaving the image', () => {
+    const crop = initialCrop(PHONE, 1)
+    expect(moveCrop(crop, PHONE, -9000, -9000)).toMatchObject({ x: 0, y: 0 })
+    expect(moveCrop(crop, PHONE, 9000, 9000)).toMatchObject({ x: 1008, y: 0 })
+  })
+
+  test('never changes the frame size', () => {
+    const crop = initialCrop(PHONE, 1)
+    const moved = moveCrop(crop, PHONE, 9000, 9000)
+    expect(moved.width).toBe(crop.width)
+    expect(moved.height).toBe(crop.height)
+  })
+})
+
+describe('resizeCrop', () => {
+  test('a free frame follows both axes independently', () => {
+    const crop = { x: 0, y: 0, width: 1000, height: 800 }
+    expect(resizeCrop(crop, PHONE, null, -300, -100)).toMatchObject({
+      width: 700,
+      height: 700,
+    })
+  })
+
+  test('a locked frame stays square whichever axis is dragged', () => {
+    const crop = { x: 0, y: 0, width: 1000, height: 1000 }
+    expect(resizeCrop(crop, PHONE, 1, -400, 0)).toMatchObject({
+      width: 600,
+      height: 600,
+    })
+    expect(resizeCrop(crop, PHONE, 1, 0, -400)).toMatchObject({
+      width: 600,
+      height: 600,
+    })
+  })
+
+  test('a locked frame stays square when it runs out of image', () => {
+    // Room to the right (4032) far exceeds room below (1024): clamping each
+    // axis on its own would give a 4032x1024 "square".
+    const crop = { x: 0, y: 2000, width: 1000, height: 1000 }
+    const resized = resizeCrop(crop, PHONE, 1, 9000, 9000)
+    expect(resized.width).toBe(resized.height)
+    expect(resized.width).toBe(1024)
+  })
+
+  test('a frame cannot be shrunk to nothing', () => {
+    const crop = { x: 0, y: 0, width: 1000, height: 1000 }
+    expect(resizeCrop(crop, PHONE, 1, -9000, -9000).width).toBe(32)
+    expect(resizeCrop(crop, PHONE, null, -9000, -9000)).toMatchObject({
+      width: 32,
+      height: 32,
+    })
+  })
+
+  test('a tiny image is allowed to be smaller than the minimum frame', () => {
+    const tiny = { width: 20, height: 20 }
+    const crop = { x: 0, y: 0, width: 20, height: 20 }
+    expect(resizeCrop(crop, tiny, 1, -9000, -9000)).toMatchObject({
+      width: 20,
+      height: 20,
+    })
+  })
+
+  test('the frame stays inside the image', () => {
+    const crop = { x: 3000, y: 2000, width: 500, height: 500 }
+    const resized = resizeCrop(crop, PHONE, 1, 9000, 9000)
+    expect(resized.x + resized.width).toBeLessThanOrEqual(PHONE.width)
+    expect(resized.y + resized.height).toBeLessThanOrEqual(PHONE.height)
+  })
+})
+
+describe('scaleCrop', () => {
+  test('sizes the frame to a fraction of the largest that fits', () => {
+    const crop = initialCrop(PHONE, 1)
+    expect(scaleCrop(crop, PHONE, 1, 0.5)).toMatchObject({
+      width: 1512,
+      height: 1512,
+    })
+  })
+
+  test('keeps the frame centred where it was', () => {
+    const crop = { x: 1000, y: 1000, width: 1000, height: 1000 }
+    const scaled = scaleCrop(crop, PHONE, 1, 0.2)
+    // Within a pixel: an odd-width frame has its centre on a half-pixel.
+    expect(Math.abs(scaled.x + scaled.width / 2 - 1500)).toBeLessThanOrEqual(1)
+    expect(Math.abs(scaled.y + scaled.height / 2 - 1500)).toBeLessThanOrEqual(1)
+  })
+
+  test('pushes the frame back inside the image rather than overhanging', () => {
+    const crop = { x: 3800, y: 2900, width: 200, height: 200 }
+    const scaled = scaleCrop(crop, PHONE, 1, 1)
+    expect(scaled.x + scaled.width).toBeLessThanOrEqual(PHONE.width)
+    expect(scaled.y + scaled.height).toBeLessThanOrEqual(PHONE.height)
+  })
+
+  test('a free frame scales on its own ratio', () => {
+    const crop = initialCrop(PHONE, null)
+    const scaled = scaleCrop(crop, PHONE, null, 0.5)
+    expect(scaled).toMatchObject({ width: 2016, height: 1512 })
+  })
+
+  test('is the inverse of cropFraction', () => {
+    const crop = initialCrop(PHONE, 1)
+    expect(cropFraction(crop, PHONE, 1)).toBe(1)
+    expect(cropFraction(scaleCrop(crop, PHONE, 1, 0.4), PHONE, 1)).toBeCloseTo(
+      0.4,
+      3,
+    )
+  })
+})
+
+describe('a locked aspect survives every path', () => {
+  test.each([
+    2160, 2161, 3023, 3024, 4031,
+  ])('an image %ipx tall still frames an exact square', (height) => {
+    const image = { width: 4031, height }
+    let crop = initialCrop(image, 1)
+    expect(crop.width).toBe(crop.height)
+    crop = scaleCrop(crop, image, 1, 0.333)
+    expect(crop.width).toBe(crop.height)
+    crop = moveCrop(crop, image, 777, 777)
+    expect(crop.width).toBe(crop.height)
+    crop = resizeCrop(crop, image, 1, 555, 111)
+    expect(crop.width).toBe(crop.height)
+    expect(crop.x + crop.width).toBeLessThanOrEqual(image.width)
+    expect(crop.y + crop.height).toBeLessThanOrEqual(image.height)
+  })
+})

--- a/src/lib/cropFrame.ts
+++ b/src/lib/cropFrame.ts
@@ -1,0 +1,185 @@
+/**
+ * The rectangle a person frames a photo with, in the decoded image's own
+ * pixels.
+ *
+ * Every number here is a source pixel, never a screen pixel. The crop editor
+ * draws the frame as a percentage of whatever box the preview happens to
+ * occupy, and converts a drag back into source pixels before it gets here, so
+ * the frame means the same thing on a phone and on a wide screen and the
+ * arithmetic below never has to know which it is running on.
+ *
+ * The invariant these functions exist to hold is that a locked aspect stays
+ * locked. A child's photo is stored square because the frame cannot be dragged,
+ * scaled, or clamped into a non-square — including at the edges of the image,
+ * which is where a naive clamp per axis quietly breaks it (ADR-0010).
+ */
+
+export interface Size {
+  readonly width: number
+  readonly height: number
+}
+
+export interface CropRect {
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+/**
+ * The smallest frame a person can shrink to, in source pixels.
+ *
+ * Small enough to crop a face out of a group photo, large enough that a
+ * fumbled drag cannot leave a frame with no pixels in it. Images smaller than
+ * this are allowed to be smaller than this — the floor never grows a frame past
+ * the image containing it.
+ */
+const MIN_CROP_PX = 32
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+/** Width ÷ height a frame should hold: the preset's, or the frame's own. */
+function aspectOf(crop: CropRect, aspect: number | null): number {
+  return aspect ?? crop.width / crop.height
+}
+
+/** The largest frame of `aspect` that fits inside the image, as a width. */
+function maxWidthFor(image: Size, aspect: number): number {
+  return Math.min(image.width, image.height * aspect)
+}
+
+/**
+ * The frame a photo opens with.
+ *
+ * A free frame encloses the whole image, so confirming it untouched crops
+ * nothing — the recipe preset relies on that. A locked frame is the largest one
+ * that fits, centred, which is the most of the photo the person can keep and
+ * the least presumptuous starting point we can offer.
+ */
+export function initialCrop(image: Size, aspect: number | null): CropRect {
+  if (aspect === null) {
+    return { x: 0, y: 0, width: image.width, height: image.height }
+  }
+  const width = Math.round(maxWidthFor(image, aspect))
+  const height = Math.round(width / aspect)
+  return {
+    x: Math.round((image.width - width) / 2),
+    y: Math.round((image.height - height) / 2),
+    width,
+    height,
+  }
+}
+
+/** Slide the frame by a delta in source pixels, keeping it inside the image. */
+export function moveCrop(crop: CropRect, image: Size, dx: number, dy: number) {
+  return {
+    ...crop,
+    x: Math.round(clamp(crop.x + dx, 0, Math.max(0, image.width - crop.width))),
+    y: Math.round(
+      clamp(crop.y + dy, 0, Math.max(0, image.height - crop.height)),
+    ),
+  }
+}
+
+/**
+ * Drag the frame's bottom-right corner by a delta in source pixels.
+ *
+ * The top-left stays put, so the room available is whatever lies below and to
+ * the right of it. Under a locked aspect the two axes cannot be clamped
+ * independently — the binding one decides the width and the other follows from
+ * it — which is the whole reason this is not two `clamp` calls.
+ */
+export function resizeCrop(
+  crop: CropRect,
+  image: Size,
+  aspect: number | null,
+  dx: number,
+  dy: number,
+): CropRect {
+  const ratio = aspectOf(crop, aspect)
+  const roomWidth = image.width - crop.x
+  const roomHeight = image.height - crop.y
+
+  if (aspect === null) {
+    const width = clamp(
+      Math.round(crop.width + dx),
+      Math.min(MIN_CROP_PX, roomWidth),
+      roomWidth,
+    )
+    const height = clamp(
+      Math.round(crop.height + dy),
+      Math.min(MIN_CROP_PX, roomHeight),
+      roomHeight,
+    )
+    return { ...crop, width, height }
+  }
+
+  // One drag, two axes, one degree of freedom: whichever axis the person moved
+  // furthest is the one they meant.
+  const wanted =
+    Math.abs(dy) > Math.abs(dx) ? crop.width + dy * ratio : crop.width + dx
+  const maxWidth = Math.min(roomWidth, roomHeight * ratio)
+  return withWidth(crop, wanted, maxWidth, ratio)
+}
+
+/**
+ * Set the frame's size to a fraction of the largest one that would fit,
+ * keeping its centre where it is.
+ *
+ * This is what the size slider drives. A slider is not a nicety next to the
+ * corner handle: dragging a corner is the only other way to resize, and it is
+ * unavailable to anyone working by keyboard.
+ */
+export function scaleCrop(
+  crop: CropRect,
+  image: Size,
+  aspect: number | null,
+  fraction: number,
+): CropRect {
+  const ratio = aspectOf(crop, aspect)
+  const maxWidth = maxWidthFor(image, ratio)
+  const sized = withWidth(
+    crop,
+    maxWidth * clamp(fraction, 0, 1),
+    maxWidth,
+    ratio,
+  )
+  const centreX = crop.x + crop.width / 2
+  const centreY = crop.y + crop.height / 2
+  return moveCrop(
+    sized,
+    image,
+    centreX - sized.width / 2 - crop.x,
+    centreY - sized.height / 2 - crop.y,
+  )
+}
+
+/** Where the size slider sits for a frame: its share of the largest that fits. */
+export function cropFraction(
+  crop: CropRect,
+  image: Size,
+  aspect: number | null,
+): number {
+  const maxWidth = maxWidthFor(image, aspectOf(crop, aspect))
+  return maxWidth === 0 ? 1 : clamp(crop.width / maxWidth, 0, 1)
+}
+
+/**
+ * Resize to a width, holding the ratio exactly.
+ *
+ * The height is derived from the rounded width rather than rounded separately,
+ * so a 1:1 frame comes out of every path with `width === height` as integers —
+ * the property the stored square depends on.
+ */
+function withWidth(
+  crop: CropRect,
+  wanted: number,
+  maxWidth: number,
+  ratio: number,
+): CropRect {
+  const minWidth = Math.min(MIN_CROP_PX, maxWidth)
+  const width = Math.round(clamp(wanted, minWidth, maxWidth))
+  return { ...crop, width, height: Math.round(width / ratio) }
+}

--- a/src/lib/photoPresets.test.ts
+++ b/src/lib/photoPresets.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest'
+import { PHOTO_PRESETS, photoPreset } from './photoPresets'
+
+/**
+ * The preset table is the only place a dimension or a quality is allowed to be
+ * written down (ADR-0010), so these tests are about the shape of the table
+ * rather than about arithmetic: two presets, the child's frame locked square,
+ * the recipe's frame free.
+ */
+describe('photo presets', () => {
+  test('there are exactly two, named for where the photo is shown', () => {
+    expect(Object.keys(PHOTO_PRESETS).sort()).toEqual([
+      'childPhoto',
+      'recipePhoto',
+    ])
+  })
+
+  test("a child's photo is a square no larger than 512px", () => {
+    expect(photoPreset('childPhoto')).toEqual({
+      aspect: 1,
+      maxEdge: 512,
+      quality: 0.82,
+    })
+  })
+
+  test('a recipe photo is freely framed, no larger than 1600px', () => {
+    expect(photoPreset('recipePhoto')).toEqual({
+      aspect: null,
+      maxEdge: 1600,
+      quality: 0.82,
+    })
+  })
+
+  test('every preset asks for a quality a JPEG encoder accepts', () => {
+    for (const preset of Object.values(PHOTO_PRESETS)) {
+      expect(preset.quality).toBeGreaterThan(0)
+      expect(preset.quality).toBeLessThanOrEqual(1)
+      expect(preset.maxEdge).toBeGreaterThan(0)
+    }
+  })
+})

--- a/src/lib/photoPresets.ts
+++ b/src/lib/photoPresets.ts
@@ -1,0 +1,43 @@
+/**
+ * What preparing a photo does, per place the photo will be shown (ADR-0010).
+ *
+ * A photo is stored as prepared, never as chosen, and *how* it is prepared is a
+ * property of where it lands rather than of the screen that uploaded it. A
+ * child's photo is a 56px circle at its smallest and is cropped by
+ * `object-cover` whatever we do, so the frame is locked square and the person
+ * decides which square. A recipe's hero is the largest photo Gather draws — 672
+ * CSS px, around 1344 physical px on a phone — so it keeps a free frame and a
+ * longest edge with room above what any screen asks for.
+ *
+ * The table is the whole configuration surface. Call sites name a preset and
+ * pass nothing else: no dimensions, no quality, no aspect. That is what stops
+ * four upload sites from drifting into four answers, and it is why adding a
+ * fifth is a change here rather than a change there.
+ *
+ * There are two, and a third arrives when a Module genuinely needs one — not
+ * before.
+ */
+
+export interface PhotoPreset {
+  /**
+   * Width ÷ height the crop frame is locked to, or `null` for a free frame.
+   * A locked frame cannot be dragged out of its aspect; a free one opens
+   * enclosing the whole image, so confirming it unchanged crops nothing.
+   */
+  readonly aspect: number | null
+  /** Longest edge of the stored image, in pixels. Never upscales past it. */
+  readonly maxEdge: number
+  /** JPEG quality, 0–1. */
+  readonly quality: number
+}
+
+export const PHOTO_PRESETS = {
+  childPhoto: { aspect: 1, maxEdge: 512, quality: 0.82 },
+  recipePhoto: { aspect: null, maxEdge: 1600, quality: 0.82 },
+} as const satisfies Record<string, PhotoPreset>
+
+export type PhotoPresetName = keyof typeof PHOTO_PRESETS
+
+export function photoPreset(name: PhotoPresetName): PhotoPreset {
+  return PHOTO_PRESETS[name]
+}

--- a/src/lib/preparePhoto.test.ts
+++ b/src/lib/preparePhoto.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { initialCrop } from './cropFrame'
+import { photoPreset } from './photoPresets'
+import {
+  type DecodedPhoto,
+  decodePhoto,
+  outputSize,
+  PHOTO_DECODE_ERROR,
+  PHOTO_PREPARE_ERROR,
+  preparePhoto,
+} from './preparePhoto'
+
+/**
+ * jsdom has neither `createImageBitmap` nor a 2D canvas, which is the honest
+ * situation: the pixels cannot be inspected here. What can be checked is every
+ * instruction we hand the browser — that we ask for EXIF orientation to be
+ * applied, that we ask for a JPEG at the preset's quality, that we draw the
+ * region the person framed at the size the preset allows — plus that each way
+ * this can fail ends in a refusal rather than in bytes.
+ */
+
+const drawImage = vi.fn()
+const toBlob = vi.fn()
+
+/** The stand-in for whatever `createImageBitmap` would have returned. */
+function decoded(width: number, height: number): DecodedPhoto {
+  return { width, height, source: {} as CanvasImageSource, close: vi.fn() }
+}
+
+beforeEach(() => {
+  drawImage.mockReset()
+  toBlob.mockReset()
+  toBlob.mockImplementation(
+    (callback: (blob: Blob | null) => void, type: string) => {
+      callback(new Blob(['jpeg'], { type }))
+    },
+  )
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+    drawImage,
+  } as unknown as CanvasRenderingContext2D)
+  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(toBlob)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('decodePhoto', () => {
+  test('asks for the EXIF orientation to be applied, so portraits stay upright', async () => {
+    const createImageBitmap = vi
+      .fn()
+      .mockResolvedValue({ width: 3024, height: 4032, close: vi.fn() })
+    vi.stubGlobal('createImageBitmap', createImageBitmap)
+
+    const file = new Blob(['…'], { type: 'image/jpeg' })
+    const photo = await decodePhoto(file)
+
+    expect(createImageBitmap).toHaveBeenCalledWith(file, {
+      imageOrientation: 'from-image',
+    })
+    // And the dimensions the person frames against are the upright ones.
+    expect(photo).toMatchObject({ width: 3024, height: 4032 })
+  })
+
+  test('refuses an image the browser cannot decode', async () => {
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn().mockRejectedValue(new Error('unsupported')),
+    )
+    await expect(decodePhoto(new Blob(['heic']))).rejects.toThrow(
+      PHOTO_DECODE_ERROR,
+    )
+  })
+
+  test('refuses an image that decodes to nothing', async () => {
+    const close = vi.fn()
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn().mockResolvedValue({ width: 0, height: 0, close }),
+    )
+    await expect(decodePhoto(new Blob(['x']))).rejects.toThrow(
+      PHOTO_DECODE_ERROR,
+    )
+    expect(close).toHaveBeenCalled()
+  })
+
+  test('refuses where the browser cannot decode images at all', async () => {
+    vi.stubGlobal('createImageBitmap', undefined)
+    await expect(decodePhoto(new Blob(['x']))).rejects.toThrow(
+      PHOTO_DECODE_ERROR,
+    )
+  })
+})
+
+describe('outputSize', () => {
+  test('shrinks the longest edge to the limit and keeps the shape', () => {
+    expect(outputSize({ width: 4032, height: 3024 }, 1600)).toEqual({
+      width: 1600,
+      height: 1200,
+    })
+    expect(outputSize({ width: 3024, height: 4032 }, 1600)).toEqual({
+      width: 1200,
+      height: 1600,
+    })
+  })
+
+  test('a square frame stays square', () => {
+    expect(outputSize({ width: 3024, height: 3024 }, 512)).toEqual({
+      width: 512,
+      height: 512,
+    })
+    expect(outputSize({ width: 3025, height: 3025 }, 512)).toEqual({
+      width: 512,
+      height: 512,
+    })
+  })
+
+  test('never upscales a photo that is already small', () => {
+    expect(outputSize({ width: 300, height: 200 }, 1600)).toEqual({
+      width: 300,
+      height: 200,
+    })
+  })
+
+  test('never exceeds the limit, whatever the rounding', () => {
+    for (const width of [1601, 1600, 1599, 4032, 33, 1]) {
+      for (const height of [1601, 900, 4032, 7, 1]) {
+        const size = outputSize({ width, height }, 1600)
+        expect(Math.max(size.width, size.height)).toBeLessThanOrEqual(1600)
+        expect(Math.min(size.width, size.height)).toBeGreaterThanOrEqual(1)
+      }
+    }
+  })
+})
+
+describe('preparePhoto', () => {
+  test("a child's photo is stored as a square JPEG no larger than 512", async () => {
+    const image = { width: 4032, height: 3024 }
+    const photo = decoded(image.width, image.height)
+    const preset = photoPreset('childPhoto')
+
+    const prepared = await preparePhoto(
+      photo,
+      initialCrop(image, preset.aspect),
+      preset,
+    )
+
+    expect(prepared).toMatchObject({ width: 512, height: 512 })
+    expect(prepared.blob.type).toBe('image/jpeg')
+    expect(toBlob).toHaveBeenCalledWith(
+      expect.any(Function),
+      'image/jpeg',
+      0.82,
+    )
+  })
+
+  test('a recipe photo is stored with its longest edge at 1600', async () => {
+    const image = { width: 4032, height: 3024 }
+    const preset = photoPreset('recipePhoto')
+
+    const prepared = await preparePhoto(
+      decoded(image.width, image.height),
+      initialCrop(image, preset.aspect),
+      preset,
+    )
+
+    expect(prepared).toMatchObject({ width: 1600, height: 1200 })
+  })
+
+  test('draws the framed region, not the whole image', async () => {
+    const photo = decoded(4032, 3024)
+    await preparePhoto(
+      photo,
+      { x: 504, y: 0, width: 3024, height: 3024 },
+      photoPreset('childPhoto'),
+    )
+
+    expect(drawImage).toHaveBeenCalledWith(
+      photo.source,
+      504,
+      0,
+      3024,
+      3024,
+      0,
+      0,
+      512,
+      512,
+    )
+  })
+
+  test('refuses rather than uploading a PNG that toBlob substituted', async () => {
+    toBlob.mockImplementation((callback: (blob: Blob | null) => void) => {
+      callback(new Blob(['png'], { type: 'image/png' }))
+    })
+    await expect(
+      preparePhoto(
+        decoded(800, 600),
+        { x: 0, y: 0, width: 800, height: 600 },
+        photoPreset('recipePhoto'),
+      ),
+    ).rejects.toThrow(PHOTO_PREPARE_ERROR)
+  })
+
+  test('refuses when the encode produces nothing', async () => {
+    toBlob.mockImplementation((callback: (blob: Blob | null) => void) => {
+      callback(null)
+    })
+    await expect(
+      preparePhoto(
+        decoded(800, 600),
+        { x: 0, y: 0, width: 800, height: 600 },
+        photoPreset('recipePhoto'),
+      ),
+    ).rejects.toThrow(PHOTO_PREPARE_ERROR)
+  })
+
+  test('refuses when the drawing surface is unavailable', async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+    await expect(
+      preparePhoto(
+        decoded(800, 600),
+        { x: 0, y: 0, width: 800, height: 600 },
+        photoPreset('recipePhoto'),
+      ),
+    ).rejects.toThrow(PHOTO_PREPARE_ERROR)
+  })
+
+  test('refuses when drawing throws', async () => {
+    drawImage.mockImplementation(() => {
+      throw new Error('out of memory')
+    })
+    await expect(
+      preparePhoto(
+        decoded(800, 600),
+        { x: 0, y: 0, width: 800, height: 600 },
+        photoPreset('recipePhoto'),
+      ),
+    ).rejects.toThrow(PHOTO_PREPARE_ERROR)
+  })
+})

--- a/src/lib/preparePhoto.test.ts
+++ b/src/lib/preparePhoto.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  type StubbedImagePipeline,
+  stubImagePipeline,
+} from '../test/imagePipeline'
 import { initialCrop } from './cropFrame'
 import { photoPreset } from './photoPresets'
 import {
@@ -19,8 +23,7 @@ import {
  * this can fail ends in a refusal rather than in bytes.
  */
 
-const drawImage = vi.fn()
-const toBlob = vi.fn()
+let pipeline: StubbedImagePipeline
 
 /** The stand-in for whatever `createImageBitmap` would have returned. */
 function decoded(width: number, height: number): DecodedPhoto {
@@ -28,17 +31,7 @@ function decoded(width: number, height: number): DecodedPhoto {
 }
 
 beforeEach(() => {
-  drawImage.mockReset()
-  toBlob.mockReset()
-  toBlob.mockImplementation(
-    (callback: (blob: Blob | null) => void, type: string) => {
-      callback(new Blob(['jpeg'], { type }))
-    },
-  )
-  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
-    drawImage,
-  } as unknown as CanvasRenderingContext2D)
-  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(toBlob)
+  pipeline = stubImagePipeline()
 })
 
 afterEach(() => {
@@ -148,7 +141,7 @@ describe('preparePhoto', () => {
 
     expect(prepared).toMatchObject({ width: 512, height: 512 })
     expect(prepared.blob.type).toBe('image/jpeg')
-    expect(toBlob).toHaveBeenCalledWith(
+    expect(pipeline.toBlob).toHaveBeenCalledWith(
       expect.any(Function),
       'image/jpeg',
       0.82,
@@ -176,7 +169,7 @@ describe('preparePhoto', () => {
       photoPreset('childPhoto'),
     )
 
-    expect(drawImage).toHaveBeenCalledWith(
+    expect(pipeline.drawImage).toHaveBeenCalledWith(
       photo.source,
       504,
       0,
@@ -190,9 +183,7 @@ describe('preparePhoto', () => {
   })
 
   test('refuses rather than uploading a PNG that toBlob substituted', async () => {
-    toBlob.mockImplementation((callback: (blob: Blob | null) => void) => {
-      callback(new Blob(['png'], { type: 'image/png' }))
-    })
+    pipeline.encodesTo(new Blob(['png'], { type: 'image/png' }))
     await expect(
       preparePhoto(
         decoded(800, 600),
@@ -203,9 +194,7 @@ describe('preparePhoto', () => {
   })
 
   test('refuses when the encode produces nothing', async () => {
-    toBlob.mockImplementation((callback: (blob: Blob | null) => void) => {
-      callback(null)
-    })
+    pipeline.encodesTo(null)
     await expect(
       preparePhoto(
         decoded(800, 600),
@@ -227,7 +216,7 @@ describe('preparePhoto', () => {
   })
 
   test('refuses when drawing throws', async () => {
-    drawImage.mockImplementation(() => {
+    pipeline.drawImage.mockImplementation(() => {
       throw new Error('out of memory')
     })
     await expect(

--- a/src/lib/preparePhoto.ts
+++ b/src/lib/preparePhoto.ts
@@ -1,0 +1,157 @@
+/**
+ * Turning a chosen file into the photo Gather actually stores (ADR-0010).
+ *
+ * Two steps, kept apart because they fail for different reasons and at
+ * different moments. `decodePhoto` runs when the file is chosen — it is what
+ * says whether this browser can read this image at all, and it decides the
+ * pixel space the person then frames in. `preparePhoto` runs when they confirm,
+ * and is the only thing that produces bytes to upload.
+ *
+ * Neither has a fallback to the original file, and that is the point. A HEIC
+ * that Chrome cannot decode is refused; uploading it untouched instead would
+ * quietly retire the size guarantee on some browsers only, leaving nothing in
+ * the data to say which rows came through which door.
+ */
+
+import type { CropRect, Size } from './cropFrame'
+import type { PhotoPreset } from './photoPresets'
+
+/**
+ * The only output format.
+ *
+ * `canvas.toBlob` falls back to `image/png` *silently* when asked for a type
+ * the browser cannot encode, and a 1600px PNG is bigger than the JPEG we were
+ * shrinking. JPEG is universally supported, so asking for it is safe — and
+ * `renderPhoto` checks what came back anyway, because a silent fallback that
+ * inflates storage is exactly the kind of failure nobody would notice.
+ */
+export const PREPARED_PHOTO_TYPE = 'image/jpeg'
+
+/** Sentences a person is meant to read, not diagnostics. */
+export const PHOTO_DECODE_ERROR =
+  'That image could not be opened in this browser. Try saving it as a JPEG and choosing it again.'
+export const PHOTO_PREPARE_ERROR =
+  'That image could not be prepared. Try a smaller photo, or save it as a JPEG and choose it again.'
+
+/**
+ * A decoded image, upright, with the dimensions the person frames against.
+ *
+ * `close` releases the decoded bitmap; a 4032×3024 photo is ~48MB of RGBA, and
+ * a person who opens and abandons the crop editor a few times would otherwise
+ * be carrying every one of them.
+ */
+export interface DecodedPhoto extends Size {
+  readonly source: CanvasImageSource
+  close: () => void
+}
+
+export interface PreparedPhoto extends Size {
+  readonly blob: Blob
+}
+
+/**
+ * Decode a chosen file, upright.
+ *
+ * `imageOrientation: 'from-image'` is the entire EXIF story and the single most
+ * likely defect in this feature if it goes missing: a phone photo carries its
+ * rotation as a tag rather than in the pixels, and a canvas draws what the
+ * pixels say. Without the flag every portrait photo is stored on its side. It
+ * is asserted in the tests for this module rather than left to be noticed in
+ * production.
+ *
+ * Re-encoding from a decoded bitmap also drops EXIF entirely, which is wanted
+ * for its own sake: photos currently reach storage carrying the GPS
+ * coordinates where they were taken, and `getUrl` serves them onward.
+ */
+export async function decodePhoto(file: Blob): Promise<DecodedPhoto> {
+  if (typeof createImageBitmap !== 'function') {
+    throw new Error(PHOTO_DECODE_ERROR)
+  }
+  let bitmap: ImageBitmap
+  try {
+    bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' })
+  } catch {
+    throw new Error(PHOTO_DECODE_ERROR)
+  }
+  if (bitmap.width === 0 || bitmap.height === 0) {
+    bitmap.close()
+    throw new Error(PHOTO_DECODE_ERROR)
+  }
+  return {
+    width: bitmap.width,
+    height: bitmap.height,
+    source: bitmap,
+    close: () => bitmap.close(),
+  }
+}
+
+/**
+ * How large the framed region is stored.
+ *
+ * Scales the longest edge down to the preset's limit and never up: a photo
+ * already smaller than the preset is stored at the size it is, rather than
+ * gaining pixels it has no information for. The height is derived from the
+ * rounded scale of both edges, so a square frame stays square.
+ */
+export function outputSize(crop: Size, maxEdge: number): Size {
+  const longest = Math.max(crop.width, crop.height)
+  const scale = longest > maxEdge ? maxEdge / longest : 1
+  return {
+    width: Math.min(maxEdge, Math.max(1, Math.round(crop.width * scale))),
+    height: Math.min(maxEdge, Math.max(1, Math.round(crop.height * scale))),
+  }
+}
+
+/** Draw the framed region at the output size and encode it as a JPEG. */
+async function renderPhoto(
+  photo: DecodedPhoto,
+  crop: CropRect,
+  size: Size,
+  quality: number,
+): Promise<Blob> {
+  const canvas = document.createElement('canvas')
+  canvas.width = size.width
+  canvas.height = size.height
+  const context = canvas.getContext('2d')
+  if (!context) throw new Error(PHOTO_PREPARE_ERROR)
+
+  let blob: Blob | null
+  try {
+    context.drawImage(
+      photo.source,
+      crop.x,
+      crop.y,
+      crop.width,
+      crop.height,
+      0,
+      0,
+      size.width,
+      size.height,
+    )
+    blob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, PREPARED_PHOTO_TYPE, quality)
+    })
+  } catch {
+    throw new Error(PHOTO_PREPARE_ERROR)
+  }
+  // A `null` blob is a decode that ran out of memory; a blob of some other type
+  // is `toBlob`'s silent PNG fallback. Both are refusals, not uploads.
+  if (!blob || blob.type !== PREPARED_PHOTO_TYPE) {
+    throw new Error(PHOTO_PREPARE_ERROR)
+  }
+  return blob
+}
+
+/**
+ * The photo that gets stored: the framed region, shrunk to the preset, as a
+ * JPEG carrying no metadata.
+ */
+export async function preparePhoto(
+  photo: DecodedPhoto,
+  crop: CropRect,
+  preset: PhotoPreset,
+): Promise<PreparedPhoto> {
+  const size = outputSize(crop, preset.maxEdge)
+  const blob = await renderPhoto(photo, crop, size, preset.quality)
+  return { blob, width: size.width, height: size.height }
+}

--- a/src/test/imagePipeline.ts
+++ b/src/test/imagePipeline.ts
@@ -1,0 +1,76 @@
+import { type Mock, vi } from 'vitest'
+
+/**
+ * The browser's image pipeline, stood in for.
+ *
+ * jsdom has no `createImageBitmap` and no 2D canvas, so every test that touches
+ * preparing a photo has to supply both. There is one copy of that here because
+ * there were briefly three, and they had already drifted into disagreeing about
+ * what `toBlob` hands back when asked for a type — which is the precise defect
+ * the real code refuses to ship (`preparePhoto` rejects anything that is not a
+ * JPEG), and so the precise thing a stub must not get quietly wrong. The same
+ * lesson `src/lib/errorMessage.ts` records about its own three copies.
+ *
+ * The default behaviour is a browser that does what it is asked: it decodes to
+ * the size given, and encodes to the type requested.
+ */
+
+export interface StubbedImagePipeline {
+  /** The 2D context's `drawImage`, for asserting what region was drawn. */
+  drawImage: Mock
+  toBlob: Mock
+  /** What `createImageBitmap` was called with, most recent call last. */
+  createImageBitmap: Mock
+  /** The crop region handed to `drawImage`, in source pixels. */
+  drawnRegion: () => { x: number; y: number; width: number; height: number }
+  /** Make the encoder hand back something else — a PNG, or nothing at all. */
+  encodesTo: (blob: Blob | null) => void
+}
+
+interface StubOptions {
+  /** The upright size the image decodes to. */
+  width?: number
+  height?: number
+  /** Replaces the decode entirely — throw from here to refuse the image. */
+  decode?: () => Promise<{ width: number; height: number; close: () => void }>
+  /** Bytes the encoder produces, so a test can tell prepared output apart. */
+  contents?: string
+}
+
+export function stubImagePipeline({
+  width = 4032,
+  height = 3024,
+  decode,
+  contents = 'prepared jpeg',
+}: StubOptions = {}): StubbedImagePipeline {
+  const drawImage = vi.fn()
+  const toBlob = vi.fn(
+    (callback: (blob: Blob | null) => void, type?: string) => {
+      callback(new Blob([contents], { type: type ?? '' }))
+    },
+  )
+  const createImageBitmap = vi.fn(
+    decode ?? (async () => ({ width, height, close: vi.fn() })),
+  )
+
+  vi.stubGlobal('createImageBitmap', createImageBitmap)
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+    drawImage,
+  } as unknown as CanvasRenderingContext2D)
+  vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation(toBlob)
+
+  return {
+    drawImage,
+    toBlob,
+    createImageBitmap,
+    drawnRegion: () => {
+      const [, x, y, w, h] = drawImage.mock.calls[0] as number[]
+      return { x, y, width: w, height: h }
+    },
+    encodesTo: (blob) => {
+      toBlob.mockImplementation((callback: (b: Blob | null) => void) =>
+        callback(blob),
+      )
+    },
+  }
+}

--- a/src/test/imagePipeline.ts
+++ b/src/test/imagePipeline.ts
@@ -25,6 +25,11 @@ export interface StubbedImagePipeline {
   drawnRegion: () => { x: number; y: number; width: number; height: number }
   /** Make the encoder hand back something else — a PNG, or nothing at all. */
   encodesTo: (blob: Blob | null) => void
+  /**
+   * Hold the encode open, as a slow phone would; the returned function lets it
+   * finish. What happens in that gap — someone cancelling — is the point.
+   */
+  deferEncoding: () => () => void
 }
 
 interface StubOptions {
@@ -71,6 +76,15 @@ export function stubImagePipeline({
       toBlob.mockImplementation((callback: (b: Blob | null) => void) =>
         callback(blob),
       )
+    },
+    deferEncoding: () => {
+      let finish: (() => void) | null = null
+      toBlob.mockImplementation(
+        (callback: (b: Blob | null) => void, type?: string) => {
+          finish = () => callback(new Blob([contents], { type: type ?? '' }))
+        },
+      )
+      return () => finish?.()
     },
   }
 }


### PR DESCRIPTION
A photo chosen from a phone reached Convex storage as it came off the
camera — ~4032x3024 and several megabytes, against a UI whose largest
rendering is ~1344 physical px and whose smallest is a 56px circle, and
carrying the EXIF GPS coordinates of where it was taken.

Choosing a file now opens a framing step instead of starting an upload.
The person adjusts or accepts the frame, and only on confirming is
anything sent: the cropped region, downscaled, re-encoded as JPEG. The
chosen file is never uploaded, and there is exactly one upload per photo.

How preparing behaves comes from one preset table rather than from each
call site — a locked square at 512px for a child, a free frame at 1600px
for a recipe. All four upload sites name a preset and pass nothing else.

Two things this leans on, both covered by tests: the decode asks for
`imageOrientation: 'from-image'`, without which every portrait photo
would be stored on its side; and the encode refuses anything that comes
back as not-a-JPEG, because `canvas.toBlob` substitutes PNG silently and
a 1600px PNG is larger than the original we were shrinking.

Preparing that fails is a refusal, never a fallback to the original —
an undecodable HEIC surfaces an error naming a way forward and uploads
nothing (ADR-0010).

Closes #35

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DQUjQ8M3kQot8vpy1CCod8