### PR TITLE
feat(nutrition): the add sheet opens on what you usually have at this meal

### DIFF
--- a/convex/consumption.test.ts
+++ b/convex/consumption.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { testConvex } from '../test/convexHarness'
 import { api } from './_generated/api'
+import type { Id } from './_generated/dataModel'
 
 /**
  * Provenance under Group ownership (ADR-0003), through the real diary
@@ -477,5 +478,197 @@ describe('the amounts you have logged for a food', () => {
     expect(
       await t.query(api.consumption.loggedAmountsForFood, { foodId }),
     ).toEqual([])
+  })
+})
+
+/**
+ * The first screen of the add sheet (#76).
+ *
+ * It used to show every recipe you owned and none of your foods. It shows what
+ * you usually have at *this* meal now — read off your own diary, ranked by how
+ * often, bounded at both ends — and everything else is behind the search box.
+ */
+describe('what the add sheet opens on', () => {
+  /** Long enough before `DAY` to be outside the 60-day window. */
+  const LAST_WINTER = '2026-01-04'
+
+  async function withHabits() {
+    const t = testConvex()
+    await t.withIdentity(asAlice).mutation(api.users.ensureUser, {})
+    await t.withIdentity(asBob).mutation(api.users.ensureUser, {})
+
+    const ids = await t.run(async (ctx) => {
+      const alice = (await ctx.db
+        .query('users')
+        .withIndex('by_clerkId', (q) => q.eq('clerkId', asAlice.subject))
+        .unique()) as { _id: Id<'users'> }
+      const household = await ctx.db.insert('groups', {
+        name: 'Household',
+        inviteCode: 'household-code',
+        slug: 'household',
+        isPersonal: false,
+      })
+      const membership = await ctx.db.insert('memberships', {
+        groupId: household,
+        userId: alice._id,
+        role: 'admin',
+      })
+      const recipe = (title: string) =>
+        ctx.db.insert('recipes', {
+          groupId: household,
+          sharedGroupIds: [],
+          createdByUserId: alice._id,
+          title,
+          ingredients: [],
+          steps: [],
+          tags: [],
+          servings: 2,
+          nutrition: RECIPE_PER_SERVING,
+        })
+      const food = (name: string) =>
+        ctx.db.insert('foods', {
+          name,
+          searchText: name.toLowerCase(),
+          baseUnit: 'g' as const,
+          nutritionPer100: { calories: 100 },
+          source: 'manual' as const,
+        })
+      return {
+        alice: alice._id,
+        membership,
+        oats: await food('Porridge oats'),
+        crisps: await food('Crisps'),
+        pancakes: await food('Pancake mix'),
+        overnightOats: await recipe('Overnight oats'),
+        neverLogged: await recipe('Sunday roast'),
+      }
+    })
+
+    /** A day's worth of the diary, written straight in so dates are chosen. */
+    const logged = async (
+      rows: Array<{
+        date: string
+        meal: 'breakfast' | 'lunch' | 'dinner' | 'snack'
+        foodId?: Id<'foods'>
+        recipeId?: Id<'recipes'>
+        userId?: Id<'users'>
+      }>,
+    ) => {
+      await t.run(async (ctx) => {
+        for (const row of rows) {
+          await ctx.db.insert('consumptionEntries', {
+            userId: row.userId ?? ids.alice,
+            date: row.date,
+            meal: row.meal,
+            foodId: row.foodId,
+            recipeId: row.recipeId,
+            label: 'Something',
+            quantity: 1,
+            quantityUnit: row.foodId ? 'g' : 'serving',
+            nutrition: SNAPSHOT,
+          })
+        }
+      })
+    }
+
+    return { t, ids, logged }
+  }
+
+  const opened = (t: Seeded['t'], meal: 'breakfast' | 'dinner' = 'breakfast') =>
+    t
+      .withIdentity(asAlice)
+      .query(api.consumption.suggestionsForMeal, { date: DAY, meal })
+
+  test('the food you have most often at this meal is first', async () => {
+    const { t, ids, logged } = await withHabits()
+    await logged([
+      { date: '2026-07-28', meal: 'breakfast', foodId: ids.oats },
+      { date: '2026-07-29', meal: 'breakfast', foodId: ids.oats },
+      { date: '2026-07-29', meal: 'snack', foodId: ids.crisps },
+      { date: '2026-07-30', meal: 'breakfast', foodId: ids.pancakes },
+    ])
+
+    const { foods } = await opened(t)
+    expect(foods.map((food) => food.name)).toEqual([
+      'Porridge oats',
+      'Pancake mix',
+    ])
+  })
+
+  test('another meal’s habits are another meal’s', async () => {
+    const { t, ids, logged } = await withHabits()
+    await logged([
+      { date: '2026-07-29', meal: 'breakfast', foodId: ids.oats },
+      { date: '2026-07-29', meal: 'dinner', foodId: ids.crisps },
+    ])
+
+    expect((await opened(t, 'dinner')).foods.map((f) => f.name)).toEqual([
+      'Crisps',
+    ])
+  })
+
+  test('a habit older than the window has stopped being the first guess', async () => {
+    const { t, ids, logged } = await withHabits()
+    await logged([
+      { date: LAST_WINTER, meal: 'breakfast', foodId: ids.pancakes },
+      { date: LAST_WINTER, meal: 'breakfast', foodId: ids.pancakes },
+      { date: '2026-07-29', meal: 'breakfast', foodId: ids.oats },
+    ])
+
+    expect((await opened(t)).foods.map((f) => f.name)).toEqual([
+      'Porridge oats',
+    ])
+  })
+
+  test('a recipe you have never logged is behind the search box', async () => {
+    const { t, ids, logged } = await withHabits()
+    await logged([
+      { date: '2026-07-29', meal: 'breakfast', recipeId: ids.overnightOats },
+    ])
+
+    const { recipes } = await opened(t)
+    expect(recipes.map((recipe) => recipe.title)).toEqual(['Overnight oats'])
+  })
+
+  test('a recipe you can no longer see is not offered back by your own history', async () => {
+    const { t, ids, logged } = await withHabits()
+    await logged([
+      { date: '2026-07-29', meal: 'breakfast', recipeId: ids.overnightOats },
+    ])
+    await t.run(async (ctx) => {
+      await ctx.db.delete(ids.membership)
+    })
+
+    expect((await opened(t)).recipes).toEqual([])
+  })
+
+  test('are yours alone — somebody else’s habits are not consulted', async () => {
+    const { t, ids, logged } = await withHabits()
+    await logged([
+      { date: '2026-07-29', meal: 'breakfast', foodId: ids.oats },
+    ])
+
+    expect(
+      await t
+        .withIdentity(asBob)
+        .query(api.consumption.suggestionsForMeal, {
+          date: DAY,
+          meal: 'breakfast',
+        }),
+    ).toEqual({ foods: [], recipes: [] })
+  })
+
+  test('are nothing at all without a session', async () => {
+    const { t, ids, logged } = await withHabits()
+    await logged([
+      { date: '2026-07-29', meal: 'breakfast', foodId: ids.oats },
+    ])
+
+    expect(
+      await t.query(api.consumption.suggestionsForMeal, {
+        date: DAY,
+        meal: 'breakfast',
+      }),
+    ).toEqual({ foods: [], recipes: [] })
   })
 })

--- a/convex/consumption.test.ts
+++ b/convex/consumption.test.ts
@@ -671,4 +671,161 @@ describe('what the add sheet opens on', () => {
       }),
     ).toEqual({ foods: [], recipes: [] })
   })
