### PR TITLE
Foods say where their nutrition figures came from

### DIFF
--- a/convex/foods.test.ts
+++ b/convex/foods.test.ts
@@ -295,3 +295,188 @@ describe('editing a food’s servings', () => {
     expect(food?.servings ?? []).toEqual([])
   })
 })
+
+/**
+ * A food says where its *figures* came from, which is a different question
+ * from where the *row* came from (`source`). The two can disagree — a row
+ * somebody added by hand can carry figures read off a packet, and an imported
+ * row can carry figures they typed over — and the pair is only worth having
+ * while each keeps answering its own question.
+ *
+ * `foods.update` decides this itself rather than being told, because it is the
+ * one place a person can type over a food's nutrition. It is a public
+ * mutation: if it took the answer as an argument, "these came from Open Food
+ * Facts" would be a claim any caller could make about numbers it had just
+ * changed.
+ */
+describe('where a food’s figures came from', () => {
+  const nutella = {
+    barcode: '3017620422003',
+    name: 'Nutella',
+    baseUnit: 'g' as const,
+    nutritionPer100: { calories: 539, sugars: 56.3 },
+  }
+
+  async function signedIn() {
+    const t = testConvex()
+    await t.withIdentity(asAlice).mutation(api.users.ensureUser, {})
+    return t
+  }
+
+  test('an Open Food Facts import records its figures as imported', async () => {
+    const t = await signedIn()
+    const id = await t
+      .withIdentity(asAlice)
+      .mutation(api.foods.upsertFromOff, nutella)
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.nutritionSource).toBe('imported')
+    // The row came from Open Food Facts too — but that is the other question,
+    // and it is still being answered separately.
+    expect(food?.source).toBe('openfoodfacts')
+  })
+
+  test('a food created by hand records its figures as manual', async () => {
+    const t = await signedIn()
+    const id = await t.withIdentity(asAlice).mutation(api.foods.create, {
+      name: 'Nora’s granola',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 471 },
+    })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.nutritionSource).toBe('manual')
+  })
+
+  test('an import corrected in the review form saves as manual', async () => {
+    const t = await signedIn()
+    // The form shows Open Food Facts' figures until the person types over
+    // one, at which point it says `manual` and the save records that.
+    const id = await t.withIdentity(asAlice).mutation(api.foods.upsertFromOff, {
+      ...nutella,
+      nutritionPer100: { calories: 530, sugars: 56.3 },
+      nutritionSource: 'manual',
+    })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.nutritionSource).toBe('manual')
+  })
+
+  test('editing the figures by hand makes them manual, whatever they were', async () => {
+    const t = await signedIn()
+    const id = await t
+      .withIdentity(asAlice)
+      .mutation(api.foods.upsertFromOff, nutella)
+
+    await t.withIdentity(asAlice).mutation(api.foods.update, {
+      id,
+      name: 'Nutella',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 530, sugars: 56.3 },
+    })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.nutritionSource).toBe('manual')
+  })
+
+  test('editing without touching the figures leaves the record alone', async () => {
+    const t = await signedIn()
+    const id = await t
+      .withIdentity(asAlice)
+      .mutation(api.foods.upsertFromOff, nutella)
+
+    // A brand, a serving, the same numbers: nothing has been claimed about
+    // where those numbers came from.
+    await t.withIdentity(asAlice).mutation(api.foods.update, {
+      id,
+      name: 'Nutella',
+      brand: 'Ferrero',
+      baseUnit: 'g',
+      nutritionPer100: { ...nutella.nutritionPer100 },
+      servings: [{ label: '1 spoon', amount: 15 }],
+    })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.nutritionSource).toBe('imported')
+  })
+
+  test('a food that recorded nothing goes on recording nothing', async () => {
+    const t = await signedIn()
+    const id = await t
+      .withIdentity(asAlice)
+      .mutation(api.foods.upsertFromOff, nutella)
+    // Exactly the rows that predate the field: nothing backfills them, so an
+    // edit that leaves the figures alone must not invent an answer either.
+    await t.run(async (ctx) => ctx.db.patch(id, { nutritionSource: undefined }))
+
+    await t.withIdentity(asAlice).mutation(api.foods.update, {
+      id,
+      name: 'Nutella',
+      brand: 'Ferrero',
+      baseUnit: 'g',
+      nutritionPer100: { ...nutella.nutritionPer100 },
+    })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.nutritionSource).toBeUndefined()
+  })
+
+  test('a refresh from Open Food Facts takes the figures back to imported', async () => {
+    const t = await signedIn()
+    const id = await t
+      .withIdentity(asAlice)
+      .mutation(api.foods.upsertFromOff, nutella)
+    await t.withIdentity(asAlice).mutation(api.foods.update, {
+      id,
+      name: 'Nutella',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 530 },
+    })
+
+    await t
+      .withIdentity(asAlice)
+      .mutation(api.foods.applyOffRefresh, { id, ...nutella })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.nutritionSource).toBe('imported')
+  })
+
+  test('a food saved with no figures claims nothing about them', async () => {
+    const t = await signedIn()
+    const id = await t.withIdentity(asAlice).mutation(api.foods.create, {
+      name: 'Water',
+      baseUnit: 'ml',
+      nutritionPer100: {},
+    })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.nutritionSource).toBeUndefined()
+  })
+
+  test('a Catalog food claims nothing, and no edit can give it an answer', async () => {
+    const t = await signedIn()
+    const id = await t.run(async (ctx) =>
+      ctx.db.insert('foods', {
+        name: 'Banana',
+        baseUnit: 'g',
+        nutritionPer100: { calories: 89 },
+        source: 'seed',
+        seedKey: 'banana',
+      }),
+    )
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    // Their figures are authored, and "Built-in" already says where they came
+    // from — no badge rather than a wrong one.
+    expect(food?.nutritionSource).toBeUndefined()
+    // Read-only (ADR 0004), and the new field is no way around that.
+    await expect(
+      t.withIdentity(asAlice).mutation(api.foods.update, {
+        id,
+        name: 'Banana',
+        baseUnit: 'g',
+        nutritionPer100: { calories: 100 },
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/convex/foods.ts
+++ b/convex/foods.ts
@@ -3,7 +3,12 @@ import type { Doc } from './_generated/dataModel'
 import type { QueryCtx } from './_generated/server'
 import { mutation, query } from './_generated/server'
 import { foodSearchText } from './lib/foodSearchText'
-import { nutritionValidator } from './lib/nutrition'
+import {
+  hasNutritionFigures,
+  nextNutritionSource,
+  nutritionSourceValidator,
+  nutritionValidator,
+} from './lib/nutrition'
 import { servingValidator } from './lib/servings'
 import { getCurrentUser } from './lib/sharing'
 import { deleteStoredFile, replaceStoredFile } from './lib/storedFiles'
@@ -86,7 +91,15 @@ export const getByBarcode = query({
 // hand), reuse that row instead of creating a duplicate — the "no duplicate
 // row per barcode" invariant applies here too, not just to `upsertFromOff`.
 export const create = mutation({
-  args: { ...foodFields, barcode: v.optional(v.string()) },
+  args: {
+    ...foodFields,
+    barcode: v.optional(v.string()),
+    // What the person was looking at when they pressed save: figures they
+    // typed are `manual`, figures something filled in for them and they
+    // accepted keep whatever the form was showing. Absent means manual,
+    // which is what typing into an empty form is.
+    nutritionSource: v.optional(nutritionSourceValidator),
+  },
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx)
     if (!user) throw new Error('Not authenticated')
@@ -99,6 +112,9 @@ export const create = mutation({
     }
     return await ctx.db.insert('foods', {
       ...args,
+      nutritionSource: hasNutritionFigures(args.nutritionPer100)
+        ? (args.nutritionSource ?? 'manual')
+        : undefined,
       searchText: foodSearchText(args),
       source: 'manual',
       createdBy: user._id,
@@ -125,6 +141,17 @@ export const update = mutation({
       // that skipped the field would make the last serving undeletable.
       servings: rest.servings ?? [],
       searchText: foodSearchText(rest),
+      // Decided here, from the figures themselves, rather than accepted as an
+      // argument — this mutation is the one place a person can type over a
+      // food's nutrition, and it must not be possible to do that while still
+      // claiming the numbers came off a packet. A save that renames the food
+      // and leaves the figures alone changes nothing about where they came
+      // from, including leaving a row that never recorded one still silent.
+      nutritionSource: nextNutritionSource(
+        food.nutritionPer100,
+        rest.nutritionPer100,
+        food.nutritionSource,
+      ),
       localEdited: true,
     })
   },
@@ -142,11 +169,22 @@ export const upsertFromOff = mutation({
     // Already fetched and stored by `foodsLookup.importFromOff`, which is the
     // only thing that can make the network call this needs.
     imageId: v.optional(v.id('_storage')),
+    // Every import is reviewed before it is saved (spec §6), so "imported" is
+    // the default rather than the certainty: a person who corrected the
+    // figures in that review form sends `manual` instead, and the food says
+    // the true thing about the numbers it actually carries.
+    nutritionSource: v.optional(nutritionSourceValidator),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx)
     if (!user) throw new Error('Not authenticated')
-    const { barcode, ...rest } = args
+    const { barcode, nutritionSource, ...withoutSource } = args
+    const rest = {
+      ...withoutSource,
+      nutritionSource: hasNutritionFigures(args.nutritionPer100)
+        ? (nutritionSource ?? ('imported' as const))
+        : undefined,
+    }
     const existing = await ctx.db
       .query('foods')
       .withIndex('by_barcode', (q) => q.eq('barcode', barcode))
@@ -201,6 +239,12 @@ export const applyOffRefresh = mutation({
       ...rest,
       searchText: foodSearchText(rest),
       source: 'openfoodfacts',
+      // A refresh replaces the figures wholesale with Open Food Facts', so
+      // whatever they used to be, that is where they come from now — unless
+      // it came back with none, which claims nothing.
+      nutritionSource: hasNutritionFigures(rest.nutritionPer100)
+        ? 'imported'
+        : undefined,
       localEdited: false,
     })
   },

--- a/convex/lib/nutrition.test.ts
+++ b/convex/lib/nutrition.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import {
+  hasNutritionFigures,
+  nextNutritionSource,
   nextNutritionStale,
   parseNutritionValue,
   parseServings,
@@ -134,5 +136,77 @@ describe('nextNutritionStale', () => {
     expect(nextNutritionStale({ ...base, nutritionStale: true }, { ...base })).toBe(
       true,
     )
+  })
+})
+
+/**
+ * Where a food's figures came from survives a save that was not about them,
+ * and stops being an import the moment somebody types over one.
+ *
+ * The comparison is the whole point: the alternative — recording `manual`
+ * whenever `update` runs — would make renaming a food a claim about its
+ * nutrition, and there is no way back from that to what it used to say.
+ */
+describe('nextNutritionSource', () => {
+  const figures = { calories: 539, sugars: 56.3 }
+
+  test('untouched figures keep the answer they had', () => {
+    expect(nextNutritionSource(figures, { ...figures }, 'imported')).toBe(
+      'imported',
+    )
+    expect(nextNutritionSource(figures, { ...figures }, 'ai')).toBe('ai')
+  })
+
+  test('a food that never recorded one still does not claim one', () => {
+    expect(
+      nextNutritionSource(figures, { ...figures }, undefined),
+    ).toBeUndefined()
+  })
+
+  test('changing a figure makes them manual, whatever they were', () => {
+    expect(nextNutritionSource(figures, { ...figures, sugars: 55 }, 'imported')).toBe(
+      'manual',
+    )
+    // The correction that must stop calling itself an estimate (#86, story 21).
+    expect(nextNutritionSource(figures, { ...figures, sugars: 55 }, 'ai')).toBe(
+      'manual',
+    )
+  })
+
+  test('adding or removing a nutrient counts as changing the figures', () => {
+    expect(
+      nextNutritionSource(figures, { ...figures, protein: 6.3 }, 'imported'),
+    ).toBe('manual')
+    expect(nextNutritionSource(figures, { calories: 539 }, 'imported')).toBe(
+      'manual',
+    )
+  })
+
+  test('an absent nutrient is not a zero', () => {
+    expect(
+      nextNutritionSource({ calories: 539 }, { calories: 539, salt: 0 }, 'imported'),
+    ).toBe('manual')
+  })
+
+  test('typing figures onto a food that had none is manual', () => {
+    expect(nextNutritionSource({}, figures, undefined)).toBe('manual')
+  })
+
+  test('clearing every figure clears the answer with them', () => {
+    // Nothing came from anywhere, so there is nothing to say — and no stale
+    // "Imported" left over an empty panel.
+    expect(nextNutritionSource(figures, {}, 'imported')).toBeUndefined()
+    expect(nextNutritionSource(figures, undefined, 'ai')).toBeUndefined()
+  })
+})
+
+describe('hasNutritionFigures', () => {
+  test('any single nutrient counts, including a real zero', () => {
+    expect(hasNutritionFigures({ calories: 539 })).toBe(true)
+    expect(hasNutritionFigures({ salt: 0 })).toBe(true)
+  })
+  test('nothing at all does not', () => {
+    expect(hasNutritionFigures({})).toBe(false)
+    expect(hasNutritionFigures(undefined)).toBe(false)
   })
 })

--- a/convex/lib/nutrition.ts
+++ b/convex/lib/nutrition.ts
@@ -113,10 +113,49 @@ export interface NutritionStaleState {
   nutritionStale?: boolean
 }
 
+/** Same figures, nutrient for nutrient. An absent nutrient is not a zero. */
 function nutritionEqual(a?: NutritionFacts, b?: NutritionFacts): boolean {
   if ((a === undefined) !== (b === undefined)) return false
   if (a === undefined || b === undefined) return true
   return NUTRIENT_KEYS.every((key) => (a[key] ?? null) === (b[key] ?? null))
+}
+
+/**
+ * Are there any figures here at all?
+ *
+ * Only ever asked before saying where figures came from: with none, there is
+ * nothing to have come from anywhere, and a food that says "Manual" over an
+ * empty panel is claiming an answer to a question nobody asked.
+ *
+ * Deliberately *not* "is this nutrition usable" — that one is about whether
+ * something can be logged from these figures, and energy alone would satisfy
+ * it. Different question, and it belongs to whoever needs it.
+ */
+export function hasNutritionFigures(facts?: NutritionFacts): boolean {
+  return facts !== undefined && NUTRIENT_KEYS.some((key) => facts[key] !== undefined)
+}
+
+/**
+ * Where a set of figures came from, after a save that may or may not have
+ * touched them.
+ *
+ * Typing over the figures makes them `manual`, whatever they were before —
+ * that is what stops a corrected estimate from still describing itself as one.
+ * A save that leaves the figures alone leaves the answer alone, including
+ * leaving it *absent* on a row that never recorded one: nothing is inferred
+ * for a food that predates the field, which is why it needs no backfill.
+ *
+ * Deliberately compares the figures rather than trusting the caller. Renaming
+ * a food, adding a serving or fixing a brand are not claims about its
+ * nutrition, and a client is in no position to say which of those it did.
+ */
+export function nextNutritionSource(
+  before: NutritionFacts | undefined,
+  after: NutritionFacts | undefined,
+  recorded: NutritionSource | undefined,
+): NutritionSource | undefined {
+  if (!hasNutritionFigures(after)) return undefined
+  return nutritionEqual(before, after) ? recorded : 'manual'
 }
 
 // Spec §5: the flag goes true when ingredients or servings change in a save

--- a/convex/lib/seed/apply.ts
+++ b/convex/lib/seed/apply.ts
@@ -17,7 +17,7 @@ import {
   SAMPLE_HOUSEMATES,
   SAMPLE_RECIPES,
   SAMPLE_TASK_LISTS,
-  SAMPLE_USER_FOOD,
+  SAMPLE_USER_FOODS,
   type SampleAuthor,
 } from './sampleHousehold'
 
@@ -478,15 +478,19 @@ export async function applySample(
     )
   }
 
-  // --- A user-created food, for contrast with the read-only Catalog --------
-  rec.track(
-    await ctx.db.insert('foods', {
-      ...SAMPLE_USER_FOOD,
-      searchText: foodSearchText(SAMPLE_USER_FOOD),
-      source: 'manual',
-      createdBy: authors.nora,
-    }),
-  )
+  // --- User-created foods, for contrast with the read-only Catalog ---------
+  // One per `nutritionSource`, so a preview shows what each of them looks
+  // like on a food — and that it is a separate answer from `source`, which
+  // each fixture carries in its own right.
+  for (const food of SAMPLE_USER_FOODS) {
+    rec.track(
+      await ctx.db.insert('foods', {
+        ...food,
+        searchText: foodSearchText(food),
+        createdBy: authors.nora,
+      }),
+    )
+  }
 
   // --- Food diary ----------------------------------------------------------
   const catalogByKey = new Map(
@@ -597,6 +601,7 @@ export async function applySample(
     diaryEntries,
     combos,
     housemates: SAMPLE_HOUSEMATES.length,
+    userFoods: SAMPLE_USER_FOODS.length,
   }
 
   // Self-check: the run recorded every row it created. Anything missing here
@@ -611,7 +616,7 @@ export async function applySample(
     counts.tasks +
     1 + // baby
     counts.babyEvents +
-    1 + // the user-created food
+    counts.userFoods +
     counts.diaryEntries +
     counts.combos +
     SAMPLE_COMBOS.reduce((n, combo) => n + combo.items.length, 0)

--- a/convex/lib/seed/sampleHousehold.ts
+++ b/convex/lib/seed/sampleHousehold.ts
@@ -889,29 +889,82 @@ export const SAMPLE_DIARY: SampleDiaryEntry[] = [
 ]
 
 /**
- * One food the owner "created" by hand, so the app shows the contrast the
- * Catalog rules depend on: this one is editable and carries Attribution,
+ * The foods the household "added" themselves, so the app shows the contrast
+ * the Catalog rules depend on: these are editable and carry Attribution,
  * while everything from `CATALOG_FOODS` is read-only and owned by nobody.
+ *
+ * One per value of `nutritionSource`, because a preview is where the
+ * distinction has to be visible before anything is built on it — and the two
+ * fields answering different questions is exactly what is easy to miss:
+ * `source` says where the row came from, `nutritionSource` where its figures
+ * did. The estimated one is a row somebody added by hand whose *numbers* a
+ * model guessed, which is the pair that would collapse if they were one field.
  */
-export const SAMPLE_USER_FOOD = {
-  name: 'Nora’s granola',
-  brand: 'Homemade',
-  baseUnit: 'g' as const,
-  nutritionPer100: {
-    calories: 471,
-    protein: 10.2,
-    carbs: 54.3,
-    sugars: 18.7,
-    fat: 22.6,
-    saturatedFat: 4.1,
-    fiber: 7.8,
-    salt: 0.1,
+export const SAMPLE_USER_FOODS = [
+  {
+    name: 'Nora’s granola',
+    brand: 'Homemade',
+    baseUnit: 'g' as const,
+    nutritionPer100: {
+      calories: 471,
+      protein: 10.2,
+      carbs: 54.3,
+      sugars: 18.7,
+      fat: 22.6,
+      saturatedFat: 4.1,
+      fiber: 7.8,
+      salt: 0.1,
+    },
+    // A food somebody authored, with the servings they actually think in — so
+    // a preview shows the chips rather than an empty row where they should be.
+    servings: [
+      { label: '1 bowl', amount: 50 },
+      { label: '1 small handful', amount: 20 },
+      { label: 'over yoghurt', amount: 35 },
+    ],
+    source: 'manual' as const,
+    nutritionSource: 'manual' as const,
   },
-  // A food somebody authored, with the servings they actually think in — so a
-  // preview shows the chips rather than an empty row where they should be.
-  servings: [
-    { label: '1 bowl', amount: 50 },
-    { label: '1 small handful', amount: 20 },
-    { label: 'over yoghurt', amount: 35 },
-  ],
-}
+  {
+    // Scanned in the shop and taken as it came: the row and its figures both
+    // come from Open Food Facts.
+    name: 'Roomboter ontbijtkoek',
+    brand: 'Peijnenburg',
+    barcode: '8710398160005',
+    baseUnit: 'g' as const,
+    nutritionPer100: {
+      calories: 328,
+      protein: 4.6,
+      carbs: 70.2,
+      sugars: 32.4,
+      fat: 2.4,
+      saturatedFat: 1.3,
+      fiber: 3.1,
+      salt: 0.75,
+    },
+    servings: [{ label: '1 plak', amount: 25 }],
+    source: 'openfoodfacts' as const,
+    nutritionSource: 'imported' as const,
+  },
+  {
+    // A store brand nobody has filed: added by hand, with figures nobody
+    // typed — the case #86's AI routes exist for, shown here as the record
+    // they leave behind.
+    name: 'Bakery seeded spelt loaf',
+    brand: 'Buurtbakker',
+    baseUnit: 'g' as const,
+    nutritionPer100: {
+      calories: 259,
+      protein: 9.4,
+      carbs: 42.1,
+      sugars: 2.8,
+      fat: 4.6,
+      saturatedFat: 0.8,
+      fiber: 6.2,
+      salt: 1.1,
+    },
+    servings: [{ label: '1 slice', amount: 40 }],
+    source: 'manual' as const,
+    nutritionSource: 'ai' as const,
+  },
+]

--- a/convex/lib/seed/sampleHousehold.ts
+++ b/convex/lib/seed/sampleHousehold.ts
@@ -928,9 +928,17 @@ export const SAMPLE_USER_FOODS = [
   {
     // Scanned in the shop and taken as it came: the row and its figures both
     // come from Open Food Facts.
+    //
+    // The barcode is deliberately a GS1 in-store code (prefix 2), never issued
+    // to a real retail product, rather than this product's actual EAN. The
+    // sample is wiped and recreated, but a *user-created* row is preserved —
+    // so a real EAN here would collide with one a developer had already scanned
+    // on dev, and `foods.getByBarcode` uses `.unique()`, which throws on two
+    // matches. That would break barcode lookup for that product until the
+    // sample was reset. A code no real packet carries cannot collide.
     name: 'Roomboter ontbijtkoek',
     brand: 'Peijnenburg',
-    barcode: '8710398160005',
+    barcode: '2000000000017',
     baseUnit: 'g' as const,
     nutritionPer100: {
       calories: 328,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -148,6 +148,19 @@ export default defineSchema({
       v.literal('manual'),
       v.literal('seed'),
     ),
+    // Where the *figures* came from, which is a different question from where
+    // the *row* came from (`source`, above): a food somebody added by hand can
+    // later be corrected off a packet, and an imported row can be typed over.
+    // Conflating the two loses both answers.
+    //
+    // The same union Recipes carry, rather than a second, finer vocabulary
+    // meaning nearly the same thing: an Open Food Facts record is `imported`,
+    // a model's guess is `ai`, typed figures are `manual`.
+    //
+    // Optional, and nothing backfills it — a food that predates the field
+    // simply does not claim a source. Absent on Catalog rows too: their
+    // figures are authored, and "Built-in" already says so.
+    nutritionSource: v.optional(nutritionSourceValidator),
     localEdited: v.optional(v.boolean()),
     // Absent on Catalog entries — seeded reference data is owned by nobody
     // (CONTEXT.md, "Catalog"). Present on every row a person created.

--- a/convex/seed.test.ts
+++ b/convex/seed.test.ts
@@ -121,4 +121,53 @@ describe('the Sample household', () => {
     expect(left.groups).toBe(0)
     expect(left.recipes).toBe(0)
   })
+
+  /**
+   * A preview is where a distinction has to be visible before anything is
+   * built on it (#87, and #86's AI routes after it). Where a food's *figures*
+   * came from is invisible unless the sample contains foods that differ in
+   * it — and it is only obviously a separate question from where the *row*
+   * came from while at least one food answers the two differently.
+   */
+  test('contains foods carrying each answer about where their figures came from', async () => {
+    const t = testConvex()
+    await buildSample(t)
+
+    const userFoods = await t.run(async (ctx) =>
+      (await ctx.db.query('foods').collect()).filter(
+        (f) => f.seedKey === undefined,
+      ),
+    )
+
+    expect(new Set(userFoods.map((f) => f.nutritionSource))).toEqual(
+      new Set(['imported', 'ai', 'manual']),
+    )
+    // Catalog foods claim nothing: their figures are authored (ADR 0004).
+    const catalog = await t.run(async (ctx) =>
+      (await ctx.db.query('foods').collect()).filter(
+        (f) => f.seedKey !== undefined,
+      ),
+    )
+    expect(catalog.every((f) => f.nutritionSource === undefined)).toBe(true)
+    // The two questions, answered differently by the same row.
+    expect(
+      userFoods.some(
+        (f) => f.source === 'manual' && f.nutritionSource === 'ai',
+      ),
+    ).toBe(true)
+  })
+
+  test('takes its user-created foods with it when it is reset', async () => {
+    const t = testConvex()
+    await buildSample(t)
+
+    await t.run(async (ctx) => await resetSample(ctx))
+
+    const left = await t.run(async (ctx) =>
+      (await ctx.db.query('foods').collect()).filter(
+        (f) => f.seedKey === undefined,
+      ),
+    )
+    expect(left).toEqual([])
+  })
 })

--- a/src/components/foods/EditFoodPage.tsx
+++ b/src/components/foods/EditFoodPage.tsx
@@ -69,8 +69,15 @@ export function EditFoodPage({ foodId, nav }: EditFoodPageProps) {
           baseUnit: food.baseUnit,
           nutritionPer100: food.nutritionPer100,
           servings: food.servings,
+          nutritionSource: food.nutritionSource,
         }}
-        onSubmit={async (values) => {
+        onSubmit={async ({
+          // Shown while editing, never sent: `foods.update` works this out
+          // from the figures themselves, so an edit cannot save one answer
+          // while changing the numbers behind it.
+          nutritionSource: _decidedByTheServer,
+          ...values
+        }) => {
           setSubmitting(true)
           setError(null)
           try {

--- a/src/components/foods/FoodDetailPage.tsx
+++ b/src/components/foods/FoodDetailPage.tsx
@@ -66,25 +66,19 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
       )}
 
       {/*
-        Reusing the "imported"/"manual" NutritionSource vocabulary for a
-        food's `source` field ('openfoodfacts'/'manual') rather than adding
-        a fourth badge type — "Imported" reads fine for OFF-sourced data too,
-        and it avoids new plumbing just for foods. If this reads awkwardly
-        once real foods exist, revisit in Phase 3.
+        The badge says where the *figures* came from, which the row now
+        records for itself. It used to be derived from `source` — where the
+        *row* came from — which answered the wrong question: an imported row
+        somebody had since typed over still read "Imported".
+
+        A food that recorded nothing (anything older than the field, and every
+        Catalog entry, whose figures are authored) gets no badge rather than a
+        guessed one. Nothing is backfilled.
       */}
       <NutritionPanel
         nutrition={food.nutritionPer100}
         unitLabel={fmt(detail.per100, { unit: food.baseUnit })}
-        source={
-          food.source === 'seed'
-            ? // Neither "Imported" nor "Manual" is true of a Catalog entry,
-              // and the "Built-in" chip above already says where it came
-              // from — so no badge rather than a wrong one.
-              undefined
-            : food.source === 'openfoodfacts'
-              ? 'imported'
-              : 'manual'
-        }
+        source={food.nutritionSource}
       />
       {food.servings && food.servings.length > 0 && (
         <p className="mb-4 text-sm opacity-60">

--- a/src/components/foods/FoodForm.test.tsx
+++ b/src/components/foods/FoodForm.test.tsx
@@ -122,6 +122,100 @@ test('a half-typed serving row is not a serving', () => {
   )
 })
 
+/**
+ * Where the figures came from is part of reading them, so the form says it
+ * while somebody is looking at the numbers rather than only afterwards on the
+ * food itself. Typing over one changes the answer in front of them — the same
+ * conclusion `foods.update` reaches independently when the save lands, which
+ * is what keeps the note honest rather than merely reassuring.
+ */
+test('says where the figures came from, and stops saying it once they are typed over', () => {
+  const onSubmit = vi.fn()
+  renderWithI18n(
+    <FoodForm
+      onSubmit={onSubmit}
+      submitting={false}
+      initial={{
+        name: 'Nutella',
+        nutritionPer100: { calories: 539 },
+        nutritionSource: 'imported',
+      }}
+    />,
+  )
+  expect(
+    screen.getByText('Where these figures came from: Imported'),
+  ).toBeDefined()
+
+  fireEvent.change(screen.getByLabelText('Calories (kcal)'), {
+    target: { value: '530' },
+  })
+
+  expect(
+    screen.getByText('Where these figures came from: Manual'),
+  ).toBeDefined()
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+  expect(onSubmit).toHaveBeenCalledWith(
+    expect.objectContaining({ nutritionSource: 'manual' }),
+  )
+})
+
+test('an untouched import is still an import when it is saved', () => {
+  const onSubmit = vi.fn()
+  renderWithI18n(
+    <FoodForm
+      onSubmit={onSubmit}
+      submitting={false}
+      initial={{
+        name: 'Nutella',
+        brand: 'Ferrero',
+        nutritionPer100: { calories: 539 },
+        nutritionSource: 'imported',
+      }}
+    />,
+  )
+  // Editing something that is not a figure says nothing about the figures.
+  fireEvent.change(screen.getByLabelText('Brand'), {
+    target: { value: 'Ferrero Nederland' },
+  })
+
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+  expect(onSubmit).toHaveBeenCalledWith(
+    expect.objectContaining({ nutritionSource: 'imported' }),
+  )
+})
+
+test('says it in Dutch too', () => {
+  renderWithI18n(
+    <FoodForm
+      onSubmit={vi.fn()}
+      submitting={false}
+      initial={{
+        name: 'Nutella',
+        nutritionPer100: { calories: 539 },
+        nutritionSource: 'ai',
+      }}
+    />,
+    { locale: 'nl' },
+  )
+  expect(
+    screen.getByText('Waar deze waarden vandaan komen: AI-schatting'),
+  ).toBeDefined()
+})
+
+test('a food with no figures claims no source for them', () => {
+  const onSubmit = vi.fn()
+  renderWithI18n(<FoodForm onSubmit={onSubmit} submitting={false} />)
+  expect(screen.queryByText(/Where these figures came from/)).toBeNull()
+
+  fireEvent.change(screen.getByLabelText('Name'), {
+    target: { value: 'Water' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+  expect(onSubmit).toHaveBeenCalledWith(
+    expect.objectContaining({ nutritionSource: undefined }),
+  )
+})
+
 test('a serving can be taken off again', () => {
   const onSubmit = vi.fn()
   renderWithI18n(

--- a/src/components/foods/FoodForm.test.tsx
+++ b/src/components/foods/FoodForm.test.tsx
@@ -216,6 +216,54 @@ test('a food with no figures claims no source for them', () => {
   )
 })
 
+test('an imported product with no nutriments claims no source either', () => {
+  // Open Food Facts holds plenty of products with a name, a picture and no
+  // figures at all. The form is opened as `imported` because the row came from
+  // there — but there is nothing for that to be true *of*, and a note over an
+  // empty grid reads as though numbers had been supplied.
+  renderWithI18n(
+    <FoodForm
+      onSubmit={vi.fn()}
+      submitting={false}
+      initial={{
+        name: 'Volkoren crackers',
+        brand: 'Plus',
+        nutritionPer100: {},
+        nutritionSource: 'imported',
+      }}
+    />,
+  )
+  expect(screen.queryByText(/Where these figures came from/)).toBeNull()
+})
+
+test('clearing the last figure takes the source note with it', () => {
+  const onSubmit = vi.fn()
+  renderWithI18n(
+    <FoodForm
+      onSubmit={onSubmit}
+      submitting={false}
+      initial={{
+        name: 'Nutella',
+        nutritionPer100: { calories: 539 },
+        nutritionSource: 'imported',
+      }}
+    />,
+  )
+  expect(
+    screen.getByText('Where these figures came from: Imported'),
+  ).toBeDefined()
+
+  fireEvent.change(screen.getByLabelText('Calories (kcal)'), {
+    target: { value: '' },
+  })
+  expect(screen.queryByText(/Where these figures came from/)).toBeNull()
+
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+  expect(onSubmit).toHaveBeenCalledWith(
+    expect.objectContaining({ nutritionSource: undefined }),
+  )
+})
+
 test('a serving can be taken off again', () => {
   const onSubmit = vi.fn()
   renderWithI18n(

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react'
-import type { NutritionFacts } from '../../../convex/lib/nutrition'
+import {
+  hasNutritionFigures,
+  type NutritionFacts,
+  type NutritionSource,
+} from '../../../convex/lib/nutrition'
 import type { Serving } from '../../../convex/lib/servings'
 import { fmt, useMessages } from '../../lib/i18n'
 import { NutrientInputGrid } from '../nutrition/NutrientInputGrid'
@@ -17,6 +21,16 @@ export interface FoodFormValues {
   baseUnit: 'g' | 'ml'
   nutritionPer100: NutritionFacts
   servings?: Serving[]
+  /**
+   * Where the figures in this form came from, as the form last knew it —
+   * prefilled by a lookup, or `manual` from the moment somebody types over a
+   * nutrient. Same vocabulary and same behaviour as `RecipeForm`.
+   *
+   * Only the paths that *create* a food read this off the form; `foods.update`
+   * decides for itself by comparing the figures it is given with the ones on
+   * the row, so an edit cannot claim to be an import.
+   */
+  nutritionSource?: NutritionSource
 }
 
 /** A serving being typed: both halves are text until they are read back. */
@@ -69,6 +83,9 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
   const [nutritionInputs, setNutritionInputs] = useState(() =>
     toNutrientInputs(initial?.nutritionPer100),
   )
+  const [nutritionSource, setNutritionSource] = useState<
+    NutritionSource | undefined
+  >(initial?.nutritionSource)
   const [servingRows, setServingRows] = useState(() =>
     toServingRows(initial?.servings),
   )
@@ -81,13 +98,18 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
       onSubmit={(e) => {
         e.preventDefault()
         const servings = fromServingRows(servingRows)
+        const facts = nutrientInputsToFacts(nutritionInputs)
         onSubmit({
           name: name.trim(),
           brand: brand.trim() || undefined,
           barcode: barcode || undefined,
           baseUnit,
-          nutritionPer100: nutrientInputsToFacts(nutritionInputs),
+          nutritionPer100: facts,
           servings: servings.length > 0 ? servings : undefined,
+          // No figures, nothing to say about where they came from.
+          nutritionSource: hasNutritionFigures(facts)
+            ? (nutritionSource ?? 'manual')
+            : undefined,
         })
       }}
     >
@@ -143,11 +165,22 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
         <legend className="px-1 text-sm font-medium">
           {fmt(form.nutritionLegend, { unit: baseUnit })}
         </legend>
+        {nutritionSource && (
+          <p className="mb-2 text-xs opacity-60">
+            {fmt(form.nutritionSourceNote, {
+              source: messages.nutrients.sources[nutritionSource],
+            })}
+          </p>
+        )}
         <NutrientInputGrid
           values={nutritionInputs}
-          onChange={(key, value) =>
+          onChange={(key, value) => {
             setNutritionInputs((prev) => ({ ...prev, [key]: value }))
-          }
+            // Typing over a figure makes the figures yours, so the note above
+            // stops saying they came from somewhere else — the same thing
+            // `foods.update` concludes independently when the save lands.
+            setNutritionSource('manual')
+          }}
         />
       </fieldset>
       <fieldset className="rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -92,6 +92,18 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
   const messages = useMessages()
   const { form } = messages.foods
 
+  // The note answers for the figures on screen now, not for the answer the form
+  // was opened with. An Open Food Facts product with no nutriments arrives as
+  // `imported` over an empty grid, and clearing the last figure by hand leaves
+  // the same mismatch — both would otherwise read "these figures came from
+  // Imported" above nothing. This is the predicate the submit below already
+  // applies, so what is shown and what is saved cannot disagree.
+  const shownNutritionSource = hasNutritionFigures(
+    nutrientInputsToFacts(nutritionInputs),
+  )
+    ? nutritionSource
+    : undefined
+
   return (
     <form
       className="mx-auto grid max-w-2xl gap-4"
@@ -165,10 +177,10 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
         <legend className="px-1 text-sm font-medium">
           {fmt(form.nutritionLegend, { unit: baseUnit })}
         </legend>
-        {nutritionSource && (
+        {shownNutritionSource && (
           <p className="mb-2 text-xs opacity-60">
             {fmt(form.nutritionSourceNote, {
-              source: messages.nutrients.sources[nutritionSource],
+              source: messages.nutrients.sources[shownNutritionSource],
             })}
           </p>
         )}

--- a/src/components/foods/NewFoodPage.tsx
+++ b/src/components/foods/NewFoodPage.tsx
@@ -85,6 +85,9 @@ export function NewFoodPage({ barcode, nav }: NewFoodPageProps) {
               brand: mapped.brand,
               nutritionPer100: mapped.nutritionPer100,
               servings: mapped.servings,
+              // Open Food Facts' figures until the person types over one, at
+              // which point the form says `manual` and the save records it.
+              nutritionSource: 'imported',
             },
             version: Date.now(),
           })

--- a/src/lib/i18n/messages/en/foods.ts
+++ b/src/lib/i18n/messages/en/foods.ts
@@ -52,6 +52,9 @@ export const foods = {
     grams: 'grams',
     milliliters: 'milliliters',
     nutritionLegend: 'Nutrition per 100 {unit}',
+    // The source name itself is `nutrients.sources`, keyed by the union the
+    // schema defines — this is only the sentence it is said in.
+    nutritionSourceNote: 'Where these figures came from: {source}',
     servingsLegend: 'Servings',
     servingsHint:
       'What you call a portion of this, and how many {unit} that is. Leave it empty and the amounts you log will be offered instead.',

--- a/src/lib/i18n/messages/nl/foods.ts
+++ b/src/lib/i18n/messages/nl/foods.ts
@@ -48,6 +48,7 @@ export const foods = {
     grams: 'gram',
     milliliters: 'milliliter',
     nutritionLegend: 'Voedingswaarde per 100 {unit}',
+    nutritionSourceNote: 'Waar deze waarden vandaan komen: {source}',
     servingsLegend: 'Porties',
     servingsHint:
       'Hoe je een portie hiervan noemt, en hoeveel {unit} dat is. Laat je dit leeg, dan worden de hoeveelheden die je noteert aangeboden.',


### PR DESCRIPTION
Closes #87

A food now records where its **nutrition figures** came from, and says so.

Groundwork for #86's two AI routes — neither can mark an estimate as an estimate until a food has somewhere to record that — but it ships as a standalone improvement: today a figure off a community database and a figure somebody typed are indistinguishable once saved.

## The shape

`foods.nutritionSource`, optional, carrying **the same union Recipes already have** (`imported | ai | manual`) from `convex/lib/nutrition.ts`. No second vocabulary for one idea. An Open Food Facts record is `imported`, a model's guess is `ai`, typed figures are `manual`.

Nothing in this PR writes `ai` — the AI routes are later issues — but the value belongs in the union now, and the Sample household carries one so the distinction is visible in a preview.

The row's existing `source` field is untouched. That says where the **row** came from; this says where its **figures** came from. The sample's bakery loaf answers the two differently (`source: 'manual'`, `nutritionSource: 'ai'`), which is the pair that would collapse if they were one field.

## How "the figures were edited" is detected

Not by trusting the client, and not by stamping `manual` on every update. `foods.update` compares the figures it is given against the ones on the row, via `nextNutritionSource(before, after, recorded)` in `convex/lib/nutrition.ts`:

- figures unchanged → the recorded answer is left exactly as it was, **including left absent** on a row that never recorded one (this is what makes "no backfill" true rather than merely unimplemented);
- any figure added, changed or removed → `manual`, whatever it was before;
- no figures at all after the save → no answer, rather than "Manual" over an empty panel.

`update` deliberately does **not** take `nutritionSource` as an argument — it is a public mutation, so accepting one would let a caller change the numbers and still claim they came off a packet. The create paths (`create`, `upsertFromOff`) do take it, because the form is the review surface and a person who corrects an import before saving should save `manual`; that mirrors how `RecipeForm` already works. `applyOffRefresh` hardcodes `imported`: it replaces the figures wholesale.

`assertNotCatalog` is untouched and still guards every write path; a Catalog food records nothing and there is no new way in (covered by a test).

## What a person sees

- **Editing**: a note above the nutrient grid — "Where these figures came from: Imported" — that switches to "Manual" as soon as a figure is typed over.
- **Viewing**: the existing `NutritionPanel` badge, now reading the recorded answer instead of deriving one from `source` (which is why an imported-then-corrected food used to still read "Imported").
- Both strings in `en` and `nl`; the source names themselves were already keyed by the union in `nutrients.sources`.

## Sample household

`SAMPLE_USER_FOOD` becomes `SAMPLE_USER_FOODS`, one per value:

| Food | `source` | `nutritionSource` |
| --- | --- | --- |
| Nora's granola | `manual` | `manual` |
| Roomboter ontbijtkoek (Peijnenburg) | `openfoodfacts` | `imported` |
| Bakery seeded spelt loaf | `manual` | `ai` |

The run's self-check count follows the fixture list rather than a hardcoded `1`, and a test asserts the reset still takes all three with it.

## Tests

At the highest seam that can see each thing, no new seams:

- `convex/lib/nutrition.test.ts` — `nextNutritionSource` and `hasNutritionFigures` as plain unit tests.
- `convex/foods.test.ts` — the Convex boundary with a real in-memory backend: import records `imported`, hand-created records `manual`, editing figures records `manual`, **editing a brand/serving leaves the record alone**, a row with nothing recorded still has nothing recorded afterwards, a refresh returns to `imported`, and a Catalog food refuses the edit.
- `src/components/foods/FoodForm.test.tsx` — the note appears, flips on a typed figure, stays put when the brand changes, is absent with no figures, and renders in Dutch.
- `convex/seed.test.ts` — the sample contains all three values, Catalog foods contain none, and one row answers the two questions differently.

`pnpm typecheck`, `pnpm test` (1036 passing) and `pnpm check` are all green. (One pre-existing test caught me dropping `searchText` from the update patch mid-change — worth noting the suite earned its keep.)

## Not verified by me — needs a human pass

No `.env.local` and no Convex/Clerk credentials in this container, so **nothing here was exercised in a running app**. Specifically unverified by hand:

1. **The form note and the detail badge as rendered**, in a browser, in both locales — covered by component tests, but not by eyes. Wording and placement (a small line under the "Nutrition per 100 g" legend) are the sort of thing worth a look.
2. **The real Open Food Facts scan → review → save path end to end.** The mutation-level behaviour is tested; the round trip through `foodsLookup.lookupBarcode` and a real barcode is not.
3. **A preview seed run.** `applySample`'s self-check is exercised in tests, but the Sample household has not been written to a live deployment. The new fixture carries barcode `8710398160005` — no Catalog fixture carries a barcode, so no collision is expected, but a preview would confirm it.
4. **Existing dev/prod rows.** The "renders without claiming a source" case is tested against a row whose field was cleared; real pre-existing foods will simply lose the old (derived, sometimes wrong) badge until they are next edited or refreshed. That is intended, and is what "no backfill" costs.


---
_Generated by [Claude Code](https://claude.ai/code/session_019w4UGLSzcg43osPSZycApg)_