### PR TITLE
fix: two horizontal-overflow defects — the native file input, and the add sheet's section track

### DIFF
--- a/src/components/app/ImageUploadField.tsx
+++ b/src/components/app/ImageUploadField.tsx
@@ -24,6 +24,18 @@ import { PhotoPrepareDialog } from './PhotoPrepareDialog'
  * id only once that id exists in Convex, and with `undefined` only when the
  * person clears the photo. A form is never holding an id for a blob that was
  * never uploaded.
+ *
+ * The `<input type="file">` is visually hidden and driven by a styled
+ * `<label htmlFor>` instead of being rendered by the browser (#61). A native
+ * file input's width is its UA button plus its "no file chosen" text, in the
+ * *browser's* language, and it does not shrink to its container — in Dutch
+ * ("Kies bestand geen bestand geselecteerd") that was wide enough to push this
+ * card past the viewport and scroll the whole document sideways. Taking the
+ * control's width back also takes its wording back, so the field reads the same
+ * in every browser and its text lives in the message tree like everything else.
+ * Nothing is lost by hiding it: the filename it would show is never the point
+ * here, because choosing a file goes straight to the framing step and what is
+ * kept afterwards is the preview.
  */
 
 interface ImageUploadFieldProps {
@@ -94,18 +106,21 @@ export function ImageUploadField({
           <img
             src={displayUrl}
             alt=""
-            className="h-20 w-20 rounded-lg object-cover"
+            className="h-20 w-20 shrink-0 rounded-lg object-cover"
           />
         ) : (
-          <div className="h-20 w-20 rounded-lg bg-black/5 dark:bg-white/10" />
+          <div className="h-20 w-20 shrink-0 rounded-lg bg-black/5 dark:bg-white/10" />
         )}
-        <div>
+        <div className="min-w-0 flex-1">
+          {/* Visually hidden, not removed: it is still the field, still the
+              thing the label above names, and still what a screen reader and a
+              keyboard reach. Only its rendering is ours now. */}
           <input
             ref={inputRef}
             id={fieldId}
             type="file"
             accept="image/*"
-            className="text-sm"
+            className="peer sr-only"
             disabled={uploading}
             onChange={(e) => {
               const file = e.target.files?.[0]
@@ -118,6 +133,12 @@ export function ImageUploadField({
               }
             }}
           />
+          <label
+            htmlFor={fieldId}
+            className="inline-flex max-w-full min-h-9 cursor-pointer items-center truncate rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-[var(--app-accent)] peer-disabled:cursor-not-allowed peer-disabled:opacity-60"
+          >
+            {displayUrl ? image.replace : image.choose}
+          </label>
           {uploading && <p className="text-xs opacity-60">{image.uploading}</p>}
           {error && (
             <p role="alert" className="text-xs text-red-800">

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -426,7 +426,13 @@ function Section({ title, children }: { title: string; children: ReactNode }) {
       <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide opacity-60">
         {title}
       </h3>
-      <ul className="grid gap-2">{children}</ul>
+      {/* `grid-cols-1` rather than a bare `grid`: the implicit column a bare
+          `grid` creates is sized `auto`, whose *minimum* is the min-content
+          width of its widest row, so one row that cannot shrink drags the whole
+          section past the sheet — and every other row in it stretches to match
+          (#83). `grid-cols-1` compiles to `repeat(1, minmax(0, 1fr))`, which
+          pins the track to the container instead. */}
+      <ul className="grid grid-cols-1 gap-2">{children}</ul>
     </div>
   )
 }

--- a/src/components/nutrition/BottomSheet.tsx
+++ b/src/components/nutrition/BottomSheet.tsx
@@ -343,9 +343,19 @@ export function BottomSheet({
           />
         </div>
         <div className="flex-none px-4 pb-2">{header}</div>
+        {/* `overflow-x-hidden` is not decoration. Setting either axis to
+            something other than `visible` makes the other compute to `auto`, so
+            leaving it alone did not mean "no horizontal overflow" — it meant
+            the body was horizontally scrollable, and anything inside it that
+            outgrew the sheet took the sheet sideways rather than being clipped
+            by it (#83). Clipping keeps a future unshrinkable child contained.
+
+            This does not touch rule 3: `touch-action` is unchanged, and it
+            already refused horizontal panning at every detent. All that goes
+            away is a scrollable overflow region nothing was meant to reach. */}
         <div
           ref={bodyRef}
-          className={`flex-1 px-4 pb-8 ${
+          className={`flex-1 overflow-x-hidden px-4 pb-8 ${
             detent === 'full' ? 'overflow-y-auto' : 'overflow-y-hidden'
           }`}
           style={{

--- a/src/components/nutrition/ResultCard.tsx
+++ b/src/components/nutrition/ResultCard.tsx
@@ -32,7 +32,12 @@ export function ResultCard({
   children,
 }: Props) {
   return (
-    <li className="rounded-[var(--app-radius)] border border-[var(--app-border)]">
+    // `min-w-0` because a grid item's automatic minimum size is its min-content
+    // width, which would let a row overflow its track even once the track is
+    // capped at the container (#83). The parts of the row below that cannot
+    // give — the `shrink-0` thumbnail and the `shrink-0` meta — are what that
+    // min-content width is made of.
+    <li className="min-w-0 rounded-[var(--app-radius)] border border-[var(--app-border)]">
       <button
         type="button"
         aria-expanded={expanded}

--- a/src/lib/i18n/messages/en/common.ts
+++ b/src/lib/i18n/messages/en/common.ts
@@ -33,6 +33,8 @@ export const common = {
   /** The photo field a recipe and a child's profile both use. */
   image: {
     label: 'Photo',
+    choose: 'Choose photo',
+    replace: 'Replace photo',
     uploading: 'Uploading…',
     failed: 'Could not upload that image',
     remove: 'Remove photo',

--- a/src/lib/i18n/messages/nl/common.ts
+++ b/src/lib/i18n/messages/nl/common.ts
@@ -26,6 +26,8 @@ export const common = {
 
   image: {
     label: 'Foto',
+    choose: 'Foto kiezen',
+    replace: 'Andere foto kiezen',
     uploading: 'Uploaden…',
     failed: 'Kon die afbeelding niet uploaden',
     remove: 'Foto verwijderen',


### PR DESCRIPTION
Closes #61
Closes #83

Two horizontal-overflow bugs. Same family — an unshrinkable child forcing a
container wider than the viewport — but **two different mechanisms, two
different fixes, and neither fixes the other**, exactly as the triage on #83
warned. They are one PR only because both are small and they touch disjoint
files; they are two commits, one per issue, and either can be reverted alone.

---

## #61 — the native file input (`eafa611`)

`ImageUploadField` rendered a bare `<input type="file">`. Its intrinsic width is
the UA's button plus its "no file chosen" text, and it does not shrink to its
container. The wrapping `<div>` was a flex item with the default
`min-width: auto`, so nothing in the row could give: the row's minimum became
`80px thumbnail + 12px gap + (file input intrinsic width)`, the card outgrew the
page, and the **document** scrolled sideways.

The control's text comes from the browser, in the browser's language, so this is
locale-dependent — `Kies bestand geen bestand geselecteerd` is far wider than
`Choose File no file chosen`. That is why it was reported from Dutch and why
review never caught it: a translated string the message tree does not own and
cannot see.

### Which fix, and why

The issue offered a minimum (`min-w-0` / `max-w-full` / `shrink-0`) and a better
option (hide the native input, drive it from a styled `<label htmlFor>`).
**I took the styled label, and kept the flex guards on top of it.**

The minimum only *accommodates* the widest translation the browser happens to
ship. It leaves the field's width a property of the user agent and its locale,
which means the next locale, or the next iOS release that rewords the control,
re-opens this. The styled label takes the width **and the wording** back, so the
field is as wide as we say and reads the same in every browser, with its text in
the message tree like everything else.

The usual cost of hiding a file input — losing the filename it displays — is not
a cost here: choosing a file goes straight to the framing dialog, and what
remains afterwards is the preview thumbnail. The "no file selected" text was
never information in this flow.

The guards go in anyway (`shrink-0` on the thumbnail, `min-w-0` on the wrapper,
`max-w-full` + `truncate` on the label), because our own label is translated too.

### What did not move

- The input is **hidden, not removed** — still `sr-only`, still focusable, still
  the control the `Photo` label names, still what `onChange` fires from.
- The **timing contract is untouched**: `onChange` fires with a storage id only
  once that id exists in Convex, and with `undefined` only on clearing.
- **The existing `ImageUploadField` test passes unchanged** (10/10). Not one
  line of it was edited.

### Call sites checked

All four take the fix, and none passes anything that would defeat it — no
`label` override, no wrapper that re-imposes a minimum:
`NewRecipePage.tsx:164`, `EditRecipePage.tsx:78`, `NewBabyPage.tsx:44`,
`EditBabyPage.tsx:96`.

### Strings

`common.image.choose` / `common.image.replace`, added to **both** `en` and `nl`
(ADR-0011).

---

## #83 — the add sheet's section track (`3543346`)

Every section is a `<ul className="grid gap-2">`. The implicit column a bare
`grid` creates is sized `auto`, whose **minimum** is the min-content width of its
widest item. One row that cannot shrink below the container drags the track
wider, and every other row in that same grid stretches to match — which is the
screenshot precisely: all eight OFF rows cut at the same x, the Your-foods
section (a separate `<ul>`) ending cleanly at the margin, and the *same product*
fitting in one and not the other.

Three layers, because each leaves the defect latent without the others:

1. **`grid-cols-1` on `Section`'s `<ul>`.** Compiles to
   `repeat(1, minmax(0, 1fr))` — verified in the built CSS — which pins the track
   to the container. This is the actual fix and it is one class.
2. **`min-w-0` on `ResultCard`'s `<li>`.** Capping the track is not sufficient by
   itself: a grid item's *automatic minimum size* is its own min-content width,
   so the row could still overflow a track that no longer grows for it.
3. **`overflow-x-hidden` on the sheet body.** Per CSS overflow, a computed
   `visible` on one axis becomes `auto` when the other is not `visible` — so
   leaving `overflow-x` alone never meant "no horizontal overflow", it meant the
   body was horizontally *scrollable* and carried the overflow rather than
   clipping it.

### Which row forces the track

Reasoned from the code rather than measured. Inside a `ResultCard` the middle
column is `min-w-0 flex-1` and both its lines `truncate`, so it contributes
nothing; the parts that cannot give are the two `shrink-0` items — the 44px
`FoodThumbnail`, which is fixed, and the **meta span**, which has no `min-w-0`,
no truncation and `shrink-0`, so it contributes its full max-content width to
the row's min-content width. It is the only variable part of the row that can
push the track, which matches the triage's suspicion.

I did **not** narrow it to one specific OFF result. Layer 1 caps the track and
layer 2 caps the item, so the fix holds whichever row it was — but the checklist
item "identify the row that actually forces the track" is honestly **not** ticked.

### Gesture ownership (PR #72) — checked

`touch-action` is **unchanged**: still `pan-y` at full and `none` otherwise, so
rule 3 ("only advertise a pan the list can actually perform") is intact. Rule 2
reads `bodyRef.current.scrollTop`, which `overflow-x` does not affect. Rule 1 is
in `useScrollLock` and untouched. The body was already a scroll container on
both axes before this change (see above); all that goes away is a horizontally
scrollable region nothing was ever meant to reach. Note this also *tightens*
the peek detent, where `overflow-x` previously computed to `auto` too.

### Deliberately not included

The `subtitle`-suppression idea from the issue body (drop the brand when it is
already a prefix of the product name) is a good idea and remains open. It would
mean a second, *semantic* change inside `AddSheet.tsx`, which another branch is
editing right now, and #83's own triage already ruled it out as the cause. Left
for its own change.

---

## Verification

| | |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm test` | pass — 95 files, 1012 tests |
| `pnpm check` | pass |
| `pnpm build` | pass |
| `ImageUploadField.test.tsx` | **10/10, file unchanged** |

**No new tests.** A jsdom test cannot observe layout, and a test that asserted
`toHaveClass('grid-cols-1')` would restate the diff rather than verify it — it
would pass just as happily if the class did nothing. Where the only honest
verification is manual, it is listed below rather than faked. The one thing that
*was* mechanically verified is that `grid-cols-1` emits
`repeat(1, minmax(0, 1fr))`, checked in the built stylesheet.

## Acceptance criteria I could NOT verify

These need a human with a phone. None of them is covered by anything above.

**#61**
- [ ] No horizontal document scroll on new recipe, edit recipe, new baby and
      edit baby at a **390pt-wide viewport** — unverified.
- [ ] The same in **both `nl` and `en`** — unverified, and the more important
      half: the fix's whole claim is that the field's width no longer depends on
      the browser's locale, and that claim is untested.
- [ ] **On a phone**, since the trigger is mobile Safari's rendering of the
      control — unverified. Please also confirm the replacement label actually
      opens the picker in iOS Safari and that its focus ring is visible when
      tabbed to, since the input it belongs to is now `sr-only`.

**#83**
- [ ] Searching `Volkoren crackers` in **nl** shows every OFF row's meta in
      full at 390pt — unverified.
- [ ] The sheet body does not scroll horizontally **at any detent** — unverified.
- [ ] Your foods and Open Food Facts render at the **same width** — unverified.
- [ ] **Driven on a phone**, not only reasoned about — unverified.
- [ ] Which row actually forced the track — **not identified**; see above for
      why the fix does not depend on the answer.

**Also unverified generally:** every claim in this PR about which element
contributes what to a min-content width is reasoning from the CSS, not a
measurement. That reasoning picked the fix; it did not confirm the fix.

## A note on files

`Section` turned out to live inside `src/components/nutrition/AddSheet.tsx`
rather than in a file of its own, and another branch is working in that file
right now. The change there is deliberately kept to **one class on one line**
plus a comment, so it should merge cleanly, but it is worth a second look at
merge time.


---
_Generated by [Claude Code](https://claude.ai/code/session_019w4UGLSzcg43osPSZycApg)_