+
+  /**
+   * A row that cannot be offered must not cost a slot.
+   *
+   * Ranking is one thing and being loggable is another: a recipe that has been
+   * deleted, or lost its nutrition, or moved out of a Group you are in, is
+   * discovered only once the document is read. Cap the ranking first and those
+   * discoveries come out of the eight — the sheet shows six, and the
+   * ninth-ranked recipe, which is perfectly good, is never even fetched.
+   */
+  describe('a row that cannot be logged does not eat a slot', () => {
+    /** Ten dinner recipes and nine dinner foods, strictly ordered by habit. */
+    async function withTenHabits() {
+      const t = testConvex()
+      await t.withIdentity(asAlice).mutation(api.users.ensureUser, {})
+
+      const built = await t.run(async (ctx) => {
+        const alice = (await ctx.db
+          .query('users')
+          .withIndex('by_clerkId', (q) => q.eq('clerkId', asAlice.subject))
+          .unique()) as { _id: Id<'users'> }
+        const household = await ctx.db.insert('groups', {
+          name: 'Household',
+          inviteCode: 'household-code',
+          slug: 'household',
+          isPersonal: false,
+        })
+        await ctx.db.insert('memberships', {
+          groupId: household,
+          userId: alice._id,
+          role: 'admin',
+        })
+
+        const log = async (
+          ref: { foodId?: Id<'foods'>; recipeId?: Id<'recipes'> },
+          times: number,
+        ) => {
+          for (let n = 0; n < times; n += 1) {
+            await ctx.db.insert('consumptionEntries', {
+              userId: alice._id,
+              date: '2026-07-20',
+              meal: 'dinner',
+              ...ref,
+              label: 'Something',
+              quantity: 1,
+              quantityUnit: ref.foodId ? 'g' : 'serving',
+              nutrition: SNAPSHOT,
+            })
+          }
+        }
+
+        const recipes: Id<'recipes'>[] = []
+        for (let rank = 0; rank < 10; rank += 1) {
+          const id = await ctx.db.insert('recipes', {
+            groupId: household,
+            sharedGroupIds: [],
+            createdByUserId: alice._id,
+            title: `Dinner ${rank}`,
+            ingredients: [],
+            steps: [],
+            tags: [],
+            servings: 2,
+            nutrition: RECIPE_PER_SERVING,
+          })
+          recipes.push(id)
+          await log({ recipeId: id }, 10 - rank)
+        }
+
+        const foods: Id<'foods'>[] = []
+        for (let rank = 0; rank < 9; rank += 1) {
+          const id = await ctx.db.insert('foods', {
+            name: `Food ${rank}`,
+            searchText: `food ${rank}`,
+            baseUnit: 'g' as const,
+            nutritionPer100: { calories: 100 },
+            source: 'manual' as const,
+          })
+          foods.push(id)
+          await log({ foodId: id }, 9 - rank)
+        }
+
+        return { recipes, foods }
+      })
+
+      return { t, ...built }
+    }
+
+    const dinner = (t: Seeded['t']) =>
+      t
+        .withIdentity(asAlice)
+        .query(api.consumption.suggestionsForMeal, { date: DAY, meal: 'dinner' })
+
+    test('the eight offered are the eight most-chosen usable recipes', async () => {
+      const { t, recipes } = await withTenHabits()
+      await t.run(async (ctx) => {
+        // The most-chosen of all is gone, and the runner-up has lost the
+        // nutrition a card is built from.
+        await ctx.db.delete(recipes[0])
+        await ctx.db.patch(recipes[1], { nutrition: undefined })
+      })
+
+      expect((await dinner(t)).recipes.map((r) => r.title)).toEqual([
+        'Dinner 2',
+        'Dinner 3',
+        'Dinner 4',
+        'Dinner 5',
+        'Dinner 6',
+        'Dinner 7',
+        'Dinner 8',
+        'Dinner 9',
+      ])
+    })
+
+    test('a deleted food does not cost a slot either', async () => {
+      const { t, foods } = await withTenHabits()
+      await t.run(async (ctx) => {
+        await ctx.db.delete(foods[0])
+      })
+
+      expect((await dinner(t)).foods.map((f) => f.name)).toEqual([
+        'Food 1',
+        'Food 2',
+        'Food 3',
+        'Food 4',
+        'Food 5',
+        'Food 6',
+        'Food 7',
+        'Food 8',
+      ])
+    })
+  })
+
+  test('a day after the one being logged is not a habit of it', async () => {
+    // The window has two ends. Opening the sheet on a day last month must ask
+    // about the habits of that month — and the scan takes the newest rows
+    // first, so an unbounded top end does not merely skew the ranking, it can
+    // spend the whole scan on entries written after the day being asked about.
+    const { t, ids, logged } = await withHabits()
+    await logged([
+      { date: '2026-08-20', meal: 'breakfast', foodId: ids.pancakes },
+      { date: '2026-08-21', meal: 'breakfast', foodId: ids.pancakes },
+      { date: '2026-07-29', meal: 'breakfast', foodId: ids.oats },
+    ])
+
+    expect((await opened(t)).foods.map((f) => f.name)).toEqual([
+      'Porridge oats',
+    ])
+  })
+
+  test('the day being logged counts, so this morning is part of this morning', async () => {
+    const { t, ids, logged } = await withHabits()
+    await logged([{ date: DAY, meal: 'breakfast', foodId: ids.oats }])
+
+    expect((await opened(t)).foods.map((f) => f.name)).toEqual([
+      'Porridge oats',
+    ])
+  })
 })

--- a/convex/consumption.ts
+++ b/convex/consumption.ts
@@ -7,9 +7,14 @@ import {
   quantityUnitValidator,
   scaleFacts,
 } from './lib/consumption'
+import { withImageUrl } from './foods'
 import { isVisibleToGroups } from './lib/groupAccess'
 import { NUTRIENT_KEYS, type NutritionFacts, nutritionValidator } from './lib/nutrition'
-import { rankLoggedAmounts } from './lib/servings'
+import {
+  rankLoggedAmounts,
+  rankMealChoices,
+  suggestionWindowStart,
+} from './lib/servings'
 import { getCurrentUser, getMyGroupIds } from './lib/sharing'
 import type { Doc, Id } from './_generated/dataModel'
 import type { MutationCtx, QueryCtx } from './_generated/server'
@@ -90,6 +95,82 @@ export const loggedAmountsForFood = query({
       )
       .collect()
     return rankLoggedAmounts(entries, food.baseUnit)
+  },
+})
+
+/**
+ * How many diary rows the empty sheet will read to work out a habit.
+ *
+ * The date window is the real bound; this is the second one, for the person
+ * who logs a dozen things a day and would otherwise turn "what do I usually
+ * have for breakfast" into a two-month scan. Entries come back newest-first,
+ * so what a cap this size drops is always the oldest of a very full window.
+ */
+const SUGGESTION_SCAN_LIMIT = 400
+
+/**
+ * What the add sheet opens on: the foods and recipes you usually have at this
+ * meal, most-chosen first (#76).
+ *
+ * The sheet used to open on every recipe you own and none of your foods, which
+ * read as broken — foods came from a search that returns nothing for an empty
+ * term, and recipes came from a list with no bound on it. Both sections are
+ * answered from your own diary now, ranked the same way and bounded to the
+ * same handful. Anything you have never logged is behind the search box, which
+ * is where a thing you have to think about belongs.
+ *
+ * The meal is an argument because the answer differs by meal — that is the
+ * point of it (#73). The date is an argument too: the window is measured back
+ * from the day being logged, so opening the sheet on a day last month asks
+ * about the habits of that month.
+ *
+ * Yours alone, like every other read of your diary: the entries are found by
+ * your user id and there is no argument by which one person can ask about
+ * another's. A recipe you can no longer see drops out here exactly as it drops
+ * out of `listForDay` (ADR-0003).
+ */
+export const suggestionsForMeal = query({
+  args: { date: v.string(), meal: mealValidator },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx)
+    if (!user) return { foods: [], recipes: [] }
+    const since = suggestionWindowStart(args.date)
+    const entries = await ctx.db
+      .query('consumptionEntries')
+      .withIndex('by_user_date', (q) =>
+        q.eq('userId', user._id).gte('date', since),
+      )
+      .order('desc')
+      .take(SUGGESTION_SCAN_LIMIT)
+    const { foodIds, recipeIds } = rankMealChoices(entries, {
+      meal: args.meal,
+      since,
+    })
+
+    const foodDocs = await Promise.all(foodIds.map((id) => ctx.db.get(id)))
+    const foods = await Promise.all(
+      foodDocs
+        .filter((food) => food !== null)
+        .map((food) => withImageUrl(ctx, food)),
+    )
+
+    const viewerGroupIds = await getMyGroupIds(ctx, user._id)
+    const recipeDocs = await Promise.all(recipeIds.map((id) => ctx.db.get(id)))
+    // Only what a card can be built from: a recipe with no nutrition has
+    // nothing to log, and one this reader may no longer see is not offered
+    // back to them by their own history.
+    const recipes = []
+    for (const recipe of recipeDocs) {
+      if (!recipe || !recipe.nutrition) continue
+      if (!isVisibleToGroups(recipe, viewerGroupIds)) continue
+      recipes.push({
+        _id: recipe._id,
+        title: recipe.title,
+        nutrition: recipe.nutrition,
+      })
+    }
+
+    return { foods, recipes }
   },
 })
 

