### PR TITLE
Add sheet: clear the search, scan in one tap, and look up a typed barcode

### DIFF
--- a/convex/lib/offFetch.test.ts
+++ b/convex/lib/offFetch.test.ts
@@ -1,5 +1,49 @@
 import { describe, expect, test, vi } from 'vitest'
-import { fetchOffProduct, searchOffProducts } from './offFetch'
+import { barcodeTerm, fetchOffProduct, searchOffProducts } from './offFetch'
+
+describe('barcodeTerm', () => {
+  test('reads the barcode out of a term that is one, ignoring the spaces around it', () => {
+    expect(barcodeTerm('8712345678901')).toBe('8712345678901')
+    expect(barcodeTerm('  8712345678901  ')).toBe('8712345678901')
+    // EAN-8 at one end, the longest code the lookup accepts at the other.
+    expect(barcodeTerm('12345678')).toBe('12345678')
+    expect(barcodeTerm('12345678901234')).toBe('12345678901234')
+  })
+
+  test('a number still being typed is not a barcode', () => {
+    // The point of the floor: the digits of a barcode arrive one at a time, and
+    // each prefix has to stay an ordinary search rather than a failed lookup.
+    for (const partial of ['8', '87', '871', '8712', '87123', '871234', '8712345']) {
+      expect(barcodeTerm(partial)).toBeNull()
+    }
+  })
+
+  test('a number longer than any barcode is not one either', () => {
+    expect(barcodeTerm('123456789012345')).toBeNull()
+  })
+
+  test('a name is not a barcode, however many digits are in it', () => {
+    expect(barcodeTerm('hagelslag')).toBeNull()
+    expect(barcodeTerm('')).toBeNull()
+    expect(barcodeTerm('cola zero 330 ml')).toBeNull()
+    expect(barcodeTerm('871234-5678901')).toBeNull()
+    expect(barcodeTerm('8712345678901 melk')).toBeNull()
+  })
+
+  test('what it accepts is exactly what the product lookup accepts', async () => {
+    // The two must not drift: a term the search box promotes to a lookup that
+    // the lookup then refuses would be a search that quietly returns nothing.
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 1 }),
+    } as Response)
+    for (const term of ['12345678', '8712345678901', '12345678901234']) {
+      fetchImpl.mockClear()
+      await fetchOffProduct(barcodeTerm(term) ?? '', fetchImpl)
+      expect(fetchImpl).toHaveBeenCalled()
+    }
+  })
+})
 
 function mockResponse(body: unknown, ok = true): Response {
   return { ok, json: async () => body } as Response

--- a/convex/lib/offFetch.ts
+++ b/convex/lib/offFetch.ts
@@ -5,6 +5,25 @@ const BARCODE_PATTERN = /^\d{8,14}$/
 const LANG_PATTERN = /^[a-z]{2}$/
 
 /**
+ * The barcode a search term is, or `null` when it is ordinary text.
+ *
+ * Lives here, beside the pattern, so the search box can tell a barcode from a
+ * name without restating `BARCODE_PATTERN` on the client — one definition of
+ * "plausible barcode" for the lookup and for the thing that decides to make
+ * one (#80).
+ *
+ * Eight digits is EAN-8, the shortest symbology gather reads, and it is also
+ * what keeps a number still being typed out of barcode mode: fewer digits is
+ * somebody part-way through, and falls through to the text search it was
+ * already getting. The caller debounces, so the intermediate lengths of a
+ * barcode being typed never reach here at all.
+ */
+export function barcodeTerm(term: string): string | null {
+  const trimmed = term.trim()
+  return BARCODE_PATTERN.test(trimmed) ? trimmed : null
+}
+
+/**
  * The language subfields search-a-licious should look in.
  *
  * The locale arrives from the client, so it is whatever a caller sent rather

--- a/src/components/foods/BarcodeScanner.test.tsx
+++ b/src/components/foods/BarcodeScanner.test.tsx
@@ -7,6 +7,11 @@ import { BarcodeScanner } from './BarcodeScanner'
 // not a stub object), so vi.spyOn has nothing to attach to unless we give it
 // a stand-in first. This is a jsdom gap, not a component bug.
 beforeEach(() => {
+  // The stand-in below is defined once and outlives the test that defined it,
+  // and `vi.spyOn` hands back the mock that is already there rather than
+  // wrapping it again — so without this, "was the camera asked for?" reads the
+  // previous test's answer.
+  vi.clearAllMocks()
   if (!navigator.mediaDevices) {
     Object.defineProperty(navigator, 'mediaDevices', {
       value: { getUserMedia: vi.fn() },
@@ -19,6 +24,12 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks()
 })
+
+/** A stream that reports whether anybody turned it off again. */
+function fakeStream() {
+  const stop = vi.fn()
+  return { stream: { getTracks: () => [{ stop }] }, stop }
+}
 
 test('manual entry keeps only digits and calls onDetected on Look up', () => {
   const onDetected = vi.fn()
@@ -58,4 +69,57 @@ test('shows a fallback message when camera access is denied', async () => {
   )
   // The scan button is replaced by the error message, not left dangling.
   expect(screen.queryByRole('button', { name: /scan barcode/i })).toBeNull()
+})
+
+test('the camera stays off until it is asked for', async () => {
+  // The foods list renders a scanner on a page that is not about scanning.
+  // Opening that page must not turn a camera on.
+  const getUserMedia = vi
+    .spyOn(navigator.mediaDevices, 'getUserMedia')
+    .mockResolvedValue(fakeStream().stream as unknown as MediaStream)
+  renderWithI18n(<BarcodeScanner onDetected={vi.fn()} />)
+
+  expect(getUserMedia).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button', { name: /scan barcode/i }))
+  await waitFor(() => expect(getUserMedia).toHaveBeenCalled())
+})
+
+test('autoStart opens the camera without anybody pressing Scan again', async () => {
+  const getUserMedia = vi
+    .spyOn(navigator.mediaDevices, 'getUserMedia')
+    .mockResolvedValue(fakeStream().stream as unknown as MediaStream)
+  renderWithI18n(<BarcodeScanner onDetected={vi.fn()} autoStart />)
+
+  await waitFor(() => expect(getUserMedia).toHaveBeenCalled())
+  // And the scanner's own Scan/Stop button is gone: the surface that set
+  // autoStart is the one that started this and the one that stops it.
+  expect(screen.queryByRole('button', { name: /scan barcode/i })).toBeNull()
+  expect(screen.queryByRole('button', { name: /^stop$/i })).toBeNull()
+})
+
+test('an auto-started camera is turned off again when the scanner goes away', async () => {
+  const { stream, stop } = fakeStream()
+  vi.spyOn(navigator.mediaDevices, 'getUserMedia').mockResolvedValue(
+    stream as unknown as MediaStream,
+  )
+  const view = renderWithI18n(<BarcodeScanner onDetected={vi.fn()} autoStart />)
+
+  await waitFor(() => expect(screen.getByRole('button', { name: /look up/i })))
+  view.unmount()
+  await waitFor(() => expect(stop).toHaveBeenCalled())
+})
+
+test('autoStart with the camera denied falls back rather than showing a dead camera', async () => {
+  vi.spyOn(navigator.mediaDevices, 'getUserMedia').mockRejectedValue(
+    new DOMException('Permission denied', 'NotAllowedError'),
+  )
+  renderWithI18n(<BarcodeScanner onDetected={vi.fn()} autoStart />)
+
+  await waitFor(() =>
+    expect(
+      screen.getByText(/camera access was denied or unavailable/i),
+    ).toBeDefined(),
+  )
+  // The manual barcode field is still the way through.
+  expect(screen.getByLabelText('Or enter the barcode number')).toBeDefined()
 })

--- a/src/components/foods/BarcodeScanner.tsx
+++ b/src/components/foods/BarcodeScanner.tsx
@@ -5,6 +5,18 @@ import { inputClass } from '../nutrition/nutrientInputs'
 
 interface Props {
   onDetected: (barcode: string) => void
+  /**
+   * Whether the camera comes on as soon as this mounts.
+   *
+   * Off by default, and deliberately a prop rather than the component's
+   * behaviour: the foods list renders a scanner on a page that is not about
+   * scanning, and turning the camera on whenever that page is opened would be
+   * a worse bug than the two-tap one this exists to fix (#81). A caller that
+   * *is* a scanning surface — the add sheet, reached by pressing Scan — sets
+   * it, and then owns stopping it, so the scanner's own Scan/Stop button goes
+   * away rather than sitting there duplicating the one that brought you here.
+   */
+  autoStart?: boolean
 }
 
 const ZXING_FORMATS = ['EAN-13', 'EAN-8', 'UPC-A', 'UPC-E'] as const
@@ -17,7 +29,7 @@ interface NativeBarcodeDetector {
   detect: (source: CanvasImageSource) => Promise<Array<{ rawValue: string }>>
 }
 
-export function BarcodeScanner({ onDetected }: Props) {
+export function BarcodeScanner({ onDetected, autoStart = false }: Props) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [manualEntry, setManualEntry] = useState('')
@@ -25,7 +37,7 @@ export function BarcodeScanner({ onDetected }: Props) {
   // reading it inside the camera effect would tear the stream down and restart
   // it every time somebody switched language mid-scan.
   const [cameraDenied, setCameraDenied] = useState(false)
-  const [scanning, setScanning] = useState(false)
+  const [scanning, setScanning] = useState(autoStart)
   const { scanner } = useMessages().foods
 
   // Read via a ref inside the scan loop below instead of depending on
@@ -128,15 +140,19 @@ export function BarcodeScanner({ onDetected }: Props) {
     <div className="grid gap-3">
       {!cameraDenied && (
         <div>
-          <button
-            type="button"
-            onClick={() => setScanning((s) => !s)}
-            className="rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 py-1.5 text-sm"
-          >
-            {scanning ? scanner.stop : scanner.scan}
-          </button>
+          {!autoStart && (
+            <button
+              type="button"
+              onClick={() => setScanning((s) => !s)}
+              className="rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 py-1.5 text-sm"
+            >
+              {scanning ? scanner.stop : scanner.scan}
+            </button>
+          )}
           {scanning && (
-            <div className="relative mt-2 max-w-sm">
+            <div
+              className={`relative max-w-sm ${autoStart ? '' : 'mt-2'}`.trim()}
+            >
               <video
                 ref={videoRef}
                 className="w-full rounded-[var(--app-radius)]"

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -171,6 +171,26 @@ test('an Open Food Facts result already in your library logs that food’s own f
   })
 })
 
+test('the search field offers a clear only while there is something to clear', async () => {
+  renderSheet()
+  expect(screen.queryByLabelText('Clear search')).toBeNull()
+
+  await search('melk')
+  await waitFor(() => expect(screen.getByText('Halfvolle melk')).toBeDefined())
+
+  fireEvent.click(screen.getByLabelText('Clear search'))
+
+  const field = screen.getByLabelText('Search foods and recipes…')
+  expect(field).toHaveValue('')
+  // Back where you left it, ready for the next thing you type.
+  expect(document.activeElement).toBe(field)
+  expect(screen.queryByLabelText('Clear search')).toBeNull()
+  // And the empty-search state is what is on screen again: the matches for the
+  // term are gone, the always-there sections are back.
+  await waitFor(() => expect(screen.queryByText('Halfvolle melk')).toBeNull())
+  expect(screen.getByText('Melkbroodjes')).toBeDefined()
+})
+
 test('one search fills labelled sections with foods, recipes and Open Food Facts', async () => {
   renderSheet()
   await search('melk')

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -62,6 +62,8 @@ const offResults = vi.hoisted(() => ({
 }))
 /** What `foods.getByBarcode` finds, for the "this is already in your library" path. */
 const existingFood = vi.hoisted(() => ({ value: null as unknown }))
+/** What `foodsLookup.lookupBarcode` finds on Open Food Facts. */
+const offProduct = vi.hoisted(() => ({ value: null as unknown }))
 const calls = vi.hoisted(() => ({ value: [] as Array<[string, unknown]> }))
 
 vi.mock('convex/react', () => ({
@@ -72,6 +74,9 @@ vi.mock('convex/react', () => ({
       return foods.value.filter((f) =>
         `${f.name} ${f.brand}`.toLowerCase().includes(term),
       )
+    }
+    if (name === 'foods:getByBarcode') {
+      return args === 'skip' ? undefined : existingFood.value
     }
     if (name === 'recipes:listAcrossMyGroups') return recipes.value
     if (name === 'combos:list') return combos.value
@@ -85,6 +90,7 @@ vi.mock('convex/react', () => ({
     return 'entry1'
   },
   useAction: (name: string) => async (args: { term?: string }) => {
+    if (name === 'foodsLookup:lookupBarcode') return offProduct.value
     if (name !== 'foodsLookup:searchByName') return null
     const term = (args.term ?? '').toLowerCase()
     return offResults.value.filter((r) => r.name.toLowerCase().includes(term))
@@ -141,6 +147,77 @@ beforeEach(() => {
   loggedAmounts.value = []
   combos.value = []
   existingFood.value = null
+  offProduct.value = null
+})
+
+test('a barcode you already have is shown from your own rows', async () => {
+  // Somebody edited these figures after importing this row once. Typing the
+  // barcode must find *that* row, not fetch Open Food Facts' version over it.
+  existingFood.value = {
+    _id: 'food9',
+    name: 'Volle melk',
+    brand: 'Zaanse Hoeve',
+    baseUnit: 'ml',
+    nutritionPer100: { calories: 100 },
+  }
+  renderSheet()
+  await search('8712345678901')
+
+  await waitFor(() => expect(screen.getByText('Your foods')).toBeDefined())
+  expect(screen.getByText('Volle melk')).toBeDefined()
+
+  fireEvent.click(screen.getByText('Volle melk'))
+  fireEvent.click(screen.getByText('Add to diary'))
+  await waitFor(() => expect(calls.value).toHaveLength(1))
+  expect(calls.value[0][1]).toMatchObject({
+    foodId: 'food9',
+    // The row's own figures, so nothing was imported over it.
+    nutrition: { calories: 100 },
+  })
+})
+
+test('a barcode only Open Food Facts has is offered as something to import', async () => {
+  offProduct.value = {
+    name: 'Nutella',
+    brand: 'Ferrero',
+    nutritionPer100: { calories: 539 },
+  }
+  renderSheet()
+  await search('3017620422003')
+
+  await waitFor(() => expect(screen.getByText('Open Food Facts')).toBeDefined())
+  expect(screen.getByText('Nutella')).toBeDefined()
+  // It is not pretending to be one of yours.
+  expect(screen.queryByText('Your foods')).toBeNull()
+})
+
+test('a barcode nobody has offers adding it, rather than an empty list', async () => {
+  renderSheet()
+  await search('9999999999999')
+
+  await waitFor(() => expect(screen.getByText(/Not found\./)).toBeDefined())
+  expect(screen.getByText('Add it to the foods library')).toBeDefined()
+  // Logging the digits themselves as a one-off would put "9999999999999" in a
+  // diary, which is not what typing a barcode meant.
+  expect(screen.queryByText(/as a one-off/)).toBeNull()
+})
+
+test('digits still being typed are an ordinary search, not a lookup', async () => {
+  // Long enough to be a number, too short to be a barcode: this must not
+  // resolve as one, or the list would flicker between modes on the way in.
+  existingFood.value = {
+    _id: 'food9',
+    name: 'Volle melk',
+    baseUnit: 'ml',
+    nutritionPer100: { calories: 100 },
+  }
+  renderSheet()
+  await search('871234')
+
+  await waitFor(() =>
+    expect(screen.getByText('Nothing found for “871234”')).toBeDefined(),
+  )
+  expect(screen.queryByText('Volle melk')).toBeNull()
 })
 
 test('an Open Food Facts result already in your library logs that food’s own figures', async () => {

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -191,6 +191,25 @@ test('a barcode only Open Food Facts has is offered as something to import', asy
   expect(screen.queryByText('Your foods')).toBeNull()
 })
 
+test('a nameless Open Food Facts product is not offered as a blank card', async () => {
+  // `mapOffProduct` maps a product with no `product_name` rather than rejecting
+  // it, deliberately leaving the name to a confirmation screen — and there is
+  // no confirmation screen on this path. Left unfiltered it renders an
+  // unlabelled row whose confirm would save a food called "". The search path
+  // drops nameless rows for the same reason.
+  offProduct.value = {
+    name: '',
+    brand: 'Plus',
+    nutritionPer100: { calories: 78 },
+  }
+  renderSheet()
+  await search('8712345678901')
+
+  await waitFor(() => expect(screen.getByText(/Not found\./)).toBeDefined())
+  expect(screen.queryByText('Open Food Facts')).toBeNull()
+  expect(screen.getByText('Add it to the foods library')).toBeDefined()
+})
+
 test('a barcode nobody has offers adding it, rather than an empty list', async () => {
   renderSheet()
   await search('9999999999999')

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -10,6 +10,7 @@ import {
   type QuantityUnit,
 } from '../../../convex/lib/consumption'
 import type { NutritionFacts } from '../../../convex/lib/nutrition'
+import { barcodeTerm } from '../../../convex/lib/offFetch'
 import type {
   OffMappedFood,
   OffSearchResult,
@@ -257,6 +258,11 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
     matchingRecipes.length === 0 &&
     offResults.length === 0 &&
     !search.offSearching
+  // A barcode that matched nothing is not a thing to log the digits of: it is a
+  // product nobody has yet, so it gets the route the scanner already has for
+  // that — add it to your library, with the barcode it was looked up by —
+  // rather than the one-off card, which would write "8712345678901" in a diary.
+  const searchedBarcode = barcodeTerm(term)
 
   return (
     <BottomSheet
@@ -331,16 +337,7 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
       {scanFailure && (
         <p className="mb-3 text-xs opacity-60">
           {scanFailure.message ?? (
-            <>
-              {foodAdd.notFound}{' '}
-              <Link
-                {...nav.createFood(scanFailure.barcode)}
-                className="underline"
-              >
-                {foodAdd.addToLibrary}
-              </Link>{' '}
-              {foodAdd.addToLibraryAfter}
-            </>
+            <NoSuchBarcode barcode={scanFailure.barcode} nav={nav} />
           )}
         </p>
       )}
@@ -427,22 +424,52 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
         </Section>
       )}
 
-      {foundNothing && (
-        <Section title={fmt(add.nothingFound, { term })}>
-          <OneOffCard
-            term={term}
-            expanded={expanded === 'one-off'}
-            onToggle={() => toggle('one-off')}
-            onLog={log}
-          />
-        </Section>
-      )}
+      {foundNothing &&
+        (searchedBarcode ? (
+          <p className="py-2 text-xs opacity-60">
+            <NoSuchBarcode barcode={searchedBarcode} nav={nav} />
+          </p>
+        ) : (
+          <Section title={fmt(add.nothingFound, { term })}>
+            <OneOffCard
+              term={term}
+              expanded={expanded === 'one-off'}
+              onToggle={() => toggle('one-off')}
+              onLog={log}
+            />
+          </Section>
+        ))}
 
       {!term &&
         matchingCombos.length === 0 &&
         matchingRecipes.length === 0 &&
         !scanned && <p className="py-2 text-sm opacity-60">{add.searchHint}</p>}
     </BottomSheet>
+  )
+}
+
+/**
+ * What a barcode nobody has offers: adding it yourself, with the barcode
+ * already filled in — so the next person who scans or types it finds a food
+ * rather than this line again. Shared by the scanner and by a barcode typed
+ * into the search box, which are the same dead end reached two ways.
+ */
+function NoSuchBarcode({
+  barcode,
+  nav,
+}: {
+  barcode: string | undefined
+  nav: NutritionNav
+}) {
+  const { foodAdd } = useMessages().nutrition.diary
+  return (
+    <>
+      {foodAdd.notFound}{' '}
+      <Link {...nav.createFood(barcode)} className="underline">
+        {foodAdd.addToLibrary}
+      </Link>{' '}
+      {foodAdd.addToLibraryAfter}
+    </>
   )
 }
 

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -321,7 +321,11 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
     >
       {scanning && (
         <div className="mb-3">
-          <BarcodeScanner onDetected={onBarcode} />
+          {/* Pressing Scan in the header is the press that starts the camera:
+              this surface exists only because that was pressed, so making you
+              press a second Scan inside it was two taps for one intent (#81).
+              The header button is what stops it again. */}
+          <BarcodeScanner onDetected={onBarcode} autoStart />
         </div>
       )}
       {scanFailure && (

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import { useAction, useConvex, useMutation, useQuery } from 'convex/react'
-import { type ReactNode, useState } from 'react'
+import { type ReactNode, useRef, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import { type ComboCounts, comboEntries } from '../../../convex/lib/combos'
@@ -99,6 +99,7 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
     meals: messages.nutrition.meals,
   }
 
+  const searchRef = useRef<HTMLInputElement>(null)
   const [expanded, setExpanded] = useState<string | null>(null)
   const [comboBusy, setComboBusy] = useState(false)
   const [comboError, setComboError] = useState<string | null>(null)
@@ -278,14 +279,35 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
             </button>
           </div>
           <div className="flex items-center gap-2">
-            <input
-              value={search.term}
-              onChange={(e) => search.setTerm(e.target.value)}
-              onFocus={() => setPromotions((n) => n + 1)}
-              placeholder={add.searchPlaceholder}
-              aria-label={add.searchPlaceholder}
-              className={`${fieldClass} min-w-0 flex-1`}
-            />
+            <div className="relative flex min-w-0 flex-1 items-center">
+              <input
+                ref={searchRef}
+                value={search.term}
+                onChange={(e) => search.setTerm(e.target.value)}
+                onFocus={() => setPromotions((n) => n + 1)}
+                placeholder={add.searchPlaceholder}
+                aria-label={add.searchPlaceholder}
+                className={`${fieldClass} w-full min-w-0 pr-12`}
+              />
+              {/* Only while there is something to clear: an always-present ✕
+                  over an empty field is a control that does nothing. Focus goes
+                  back to the input, so clearing is the start of the next search
+                  rather than the end of this one — and the refocus re-promotes
+                  the sheet, which is why clearing never drops it to peek. */}
+              {search.term !== '' && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    search.setTerm('')
+                    searchRef.current?.focus()
+                  }}
+                  aria-label={add.clearSearch}
+                  className="absolute right-0 flex min-h-11 min-w-11 items-center justify-center text-sm opacity-60"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
             <button
               type="button"
               onClick={() => setScanning((on) => !on)}

--- a/src/components/nutrition/useFoodSearch.test.ts
+++ b/src/components/nutrition/useFoodSearch.test.ts
@@ -1,5 +1,33 @@
 import { expect, test } from 'vitest'
-import { offCacheKey, shouldSearchOff } from './useFoodSearch'
+import { barcodeTerm, offCacheKey, shouldSearchOff } from './useFoodSearch'
+
+test('a barcode typed into the search box is resolved as a barcode', () => {
+  // Not restated here: the search box borrows the pattern the lookup itself
+  // uses, so "what counts as a barcode" has one definition (#80).
+  expect(barcodeTerm('8712345678901')).toBe('8712345678901')
+})
+
+test('digits still arriving stay an ordinary search', () => {
+  // The mode is decided about the debounced term, so these are the states a
+  // pause could land on, not every keystroke — but each of them still has to
+  // mean "keep searching by text" rather than "look this up and find nothing".
+  expect(barcodeTerm('871')).toBeNull()
+  expect(barcodeTerm('8712345')).toBeNull()
+  // …and a term that is a barcode is still worth asking OFF about, so the two
+  // gates never disagree about whether to reach Open Food Facts at all.
+  expect(shouldSearchOff('8712345678901')).toBe(true)
+})
+
+test('a barcode lookup is cached and rate-limited like any other term', () => {
+  // It goes through the same per-term cache: the key is the term, whatever
+  // kind of term it turned out to be.
+  expect(offCacheKey('8712345678901', 'nl')).toBe(
+    offCacheKey('8712345678901', 'nl'),
+  )
+  expect(offCacheKey('8712345678901', 'nl')).not.toBe(
+    offCacheKey('8712345678901', 'en'),
+  )
+})
 
 test('a term of three characters or more is worth asking Open Food Facts about', () => {
   expect(shouldSearchOff('brie')).toBe(true)

--- a/src/components/nutrition/useFoodSearch.ts
+++ b/src/components/nutrition/useFoodSearch.ts
@@ -2,6 +2,7 @@ import { useAction, useQuery } from 'convex/react'
 import type { FunctionReturnType } from 'convex/server'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
+import { barcodeTerm } from '../../../convex/lib/offFetch'
 import type { OffSearchResult } from '../../../convex/lib/offMapping'
 import { useI18n } from '../../lib/i18n'
 
@@ -24,6 +25,14 @@ export const SEARCH_DEBOUNCE_MS = 250
  * product is a handful of requests, well inside the ceiling.
  */
 export const OFF_SEARCH_DEBOUNCE_MS = 400
+
+/**
+ * Whether the term is a barcode, and so resolves by lookup rather than by
+ * search. Re-exported from `convex/lib/offFetch` rather than restated: the
+ * pattern that decides what a lookup will accept is the one that decides
+ * whether to make one.
+ */
+export { barcodeTerm }
 
 /**
  * Whether a term is worth asking Open Food Facts about at all.
@@ -85,7 +94,30 @@ export function useFoodSearch(): FoodSearch {
     const id = setTimeout(() => setDebouncedTerm(term), SEARCH_DEBOUNCE_MS)
     return () => clearTimeout(id)
   }, [term])
-  const results = useQuery(api.foods.search, { term: debouncedTerm })
+
+  // Read off the *debounced* term, so the mode is only ever decided about a
+  // term somebody has stopped typing: the digits of a barcode arriving one at a
+  // time never flip the list between a text search and a lookup on the way.
+  const localBarcode = barcodeTerm(debouncedTerm)
+  // The full-text index is built from name and brand (`foodSearchText.ts`), so
+  // a barcode put through it matches nothing. The row is found by its barcode
+  // instead — and found rather than imported, which is what keeps a product you
+  // already have from being overwritten by Open Food Facts' version of it.
+  const textMatches = useQuery(
+    api.foods.search,
+    localBarcode ? 'skip' : { term: debouncedTerm },
+  )
+  const barcodeMatch = useQuery(
+    api.foods.getByBarcode,
+    localBarcode ? { barcode: localBarcode } : 'skip',
+  )
+  const results: FoodSearchResult[] | undefined = localBarcode
+    ? barcodeMatch === undefined
+      ? undefined
+      : barcodeMatch
+        ? [barcodeMatch]
+        : []
+    : textMatches
 
   const [offTerm, setOffTerm] = useState('')
   useEffect(() => {
@@ -101,9 +133,11 @@ export function useFoodSearch(): FoodSearch {
   const offCacheRef = useRef<Map<string, OffSearchResult[]>>(new Map())
 
   const searchByName = useAction(api.foodsLookup.searchByName)
+  const lookupBarcode = useAction(api.foodsLookup.lookupBarcode)
 
   useEffect(() => {
-    if (!shouldSearchOff(offTerm)) {
+    const barcode = barcodeTerm(offTerm)
+    if (!barcode && !shouldSearchOff(offTerm)) {
       setOffResults(null)
       setOffSearching(false)
       return
@@ -129,7 +163,18 @@ export function useFoodSearch(): FoodSearch {
     let abandoned = false
     setOffSearching(true)
     setOffError(null)
-    searchByName({ term: offTerm, locale })
+    // A barcode is a lookup, not a search — but it goes through the same
+    // debounce, the same cache and the same abandonment as a name, because the
+    // rate ceiling is about how often this hook reaches Open Food Facts, not
+    // about which endpoint it reaches it by. A product the lookup has is one
+    // result; a barcode nobody has is none, which is the empty result the
+    // caller already turns into "not found — add it yourself".
+    const ask: Promise<OffSearchResult[]> = barcode
+      ? lookupBarcode({ barcode }).then((mapped) =>
+          mapped ? [{ ...mapped, barcode }] : [],
+        )
+      : searchByName({ term: offTerm, locale })
+    ask
       .then((found) => {
         if (abandoned) return
         offCacheRef.current.set(offCacheKey(offTerm, locale), found)
@@ -147,7 +192,7 @@ export function useFoodSearch(): FoodSearch {
     return () => {
       abandoned = true
     }
-  }, [offTerm, locale, searchByName])
+  }, [offTerm, locale, searchByName, lookupBarcode])
 
   const clearOffError = useCallback(() => setOffError(null), [])
 

--- a/src/components/nutrition/useFoodSearch.ts
+++ b/src/components/nutrition/useFoodSearch.ts
@@ -169,9 +169,16 @@ export function useFoodSearch(): FoodSearch {
     // about which endpoint it reaches it by. A product the lookup has is one
     // result; a barcode nobody has is none, which is the empty result the
     // caller already turns into "not found — add it yourself".
+    //
+    // A nameless product counts as none. `mapOffProduct` deliberately maps a
+    // product with no `product_name` rather than rejecting it, leaving the name
+    // to the confirmation screen — but there is no confirmation screen on this
+    // path, so an unfiltered mapping renders a blank card whose confirm would
+    // save a food called "". `mapOffSearchResults` drops nameless rows for the
+    // same reason; this is that filter, applied where the barcode path needs it.
     const ask: Promise<OffSearchResult[]> = barcode
       ? lookupBarcode({ barcode }).then((mapped) =>
-          mapped ? [{ ...mapped, barcode }] : [],
+          mapped?.name.trim() ? [{ ...mapped, barcode }] : [],
         )
       : searchByName({ term: offTerm, locale })
     ask

--- a/src/lib/i18n/messages/en/nutrition.ts
+++ b/src/lib/i18n/messages/en/nutrition.ts
@@ -65,6 +65,7 @@ export const diary = {
     title: 'Add to {meal}',
     searchPlaceholder: 'Search foods and recipes…',
     searchHint: 'Search for a food, or scan a barcode.',
+    clearSearch: 'Clear search',
     scan: 'Scan',
     hideScanner: 'Hide scanner',
     sections: {

--- a/src/lib/i18n/messages/nl/nutrition.ts
+++ b/src/lib/i18n/messages/nl/nutrition.ts
@@ -52,6 +52,7 @@ export const diary = {
     title: 'Toevoegen aan {meal}',
     searchPlaceholder: 'Voedingsmiddelen en recepten zoeken…',
     searchHint: 'Zoek een voedingsmiddel, of scan een barcode.',
+    clearSearch: 'Zoekopdracht wissen',
     scan: 'Scannen',
     hideScanner: 'Scanner verbergen',
     sections: {


### PR DESCRIPTION
Closes #78
Closes #81
Closes #80

## Why these three together

All three change the add sheet's search-and-scan surface — the header row that holds
the search box and the Scan button, the scanner it mounts, and the hook behind the
results list. As separate branches they would have conflicted in `AddSheet.tsx` line
for line, so they are one PR with **one commit per issue** to keep the issue→commit
mapping traceable:

| commit | issue |
| --- | --- |
| `feat(nutrition): clear the add sheet's search box in one tap` | #78 |
| `fix(nutrition): one tap on the sheet's Scan button opens the camera` | #81 |
| `feat(nutrition): a barcode typed into the search box is looked up` | #80 |

## What changed

### #78 — clearing the search box

A ✕ inside the search field, rendered only while the term is non-empty. It empties
the term and puts focus back in the input; the refocus re-fires the sheet's
`promoteToFull` counter, so clearing never drops the sheet back to peek. Tap target
is `min-h-11 min-w-11` (44px), and its `aria-label` is a new `nutrition.diary.add.clearSearch`
message in both `en` and `nl` — no English literal in `src/` (ADR-0011).

### #81 — scanning in one tap

`BarcodeScanner` gains `autoStart`, defaulting to `false`, which starts its internal
`scanning` state on mount. `AddSheet` passes it; **`FoodsPage` is untouched** and
still requires an explicit press, which is the whole reason this is a prop rather
than a change to the component's default — auto-starting a camera whenever the foods
list is opened would be a worse bug than the one being fixed.

With `autoStart` set, the scanner's own Scan/Stop button is hidden: the surface that
started the camera is the one that stops it, so the header button is not shadowed by
a second control saying the same word. The camera effect and its cleanup are
unchanged, so the auto-started path stops its media tracks on unmount and on toggle
exactly as the pressed path always did. A denied permission still sets `cameraDenied`,
drops out of scanning, and leaves the message plus the manual barcode field — not a
dead camera area.

### #80 — a typed barcode is a barcode

The pure part lives beside `BARCODE_PATTERN` in `convex/lib/offFetch.ts`:

```ts
export function barcodeTerm(term: string): string | null
```

The client imports it (re-exported from `useFoodSearch` for the callers already
importing from there) rather than restating the regex — one definition of "plausible
barcode" for the thing that decides to make a lookup and for the lookup that accepts
it. There is a test asserting the two do not drift.

In `useFoodSearch`, a term that is a barcode resolves by `api.foods.getByBarcode`
locally and `api.foodsLookup.lookupBarcode` on Open Food Facts, instead of
`foods.search` and `searchByName`. A local hit renders as an ordinary food card and
is **not** re-imported over; an OFF-only hit renders as an `OffCard`, whose existing
import path already reuses a row with that barcode. Nothing new appears on screen.

**The flicker case.** The mode is decided about the *debounced* terms, never about
`term` itself: `barcodeTerm(debouncedTerm)` drives the local query and
`barcodeTerm(offTerm)` drives the OFF effect. So the intermediate lengths of a
barcode being typed do not reach the decision at all — a pause is what produces a
mode, and a pause on fewer than 8 digits falls through to ordinary text search
(covered by a component test on `871234` and by unit tests on every prefix of a
barcode). The barcode lookup goes through the same 400 ms debounce, the same
per-term cache and the same abandonment-on-newer-term as a name search, so it is
inside the documented rate ceiling rather than exempt from it.

**A barcode nobody has** gets the scanner's existing "Not found. Add it to the foods
library first." route, carrying the barcode into the create-food link — extracted as
a small local `NoSuchBarcode` so the scanner and the typed-barcode path share it.
The one-off card is deliberately *not* offered here: logging `9999999999999` as a
diary label is not what typing a barcode meant.

## Tests

`pnpm typecheck`, `pnpm test` (95 files, 1029 tests) and `pnpm check` all pass.

- `convex/lib/offFetch.test.ts` — `barcodeTerm` unit tests at the highest seam:
  what it accepts, every prefix of a barcode being typed, over-long numbers, names
  with digits in them, and that its acceptance matches `fetchOffProduct`'s.
- `src/components/nutrition/useFoodSearch.test.ts` — the barcode decision as the
  hook exposes it, and that a barcode shares the per-term cache key.
- `src/components/nutrition/AddSheet.test.tsx` — through `renderWithI18n`: the clear
  control appearing/disappearing and restoring focus and the empty-search state; a
  barcode you already have logging your own row's figures; a barcode only OFF has
  appearing as importable; a barcode nobody has offering the add-it-yourself route;
  and short digit strings staying an ordinary search.
- `src/components/foods/BarcodeScanner.test.tsx` — `autoStart` opening the camera
  with no press and hiding the redundant button, the default still requiring a press
  (the `FoodsPage` guarantee), tracks stopped when the auto-started scanner goes
  away, and denied permission falling back to the manual field.

No Convex schema or function signature changed; `convex/lib/offFetch.ts` only gained
an exported pure function.

## Acceptance criteria I could NOT verify

Please give these a human pass:

- **#81 — "Driven on a phone with a real camera, not only unit-tested."** Not
  possible from an agent. `getUserMedia` is mocked in jsdom, so what is proven is
  that it is *called* without a press, that the tracks are stopped on teardown, and
  that a rejected permission falls back. **Unverified on real hardware:** that the
  camera preview actually appears and focuses, that `facingMode: 'environment'`
  picks the rear camera, that the browser's permission prompt on first use does not
  leave the sheet in a bad state while it is open, and that scanning a real packet
  still detects.
- **#81 — "Closing the sheet … stops the media tracks."** Verified as component
  unmount stopping the tracks. That the camera indicator light actually goes out on
  a phone is the same real-hardware gap.
- **#78 — "Its tap target is at least 44px."** Asserted only as the `min-h-11
  min-w-11` classes; jsdom does not lay out, so nothing measured a rendered box.
  Worth a glance in a real viewport, particularly that the ✕ does not overlap the
  text at the right-hand end of a long term (the input carries `pr-12` for this).
- **#78 — "does not collapse the sheet back to peek."** Verified by reasoning about
  `promoteToFull` plus the refocus, not by a test — the sheet's detents are
  deliberately not asserted in jsdom (see the note at the top of `AddSheet.test.tsx`,
  which is why dragging is untested there too).
- **#80 — the real Open Food Facts responses.** Every OFF call is behind a mocked
  action or an injected `fetch`; no test hits the network. That a real barcode
  returns a mappable product, and that a lookup for an unknown barcode returns the
  null the code expects, is unverified against the live service.
- **Both locales on screen.** The `nl` strings are type-checked and covered by
  `messages.test.ts`, but no test renders the sheet in Dutch, so the Dutch clear
  label has not been seen in place.


---
_Generated by [Claude Code](https://claude.ai/code/session_019w4UGLSzcg43osPSZycApg)_