--- a/convex/consumption.ts
+++ b/convex/consumption.ts
@@ -11,6 +11,7 @@ import { withImageUrl } from './foods'
 import { isVisibleToGroups } from './lib/groupAccess'
 import { NUTRIENT_KEYS, type NutritionFacts, nutritionValidator } from './lib/nutrition'
 import {
+  MAX_MEAL_SUGGESTIONS,
   rankLoggedAmounts,
   rankMealChoices,
   suggestionWindowStart,
@@ -135,22 +136,33 @@ export const suggestionsForMeal = query({
     const user = await getCurrentUser(ctx)
     if (!user) return { foods: [], recipes: [] }
     const since = suggestionWindowStart(args.date)
+    // Both ends of the window. Without the upper one the scan below, which
+    // takes the newest rows first, could be spent entirely on entries written
+    // after the day being asked about — a sheet opened on a day last month
+    // would rank it by a routine its owner had not started yet.
     const entries = await ctx.db
       .query('consumptionEntries')
       .withIndex('by_user_date', (q) =>
-        q.eq('userId', user._id).gte('date', since),
+        q.eq('userId', user._id).gte('date', since).lte('date', args.date),
       )
       .order('desc')
       .take(SUGGESTION_SCAN_LIMIT)
     const { foodIds, recipeIds } = rankMealChoices(entries, {
       meal: args.meal,
       since,
+      until: args.date,
     })
 
+    // Ranked in full, then cut to size *after* the rows that cannot be logged
+    // are gone. The other order spends a slot on every deleted food and every
+    // recipe this reader may no longer see, and never fetches the perfectly
+    // good ninth-ranked one behind them. Still bounded work: the ranking is
+    // only ever as long as the window and the scan limit allowed.
     const foodDocs = await Promise.all(foodIds.map((id) => ctx.db.get(id)))
     const foods = await Promise.all(
       foodDocs
         .filter((food) => food !== null)
+        .slice(0, MAX_MEAL_SUGGESTIONS)
         .map((food) => withImageUrl(ctx, food)),
     )
 
@@ -161,6 +173,7 @@ export const suggestionsForMeal = query({
     // back to them by their own history.
     const recipes = []
     for (const recipe of recipeDocs) {
+      if (recipes.length === MAX_MEAL_SUGGESTIONS) break
       if (!recipe || !recipe.nutrition) continue
       if (!isVisibleToGroups(recipe, viewerGroupIds)) continue
       recipes.push({

--- a/convex/foods.ts
+++ b/convex/foods.ts
@@ -38,7 +38,7 @@ function assertNotCatalog(food: Doc<'foods'>) {
  * The row holds a `_storage` id, which is no use to an `<img>`. Resolving it
  * here rather than in the client is what keeps a result list one round trip.
  */
-async function withImageUrl(ctx: QueryCtx, food: Doc<'foods'>) {
+export async function withImageUrl(ctx: QueryCtx, food: Doc<'foods'>) {
   return {
     ...food,
     imageUrl: food.imageId ? await ctx.storage.getUrl(food.imageId) : null,

--- a/convex/lib/seed/sampleHousehold.ts
+++ b/convex/lib/seed/sampleHousehold.ts
@@ -798,7 +798,6 @@ export type SampleDiaryEntry = {
   | { kind: 'recipe'; recipeKey: string; servings: number }
 )
 
-/** Seven days of the owner's diary, thinning out toward the older end. */
 /**
  * A Combo the sample person has saved, so a preview shows the fastest path in
  * the add sheet rather than an empty section (ADR-0012).
@@ -856,11 +855,33 @@ export const SAMPLE_COMBOS: SampleCombo[] = [
   },
 ]
 
+/**
+ * A fortnight of the owner's diary, thinning out toward the older end.
+ *
+ * **Deliberately repetitive, per meal.** The add sheet opens on what you
+ * usually have at the meal you are logging, ranked by how often (#76) — so a
+ * diary in which everything appears exactly once demonstrates nothing: the
+ * ranking is real but the order it produces looks arbitrary, and a preview is
+ * how anybody decides whether this feature was worth building. These fixtures
+ * give each meal a habit and a runner-up:
+ *
+ * - **breakfast** — porridge oats with semi-skimmed milk five times, wholemeal
+ *   toast with peanut butter three, and overnight oats as the recipe you make
+ *   on a slow morning.
+ * - **lunch** — bread and cheddar at a desk three times, Greek salad three.
+ * - **dinner** — the chickpea curry more often than anything else, grated
+ *   parmesan on the pasta nights.
+ * - **snack** — a banana most days, Greek yoghurt otherwise.
+ *
+ * Seven days was not enough room for that to be visible without making every
+ * day identical, which is why this is fourteen. Every date is still relative
+ * to the run, so a preview is never looking at a stale month.
+ */
 export const SAMPLE_DIARY: SampleDiaryEntry[] = [
   // Today
   { daysAgo: 0, meal: 'breakfast', label: 'Overnight oats', kind: 'recipe', recipeKey: 'overnight-oats', servings: 1 },
-  { daysAgo: 0, meal: 'snack', label: 'Banana', kind: 'food', seedKey: 'banana', quantity: 1, unit: 'piece' },
   { daysAgo: 0, meal: 'lunch', label: 'Greek salad', kind: 'recipe', recipeKey: 'greek-salad', servings: 1 },
+  { daysAgo: 0, meal: 'snack', label: 'Banana', kind: 'food', seedKey: 'banana', quantity: 1, unit: 'piece' },
   // Yesterday
   { daysAgo: 1, meal: 'breakfast', label: 'Porridge oats', kind: 'food', seedKey: 'oats-rolled', quantity: 60, unit: 'g' },
   { daysAgo: 1, meal: 'breakfast', label: 'Semi-skimmed milk', kind: 'food', seedKey: 'milk-semi-skimmed', quantity: 200, unit: 'ml' },
@@ -876,16 +897,63 @@ export const SAMPLE_DIARY: SampleDiaryEntry[] = [
   { daysAgo: 3, meal: 'breakfast', label: 'Banana oat pancakes', kind: 'recipe', recipeKey: 'banana-oat-pancakes', servings: 1 },
   { daysAgo: 3, meal: 'lunch', label: 'Minestrone', kind: 'recipe', recipeKey: 'minestrone', servings: 1.5 },
   { daysAgo: 3, meal: 'dinner', label: 'Lasagne alla bolognese', kind: 'recipe', recipeKey: 'lasagne', servings: 1 },
+  { daysAgo: 3, meal: 'dinner', label: 'Parmesan', kind: 'food', seedKey: 'cheese-parmesan', quantity: 15, unit: 'g' },
+  { daysAgo: 3, meal: 'snack', label: 'Banana', kind: 'food', seedKey: 'banana', quantity: 1, unit: 'piece' },
   // Four days ago
   { daysAgo: 4, meal: 'breakfast', label: 'Overnight oats', kind: 'recipe', recipeKey: 'overnight-oats', servings: 1 },
   { daysAgo: 4, meal: 'dinner', label: 'Shakshuka', kind: 'recipe', recipeKey: 'shakshuka', servings: 1.5 },
   { daysAgo: 4, meal: 'snack', label: 'Cheddar', kind: 'food', seedKey: 'cheese-cheddar', quantity: 30, unit: 'g' },
   // Five days ago
+  { daysAgo: 5, meal: 'breakfast', label: 'Porridge oats', kind: 'food', seedKey: 'oats-rolled', quantity: 60, unit: 'g' },
+  { daysAgo: 5, meal: 'breakfast', label: 'Semi-skimmed milk', kind: 'food', seedKey: 'milk-semi-skimmed', quantity: 200, unit: 'ml' },
   { daysAgo: 5, meal: 'lunch', label: 'Tarka dal', kind: 'recipe', recipeKey: 'tarka-dal', servings: 1 },
   { daysAgo: 5, meal: 'dinner', label: 'Chicken and potato traybake', kind: 'recipe', recipeKey: 'chicken-traybake', servings: 1 },
   // Six days ago
   { daysAgo: 6, meal: 'breakfast', label: 'Wholemeal toast', kind: 'food', seedKey: 'bread-wholemeal', quantity: 2, unit: 'piece' },
+  { daysAgo: 6, meal: 'breakfast', label: 'Peanut butter', kind: 'food', seedKey: 'peanut-butter', quantity: 20, unit: 'g' },
   { daysAgo: 6, meal: 'dinner', label: 'Spinach and feta filo pie', kind: 'recipe', recipeKey: 'spinach-feta-pie', servings: 1 },
+  { daysAgo: 6, meal: 'dinner', label: 'Wholemeal bread', kind: 'food', seedKey: 'bread-wholemeal', quantity: 40, unit: 'g' },
+  { daysAgo: 6, meal: 'snack', label: 'Banana', kind: 'food', seedKey: 'banana', quantity: 1, unit: 'piece' },
+  // A week ago
+  { daysAgo: 7, meal: 'breakfast', label: 'Porridge oats', kind: 'food', seedKey: 'oats-rolled', quantity: 60, unit: 'g' },
+  { daysAgo: 7, meal: 'breakfast', label: 'Semi-skimmed milk', kind: 'food', seedKey: 'milk-semi-skimmed', quantity: 200, unit: 'ml' },
+  { daysAgo: 7, meal: 'lunch', label: 'Greek salad', kind: 'recipe', recipeKey: 'greek-salad', servings: 1 },
+  { daysAgo: 7, meal: 'dinner', label: 'Chickpea and spinach curry', kind: 'recipe', recipeKey: 'chickpea-curry', servings: 1.5 },
+  { daysAgo: 7, meal: 'snack', label: 'Greek yoghurt', kind: 'food', seedKey: 'yoghurt-greek-natural', quantity: 150, unit: 'g' },
+  // Eight days ago
+  { daysAgo: 8, meal: 'breakfast', label: 'Overnight oats', kind: 'recipe', recipeKey: 'overnight-oats', servings: 1 },
+  { daysAgo: 8, meal: 'lunch', label: 'Wholemeal bread', kind: 'food', seedKey: 'bread-wholemeal', quantity: 80, unit: 'g' },
+  { daysAgo: 8, meal: 'lunch', label: 'Cheddar', kind: 'food', seedKey: 'cheese-cheddar', quantity: 30, unit: 'g' },
+  { daysAgo: 8, meal: 'dinner', label: 'Salmon and rice bowl', kind: 'recipe', recipeKey: 'salmon-rice-bowl', servings: 1 },
+  { daysAgo: 8, meal: 'snack', label: 'Apple', kind: 'food', seedKey: 'apple', quantity: 1, unit: 'piece' },
+  // Nine days ago
+  { daysAgo: 9, meal: 'breakfast', label: 'Porridge oats', kind: 'food', seedKey: 'oats-rolled', quantity: 60, unit: 'g' },
+  { daysAgo: 9, meal: 'breakfast', label: 'Semi-skimmed milk', kind: 'food', seedKey: 'milk-semi-skimmed', quantity: 200, unit: 'ml' },
+  { daysAgo: 9, meal: 'lunch', label: 'Greek salad', kind: 'recipe', recipeKey: 'greek-salad', servings: 1 },
+  { daysAgo: 9, meal: 'dinner', label: 'Pasta puttanesca', kind: 'recipe', recipeKey: 'pasta-puttanesca', servings: 1.5 },
+  { daysAgo: 9, meal: 'dinner', label: 'Parmesan', kind: 'food', seedKey: 'cheese-parmesan', quantity: 15, unit: 'g' },
+  { daysAgo: 9, meal: 'snack', label: 'Banana', kind: 'food', seedKey: 'banana', quantity: 1, unit: 'piece' },
+  // Ten days ago
+  { daysAgo: 10, meal: 'lunch', label: 'Wholemeal bread', kind: 'food', seedKey: 'bread-wholemeal', quantity: 80, unit: 'g' },
+  { daysAgo: 10, meal: 'lunch', label: 'Cheddar', kind: 'food', seedKey: 'cheese-cheddar', quantity: 30, unit: 'g' },
+  { daysAgo: 10, meal: 'dinner', label: 'Shakshuka', kind: 'recipe', recipeKey: 'shakshuka', servings: 1 },
+  { daysAgo: 10, meal: 'snack', label: 'Greek yoghurt', kind: 'food', seedKey: 'yoghurt-greek-natural', quantity: 150, unit: 'g' },
+  // Eleven days ago
+  { daysAgo: 11, meal: 'breakfast', label: 'Porridge oats', kind: 'food', seedKey: 'oats-rolled', quantity: 60, unit: 'g' },
+  { daysAgo: 11, meal: 'breakfast', label: 'Semi-skimmed milk', kind: 'food', seedKey: 'milk-semi-skimmed', quantity: 200, unit: 'ml' },
+  { daysAgo: 11, meal: 'dinner', label: 'Lasagne alla bolognese', kind: 'recipe', recipeKey: 'lasagne', servings: 1 },
+  { daysAgo: 11, meal: 'dinner', label: 'Parmesan', kind: 'food', seedKey: 'cheese-parmesan', quantity: 15, unit: 'g' },
+  { daysAgo: 11, meal: 'snack', label: 'Peanut butter', kind: 'food', seedKey: 'peanut-butter', quantity: 20, unit: 'g' },
+  // Twelve days ago
+  { daysAgo: 12, meal: 'breakfast', label: 'Wholemeal toast', kind: 'food', seedKey: 'bread-wholemeal', quantity: 2, unit: 'piece' },
+  { daysAgo: 12, meal: 'breakfast', label: 'Peanut butter', kind: 'food', seedKey: 'peanut-butter', quantity: 20, unit: 'g' },
+  { daysAgo: 12, meal: 'lunch', label: 'Wholemeal bread', kind: 'food', seedKey: 'bread-wholemeal', quantity: 80, unit: 'g' },
+  { daysAgo: 12, meal: 'dinner', label: 'Chicken and potato traybake', kind: 'recipe', recipeKey: 'chicken-traybake', servings: 1 },
+  { daysAgo: 12, meal: 'snack', label: 'Banana', kind: 'food', seedKey: 'banana', quantity: 1, unit: 'piece' },
+  // A fortnight ago, all but forgotten
+  { daysAgo: 13, meal: 'breakfast', label: 'Banana oat pancakes', kind: 'recipe', recipeKey: 'banana-oat-pancakes', servings: 1 },
+  { daysAgo: 13, meal: 'lunch', label: 'Minestrone', kind: 'recipe', recipeKey: 'minestrone', servings: 1.5 },
+  { daysAgo: 13, meal: 'dinner', label: 'Chickpea and spinach curry', kind: 'recipe', recipeKey: 'chickpea-curry', servings: 1 },
 ]
 
 /**

--- a/convex/lib/servings.test.ts
+++ b/convex/lib/servings.test.ts
@@ -1,10 +1,13 @@
 import { expect, test } from 'vitest'
 import {
   authoredServings,
+  MAX_MEAL_SUGGESTIONS,
   offeredServings,
   parseServingAmount,
   rankLoggedAmounts,
+  rankMealChoices,
   resolveAmount,
+  suggestionWindowStart,
 } from './servings'
 
 const bread = {
@@ -144,4 +147,106 @@ test('a Catalog food nobody may edit still gets your own amounts', () => {
   expect(offeredServings({}, [{ label: '90 g', amount: 90 }])).toEqual([
     { label: '90 g', amount: 90, own: true },
   ])
+})
+
+/**
+ * What the add sheet opens on: the things you usually have at *this* meal.
+ *
+ * Breakfast opens on breakfast things — the whole point of the empty state is
+ * that the common case needs no typing, and what somebody has every morning is
+ * a far better guess than whatever they logged last night (#76, #73).
+ */
+const entry = (
+  meal: string,
+  date: string,
+  ref: { foodId?: string; recipeId?: string },
+) => ({ meal, date, ...ref })
+
+test('the things you have most often at a meal come first', () => {
+  expect(
+    rankMealChoices(
+      [
+        entry('breakfast', '2026-08-01', { foodId: 'oats' }),
+        entry('breakfast', '2026-08-02', { foodId: 'oats' }),
+        entry('breakfast', '2026-08-03', { foodId: 'toast' }),
+        entry('breakfast', '2026-08-04', { foodId: 'oats' }),
+      ],
+      { meal: 'breakfast' },
+    ),
+  ).toEqual({ foodIds: ['oats', 'toast'], recipeIds: [] })
+})
+
+test('a habit is per meal — dinner is not asked about breakfast', () => {
+  const entries = [
+    entry('breakfast', '2026-08-01', { foodId: 'oats' }),
+    entry('breakfast', '2026-08-02', { foodId: 'oats' }),
+    entry('dinner', '2026-08-01', { foodId: 'rice' }),
+  ]
+  expect(rankMealChoices(entries, { meal: 'dinner' })).toEqual({
+    foodIds: ['rice'],
+    recipeIds: [],
+  })
+})
+
+test('a tie goes to the newer habit, so a change of routine overtakes', () => {
+  expect(
+    rankMealChoices(
+      [
+        entry('lunch', '2026-06-01', { foodId: 'soup' }),
+        entry('lunch', '2026-06-02', { foodId: 'soup' }),
+        entry('lunch', '2026-07-20', { foodId: 'salad' }),
+        entry('lunch', '2026-07-21', { foodId: 'salad' }),
+      ],
+      { meal: 'lunch' },
+    ).foodIds,
+  ).toEqual(['salad', 'soup'])
+})
+
+test('foods and recipes are counted apart — they are two sections', () => {
+  expect(
+    rankMealChoices(
+      [
+        entry('dinner', '2026-08-01', { recipeId: 'curry' }),
+        entry('dinner', '2026-08-02', { recipeId: 'curry' }),
+        entry('dinner', '2026-08-02', { foodId: 'rice' }),
+        // A one-off references neither, and there is nothing to offer back.
+        entry('dinner', '2026-08-03', {}),
+      ],
+      { meal: 'dinner' },
+    ),
+  ).toEqual({ foodIds: ['rice'], recipeIds: ['curry'] })
+})
+
+test('a habit older than the window is not still the first thing offered', () => {
+  expect(
+    rankMealChoices(
+      [
+        entry('breakfast', '2026-01-01', { foodId: 'pancakes' }),
+        entry('breakfast', '2026-01-02', { foodId: 'pancakes' }),
+        entry('breakfast', '2026-08-01', { foodId: 'oats' }),
+      ],
+      { meal: 'breakfast', since: '2026-06-10' },
+    ).foodIds,
+  ).toEqual(['oats'])
+})
+
+test('the window is measured back from the day being logged', () => {
+  expect(suggestionWindowStart('2026-08-09', 60)).toBe('2026-06-10')
+  // Across a year boundary, because a diary does not stop on the 1st.
+  expect(suggestionWindowStart('2026-01-05', 60)).toBe('2025-11-06')
+  // A date this cannot parse narrows to the day itself rather than quietly
+  // widening the scan to the whole diary.
+  expect(suggestionWindowStart('not a date')).toBe('not a date')
+})
+
+test('only a handful is offered, however long the habit list is', () => {
+  const entries = Array.from({ length: 20 }, (_, i) =>
+    entry('snack', '2026-08-01', { foodId: `food${i}` }),
+  )
+  expect(rankMealChoices(entries, { meal: 'snack' }).foodIds).toHaveLength(
+    MAX_MEAL_SUGGESTIONS,
+  )
+  expect(
+    rankMealChoices(entries, { meal: 'snack', limit: 3 }).foodIds,
+  ).toHaveLength(3)
 })

--- a/convex/lib/servings.test.ts
+++ b/convex/lib/servings.test.ts
@@ -230,6 +230,32 @@ test('a habit older than the window is not still the first thing offered', () =>
   ).toEqual(['oats'])
 })
 
+test('a day after the one being logged is not a habit of it', () => {
+  // The window has two ends. Opening the sheet on a day last month must ask
+  // about the habits of that month — if what came *after* counted, a historical
+  // day would be ranked by a routine its owner had not started yet, and the
+  // caller's newest-first scan cap would spend itself on those rows first.
+  expect(
+    rankMealChoices(
+      [
+        entry('breakfast', '2026-08-20', { foodId: 'granola' }),
+        entry('breakfast', '2026-08-21', { foodId: 'granola' }),
+        entry('breakfast', '2026-07-04', { foodId: 'oats' }),
+      ],
+      { meal: 'breakfast', since: '2026-05-06', until: '2026-07-05' },
+    ).foodIds,
+  ).toEqual(['oats'])
+})
+
+test('the day being logged counts, so this morning is part of this morning', () => {
+  expect(
+    rankMealChoices([entry('breakfast', '2026-07-05', { foodId: 'oats' })], {
+      meal: 'breakfast',
+      until: '2026-07-05',
+    }).foodIds,
+  ).toEqual(['oats'])
+})
+
 test('the window is measured back from the day being logged', () => {
   expect(suggestionWindowStart('2026-08-09', 60)).toBe('2026-06-10')
   // Across a year boundary, because a diary does not stop on the 1st.
@@ -239,14 +265,14 @@ test('the window is measured back from the day being logged', () => {
   expect(suggestionWindowStart('not a date')).toBe('not a date')
 })
 
-test('only a handful is offered, however long the habit list is', () => {
+test('everything in the window is ranked, because a slot must not be spent early', () => {
+  // Only a handful is ever *offered* (`MAX_MEAL_SUGGESTIONS`), but that cut is
+  // the caller's to make once it has read the rows and dropped the ones that
+  // cannot be logged. Cutting here would spend a slot on every deleted food
+  // and never reach the good one behind it.
   const entries = Array.from({ length: 20 }, (_, i) =>
     entry('snack', '2026-08-01', { foodId: `food${i}` }),
   )
-  expect(rankMealChoices(entries, { meal: 'snack' }).foodIds).toHaveLength(
-    MAX_MEAL_SUGGESTIONS,
-  )
-  expect(
-    rankMealChoices(entries, { meal: 'snack', limit: 3 }).foodIds,
-  ).toHaveLength(3)
+  expect(rankMealChoices(entries, { meal: 'snack' }).foodIds).toHaveLength(20)
+  expect(MAX_MEAL_SUGGESTIONS).toBe(8)
 })

--- a/convex/lib/servings.ts
+++ b/convex/lib/servings.ts
@@ -69,6 +69,116 @@ export function rankLoggedAmounts(
     .map(([amount]) => ({ label: `${amount} ${baseUnit}`, amount }))
 }
 
+/** How many things each section of the empty add sheet offers (#76). */
+export const MAX_MEAL_SUGGESTIONS = 8
+
+/**
+ * How far back the empty add sheet looks for a habit.
+ *
+ * Bounded on purpose: a year of entries is not needed to know what somebody
+ * has for breakfast, and the alternative is collecting a diary of unbounded
+ * length on every open of the sheet. Two months is long enough that a habit
+ * kept a few times a week is obvious and short enough that one abandoned in
+ * spring is not still the first thing offered in autumn.
+ */
+export const SUGGESTION_WINDOW_DAYS = 60
+
+/**
+ * The earliest day the empty sheet counts, given the day being logged.
+ *
+ * Days rather than timestamps because that is what a diary entry stores — an
+ * ISO `YYYY-MM-DD` string, which compares and sorts as a date without being
+ * parsed. A date this cannot parse yields itself, so a broken argument narrows
+ * the window to a single day rather than quietly widening it to everything.
+ */
+export function suggestionWindowStart(
+  date: string,
+  days: number = SUGGESTION_WINDOW_DAYS,
+): string {
+  const start = new Date(`${date}T00:00:00Z`)
+  if (Number.isNaN(start.getTime())) return date
+  start.setUTCDate(start.getUTCDate() - days)
+  return start.toISOString().slice(0, 10)
+}
+
+/** As much of a diary entry as ranking a meal's habits depends on. */
+export interface MealChoiceEntry<F extends string, R extends string> {
+  meal: string
+  date: string
+  foodId?: F
+  recipeId?: R
+}
+
+/**
+ * What somebody usually has at this meal, most-chosen first (#76, #73).
+ *
+ * The empty add sheet's whole point is that the common case needs no typing,
+ * and "the thing I eat every breakfast" is a far better guess than "the thing
+ * I logged last night" — so this ranks a person's distinct foods and recipes
+ * by *how often* they logged each one in this meal slot, and breaks ties on
+ * recency so that a new habit overtakes an old one of equal count. The final
+ * tie-break on the id itself is not meaningful; it is there so the order does
+ * not depend on which entry a query happened to return first.
+ *
+ * Foods and recipes are counted separately because they are offered as two
+ * sections and logged in different units — they are never ranked against each
+ * other. A one-off entry references neither and counts towards nothing: there
+ * is nothing to offer back.
+ *
+ * Pure, and given the window rather than computing it, so the same bound the
+ * caller's index range applies is applied again here — the two cannot drift,
+ * and a test can state the window without a database.
+ */
+export function rankMealChoices<F extends string, R extends string>(
+  entries: readonly MealChoiceEntry<F, R>[],
+  options: { meal: string; since?: string; limit?: number },
+): { foodIds: F[]; recipeIds: R[] } {
+  const limit = options.limit ?? MAX_MEAL_SUGGESTIONS
+  const foods = new Map<F, Tally>()
+  const recipes = new Map<R, Tally>()
+  for (const entry of entries) {
+    if (entry.meal !== options.meal) continue
+    if (options.since !== undefined && entry.date < options.since) continue
+    if (entry.foodId !== undefined) tally(foods, entry.foodId, entry.date)
+    if (entry.recipeId !== undefined) tally(recipes, entry.recipeId, entry.date)
+  }
+  return {
+    foodIds: mostChosen(foods, limit),
+    recipeIds: mostChosen(recipes, limit),
+  }
+}
+
+interface Tally {
+  count: number
+  last: string
+}
+
+function tally<K extends string>(counts: Map<K, Tally>, key: K, date: string) {
+  const seen = counts.get(key)
+  if (!seen) {
+    counts.set(key, { count: 1, last: date })
+    return
+  }
+  seen.count += 1
+  if (date > seen.last) seen.last = date
+}
+
+function mostChosen<K extends string>(counts: Map<K, Tally>, limit: number): K[] {
+  return [...counts.entries()]
+    .sort(
+      ([aKey, a], [bKey, b]) =>
+        b.count - a.count ||
+        compare(b.last, a.last) ||
+        compare(aKey as string, bKey as string),
+    )
+    .slice(0, limit)
+    .map(([key]) => key)
+}
+
+function compare(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
 /** A serving on offer, and whether it came from the food or from your own logging. */
 export interface OfferedServing extends Serving {
   own: boolean

--- a/convex/lib/servings.ts
+++ b/convex/lib/servings.ts
@@ -69,7 +69,12 @@ export function rankLoggedAmounts(
     .map(([amount]) => ({ label: `${amount} ${baseUnit}`, amount }))
 }
 
-/** How many things each section of the empty add sheet offers (#76). */
+/**
+ * How many things each section of the empty add sheet offers (#76).
+ *
+ * Applied by the caller *after* it has read the documents and dropped the ones
+ * that cannot be logged, never by the ranking — see `rankMealChoices`.
+ */
 export const MAX_MEAL_SUGGESTIONS = 8
 
 /**
@@ -125,27 +130,36 @@ export interface MealChoiceEntry<F extends string, R extends string> {
  * other. A one-off entry references neither and counts towards nothing: there
  * is nothing to offer back.
  *
- * Pure, and given the window rather than computing it, so the same bound the
- * caller's index range applies is applied again here — the two cannot drift,
- * and a test can state the window without a database.
+ * **The window has two ends.** `since` is the horizon and `until` is the day
+ * being logged, inclusive — so opening the sheet on a day last month asks
+ * about the habits of that month rather than being ranked by a routine its
+ * owner had not started yet. Pure, and given both bounds rather than computing
+ * them, so the same window the caller's index range applies is applied again
+ * here: the two cannot drift, and a test can state the window without a
+ * database.
+ *
+ * **Nothing is capped here.** How many to offer is `MAX_MEAL_SUGGESTIONS`, and
+ * it can only be applied once the documents have been read — a recipe that has
+ * been deleted, lost its nutrition or moved out of a Group you are in cannot
+ * be logged, and is discovered too late to have been ranked around. Capping
+ * first would spend those slots on rows nobody can be offered. The result is
+ * bounded by what the caller passed in, which is bounded by the window and by
+ * its own scan limit.
  */
 export function rankMealChoices<F extends string, R extends string>(
   entries: readonly MealChoiceEntry<F, R>[],
-  options: { meal: string; since?: string; limit?: number },
+  options: { meal: string; since?: string; until?: string },
 ): { foodIds: F[]; recipeIds: R[] } {
-  const limit = options.limit ?? MAX_MEAL_SUGGESTIONS
   const foods = new Map<F, Tally>()
   const recipes = new Map<R, Tally>()
   for (const entry of entries) {
     if (entry.meal !== options.meal) continue
     if (options.since !== undefined && entry.date < options.since) continue
+    if (options.until !== undefined && entry.date > options.until) continue
     if (entry.foodId !== undefined) tally(foods, entry.foodId, entry.date)
     if (entry.recipeId !== undefined) tally(recipes, entry.recipeId, entry.date)
   }
-  return {
-    foodIds: mostChosen(foods, limit),
-    recipeIds: mostChosen(recipes, limit),
-  }
+  return { foodIds: mostChosen(foods), recipeIds: mostChosen(recipes) }
 }
 
 interface Tally {
@@ -163,7 +177,7 @@ function tally<K extends string>(counts: Map<K, Tally>, key: K, date: string) {
   if (date > seen.last) seen.last = date
 }
 
-function mostChosen<K extends string>(counts: Map<K, Tally>, limit: number): K[] {
+function mostChosen<K extends string>(counts: Map<K, Tally>): K[] {
   return [...counts.entries()]
     .sort(
       ([aKey, a], [bKey, b]) =>
@@ -171,7 +185,6 @@ function mostChosen<K extends string>(counts: Map<K, Tally>, limit: number): K[]
         compare(b.last, a.last) ||
         compare(aKey as string, bKey as string),
     )
-    .slice(0, limit)
     .map(([key]) => key)
 }
 

--- a/convex/seed.test.ts
+++ b/convex/seed.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { testConvex } from '../test/convexHarness'
+import { api } from './_generated/api'
 import {
   applyCatalog,
   applySample,
@@ -7,6 +8,7 @@ import {
   resetSample,
 } from './lib/seed/apply'
 import { SAMPLE_GROUP_NAME } from './lib/seed/sampleHousehold'
+import { MAX_MEAL_SUGGESTIONS } from './lib/servings'
 
 /**
  * The Sample household, built against the Group boundary.
@@ -120,5 +122,49 @@ describe('the Sample household', () => {
 
     expect(left.groups).toBe(0)
     expect(left.recipes).toBe(0)
+  })
+
+  /**
+   * The add sheet's first screen has to *demonstrate* something in a preview
+   * (#76). A diary in which everything appears exactly once ranks correctly and
+   * still looks arbitrary, so the fixtures owe each meal a habit — and this is
+   * the test that notices when an edit to them quietly takes one away.
+   */
+  test('gives each meal a habit the add sheet can open on', async () => {
+    const t = testConvex()
+    await buildSample(t)
+    const today = new Date().toISOString().slice(0, 10)
+    const asOwner = t.withIdentity({ subject: owner.clerkId })
+
+    const breakfast = await asOwner.query(api.consumption.suggestionsForMeal, {
+      date: today,
+      meal: 'breakfast',
+    })
+    // Porridge and milk, most mornings — ahead of the toast, on count. They
+    // are logged together every time, so which of the two leads is decided by
+    // the last tie-break and is not worth asserting.
+    expect(breakfast.foods.slice(0, 2).map((f) => f.name).sort()).toEqual([
+      'Milk, semi-skimmed',
+      'Oats, rolled',
+    ])
+    expect(breakfast.recipes[0].title).toBe('Overnight oats')
+
+    const dinner = await asOwner.query(api.consumption.suggestionsForMeal, {
+      date: today,
+      meal: 'dinner',
+    })
+    // A different meal opens on different things, which is the whole point.
+    expect(dinner.recipes[0].title).toBe('Chickpea and spinach curry')
+    expect(dinner.recipes.map((r) => r.title)).not.toContain('Overnight oats')
+
+    // And bounded: eight of each at most, however much has been logged.
+    for (const suggestions of [breakfast, dinner]) {
+      expect(suggestions.foods.length).toBeLessThanOrEqual(
+        MAX_MEAL_SUGGESTIONS,
+      )
+      expect(suggestions.recipes.length).toBeLessThanOrEqual(
+        MAX_MEAL_SUGGESTIONS,
+      )
+    }
   })
 })

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -50,6 +50,10 @@ const recipes = vi.hoisted(() => ({
     { _id: 'recipe2', title: 'Chili', nutrition: undefined },
   ],
 }))
+/** What this person usually has at the meal the sheet is adding to (#76). */
+const suggestions = vi.hoisted(() => ({
+  value: { foods: [] as unknown[], recipes: [] as unknown[] },
+}))
 const offResults = vi.hoisted(() => ({
   value: [
     {
@@ -78,7 +82,12 @@ vi.mock('convex/react', () => ({
     if (name === 'foods:getByBarcode') {
       return args === 'skip' ? undefined : existingFood.value
     }
-    if (name === 'recipes:listAcrossMyGroups') return recipes.value
+    if (name === 'recipes:listAcrossMyGroups') {
+      return args === 'skip' ? undefined : recipes.value
+    }
+    if (name === 'consumption:suggestionsForMeal') {
+      return args === 'skip' ? undefined : suggestions.value
+    }
     if (name === 'combos:list') return combos.value
     if (name === 'consumption:loggedAmountsForFood') {
       return args === 'skip' ? undefined : loggedAmounts.value
@@ -117,6 +126,7 @@ vi.mock('../../../convex/_generated/api', () => ({
       createMany: 'consumption:createMany',
       remove: 'consumption:remove',
       loggedAmountsForFood: 'consumption:loggedAmountsForFood',
+      suggestionsForMeal: 'consumption:suggestionsForMeal',
     },
   },
 }))
@@ -148,6 +158,46 @@ beforeEach(() => {
   combos.value = []
   existingFood.value = null
   offProduct.value = null
+  suggestions.value = {
+    foods: [foods.value[1]],
+    recipes: [recipes.value[0]],
+  }
+})
+
+/**
+ * The first screen, before anything is typed (#76).
+ *
+ * It used to be every recipe you owned and none of your foods, which read as
+ * broken. It is what you usually have at *this* meal now — and a person with
+ * no history to draw on is the one who gets told to start typing.
+ */
+test('the sheet opens on what you usually have at this meal', async () => {
+  renderSheet()
+
+  expect(screen.getByText('Your usual foods')).toBeDefined()
+  expect(screen.getByText('Volkorenbrood')).toBeDefined()
+  expect(screen.getByText('Your usual recipes')).toBeDefined()
+  expect(screen.getByText('Melkbroodjes')).toBeDefined()
+  // Not a hint to start typing: there is something here to tap.
+  expect(screen.queryByText('Search for a food, or scan a barcode.')).toBeNull()
+})
+
+test('a recipe you have never logged is behind the search box', async () => {
+  // `recipes.value` still holds Melkbroodjes — what changed is that owning it
+  // is no longer why it would be on the first screen. Nothing is.
+  suggestions.value = { foods: [], recipes: [] }
+  renderSheet()
+
+  expect(screen.queryByText('Melkbroodjes')).toBeNull()
+  // And now the hint appears, which is exactly when it is useful: this person
+  // has logged nothing yet, so the search box is the only way in.
+  expect(
+    screen.getByText('Search for a food, or scan a barcode.'),
+  ).toBeDefined()
+
+  // Typed, it is findable — the library did not go anywhere.
+  await search('melk')
+  await waitFor(() => expect(screen.getByText('Melkbroodjes')).toBeDefined())
 })
 
 test('a barcode you already have is shown from your own rows', async () => {

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -65,6 +65,13 @@ interface FoodSummary {
   imageUrl?: string | null
 }
 
+/** What a recipe card needs, from a search match or from your own history. */
+interface RecipeSummary {
+  _id: Id<'recipes'>
+  title: string
+  nutrition: NutritionFacts
+}
+
 interface Props {
   date: string
   meal: MealName
@@ -85,7 +92,14 @@ interface Props {
 export function AddSheet({ date, meal, nav, onClose }: Props) {
   const search = useFoodSearch()
   const term = search.term.trim()
-  const recipes = useQuery(api.recipes.listAcrossMyGroups, {})
+  const recipes = useQuery(api.recipes.listAcrossMyGroups, term ? {} : 'skip')
+  // What this person usually has at *this* meal, most-chosen first (#76). Only
+  // asked for while the search box is empty: once there is a term, the sheet is
+  // answering that instead, and the whole library is behind it.
+  const suggestions = useQuery(
+    api.consumption.suggestionsForMeal,
+    term ? 'skip' : { date, meal },
+  )
   const combos = useQuery(api.combos.list, {})
   const createEntry = useMutation(api.consumption.create)
   const createEntries = useMutation(api.consumption.createMany)
@@ -243,13 +257,25 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
   const matchingCombos = (combos ?? []).filter(
     (combo) => !term || combo.name.toLowerCase().includes(term.toLowerCase()),
   )
-  const foods = search.results ?? []
-  const withNutrition = (recipes ?? []).filter((r) => r.nutrition)
-  const matchingRecipes = term
-    ? withNutrition.filter((r) =>
-        r.title.toLowerCase().includes(term.toLowerCase()),
-      )
-    : withNutrition
+  // Empty box: your habits, bounded and ranked by the query. Anything typed:
+  // what matches it. The two never mix — a term is a question the sheet has to
+  // answer with the whole library rather than with the first screen's guesses.
+  const foods: FoodSummary[] = term
+    ? (search.results ?? [])
+    : (suggestions?.foods ?? [])
+  const matchingRecipes: RecipeSummary[] = term
+    ? (recipes ?? [])
+        .filter(
+          (r) =>
+            r.nutrition && r.title.toLowerCase().includes(term.toLowerCase()),
+        )
+        .map((r) => ({
+          _id: r._id,
+          title: r.title,
+          // Filtered to recipes that have it, which the type cannot see.
+          nutrition: r.nutrition as NutritionFacts,
+        }))
+    : (suggestions?.recipes ?? [])
   const offResults = search.offResults ?? []
   const foundNothing =
     term.length > 0 &&
@@ -371,7 +397,7 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
       )}
 
       {foods.length > 0 && (
-        <Section title={add.sections.foods}>
+        <Section title={term ? add.sections.foods : add.sections.usualFoods}>
           {foods.map((food) => (
             <FoodCard
               key={food._id}
@@ -385,16 +411,13 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
       )}
 
       {matchingRecipes.length > 0 && (
-        <Section title={add.sections.recipes}>
+        <Section
+          title={term ? add.sections.recipes : add.sections.usualRecipes}
+        >
           {matchingRecipes.map((recipe) => (
             <RecipeCard
               key={recipe._id}
-              recipe={{
-                _id: recipe._id,
-                title: recipe.title,
-                // Filtered to recipes that have it, which the type cannot see.
-                nutrition: recipe.nutrition as NutritionFacts,
-              }}
+              recipe={recipe}
               expanded={expanded === `recipe:${recipe._id}`}
               onToggle={() => toggle(`recipe:${recipe._id}`)}
               onLog={log}
@@ -440,8 +463,17 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
           </Section>
         ))}
 
+      {/* The hint used to require no Combos *and* no Recipes, and every recipe
+          you owned counted — so it almost never appeared. Now that the first
+          screen is your own history, it shows exactly when there is no history
+          to show: a person who has logged nothing yet, for whom the search box
+          really is the only way in. Both queries have to have answered first,
+          or it flashes on the way to a full sheet. */}
       {!term &&
+        combos !== undefined &&
+        suggestions !== undefined &&
         matchingCombos.length === 0 &&
+        foods.length === 0 &&
         matchingRecipes.length === 0 &&
         !scanned && <p className="py-2 text-sm opacity-60">{add.searchHint}</p>}
     </BottomSheet>

--- a/src/lib/i18n/messages/en/nutrition.ts
+++ b/src/lib/i18n/messages/en/nutrition.ts
@@ -73,6 +73,15 @@ export const diary = {
       foods: 'Your foods',
       recipes: 'Recipes',
       off: 'Open Food Facts',
+      /**
+       * What the sheet opens on before anything is typed: the foods and
+       * recipes you most often log in *this* meal (#76). Two headings rather
+       * than one, because they are two kinds of thing logged in different
+       * units — and both say "usual" so it is clear why these few are here
+       * and the rest of your library is not.
+       */
+      usualFoods: 'Your usual foods',
+      usualRecipes: 'Your usual recipes',
     },
     amount: 'Amount',
     unit: 'Unit',

--- a/src/lib/i18n/messages/nl/nutrition.ts
+++ b/src/lib/i18n/messages/nl/nutrition.ts
@@ -60,6 +60,8 @@ export const diary = {
       foods: 'Jouw voedingsmiddelen',
       recipes: 'Recepten',
       off: 'Open Food Facts',
+      usualFoods: 'Jouw vaste voedingsmiddelen',
+      usualRecipes: 'Jouw vaste recepten',
     },
     amount: 'Hoeveelheid',
     unit: 'Eenheid',


### PR DESCRIPTION
Closes #76

**Stacked on #95, which merges first.** This branch is cut from
`claude/add-sheet-polish-78-81-80` at `ed7c068` and targets it, so the diff
below is only this issue's work.

## What changed

The empty add sheet showed every recipe you own and none of your foods —
`foods.search` returns `[]` for an empty term, and the recipe list had no bound
on it. Both sections now come from your own diary.

**The ranking decision came from the triage comment on #76, which overrides the
issue body.** The body recommended most-recent-first as the cheapest option;
the comment folded in #73 and settled on **most chosen, within the meal being
logged**, ties broken on recency. Breakfast opens on breakfast things. That is
what is implemented.

- `rankMealChoices` + `suggestionWindowStart` in `convex/lib/servings.ts`,
  beside `rankLoggedAmounts` — pure, and the seam the tests sit at. Foods and
  recipes are counted separately because they are two sections logged in
  different units; a one-off references neither and counts towards nothing.
- `consumption.suggestionsForMeal({ date, meal })` — takes the meal because the
  answer differs by meal, and the date because the window is measured back from
  the day being logged. Yours alone, and a recipe you can no longer see drops
  out exactly as it does in `listForDay` (ADR-0003).
- `AddSheet` renders those two lists under **Your usual foods** / **Your usual
  recipes** while the search box is empty, and the search results under the
  existing headings once anything is typed. `recipes.listAcrossMyGroups` is now
  skipped until there is a term, so opening the sheet no longer reads every
  recipe you can see.

### How the window is bounded, and why

Two bounds, both cheap:

1. **A 60-day window** on the existing `by_user_date` index —
   `q.eq('userId', …).gte('date', since)`, descending. The triage comment
   preferred bounding the window over adding an index that leads with `meal`,
   and this needs no schema change. Sixty days is long enough that a habit kept
   a few times a week is obvious, short enough that one abandoned in spring is
   not still the first thing offered in autumn.
2. **A 400-row cap** on top of it, for the person who logs a dozen things a day
   and would otherwise turn "what do I have for breakfast" into a two-month
   scan. Rows come back newest-first, so what the cap drops is always the
   oldest of a very full window.

The window is applied *again* inside the pure function rather than trusted from
the index range, so the two cannot drift and a test can state it without a
database.

### Recipes bound, and `searchHint`

Both settled as the triage comment asked. Recipes get the **same bound of 8**
and the same ranking as foods — a recipe you have never logged is behind the
search box, not on the first screen. `add.searchHint` no longer requires "no
Combos *and* no Recipes" (which almost never held); it shows when there is
genuinely no history — no Combos, no suggested foods, no suggested recipes —
and waits for both queries to answer so it does not flash on the way to a full
sheet.

### Sample household

The fixtures did need adjusting: at 22 entries over 7 days almost everything
was logged exactly once, so the ranking would have been correct and looked
arbitrary. The diary is 14 days and 63 entries now, with a habit per meal —
porridge and milk most mornings, bread and cheddar at a desk, the chickpea
curry more often than any other dinner, a banana most days. `seed.test.ts`
asserts that through the real query, so an edit that flattens the fixtures
again fails rather than quietly demoing nothing.

## Tests

`pnpm typecheck`, `pnpm test` (1047 passing) and `pnpm check` all pass.

- `convex/lib/servings.test.ts` — frequency ordering, tie-broken-on-recency,
  the per-meal split, foods vs recipes counted apart, the window bound and the
  limit. This is the main target.
- `convex/consumption.test.ts` — the query against the in-memory backend with
  injected identity: per-meal ranking, the window, a never-logged recipe, a
  recipe the reader can no longer see, somebody else's diary, no session.
- `convex/seed.test.ts` — the seeded household actually demonstrates it.
- `src/components/nutrition/AddSheet.test.tsx` — what a person sees on the
  first screen, and that a person with no history gets the hint.

## Acceptance criteria I could not verify

#76 asks for it to be **driven on a phone, not only unit-tested**, and notes
this is exactly the defect class PR #72's tests failed to catch. I have no
device or browser in this environment, so:

- **Not verified: driven on a phone.** Nothing here was exercised in a real
  browser at all — not the sheet opening on a real deployment, not the sections
  at a phone width, not what the sheet feels like when the suggestions query
  resolves a moment after the Combos do.
- **Not verified: how it looks with a real diary.** The ranking is checked
  against fixtures and against the seeded household; nobody has opened it on a
  deployment with somebody's actual history in it.
- **Not verified: the 60-day window and the bound of 8 as *choices*.** Both are
  the numbers the triage comment named as starting points, and both are single
  constants — whether they are right is a judgement to make on a phone with a
  real diary, not from a test.

Worth driving on the preview at each meal in turn, and on a fresh account with
no history, before this is called done.

---
_Generated by [Claude Code](https://claude.ai/code/session_019w4UGLSzcg43osPSZycApg)_