### PR TITLE
Review an Open Food Facts import before it is saved, and offer to add a food when a search finds nothing

### DIFF
--- a/convex/foods.test.ts
+++ b/convex/foods.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { testConvex } from '../test/convexHarness'
 import { api } from './_generated/api'
 
@@ -478,5 +478,114 @@ describe('where a food’s figures came from', () => {
         nutritionPer100: { calories: 100 },
       }),
     ).rejects.toThrow()
+  })
+})
+
+/**
+ * Every Open Food Facts import is reviewed before it is saved (#93): choosing a
+ * result opens the pre-filled form, and *saving* is what imports the food and
+ * logs the entry.
+ *
+ * The property that makes that safe is the first one below — the lookup that
+ * fills the form is a read, all the way down. Somebody who opens the review and
+ * changes their mind leaves the database exactly as they found it: no orphaned
+ * food row, and no picture in storage. The picture is fetched by
+ * `importFromOff`, at the save, which is the only reason that can be true.
+ */
+describe('reviewing an import before it is saved', () => {
+  const product = {
+    status: 1,
+    product: {
+      code: '3017620422003',
+      product_name: 'Nutella',
+      brands: 'Ferrero',
+      nutriments: { 'energy-kcal_100g': 539 },
+      image_front_small_url:
+        'https://images.openfoodfacts.org/images/products/front.jpg',
+    },
+  }
+
+  async function signedIn() {
+    const t = testConvex()
+    await t.withIdentity(asAlice).mutation(api.users.ensureUser, {})
+    return t
+  }
+
+  /** What is actually in the database, whatever anybody meant to put there. */
+  async function contents(t: ReturnType<typeof testConvex>) {
+    return await t.run(async (ctx) => ({
+      foods: await ctx.db.query('foods').collect(),
+      files: await ctx.db.system.query('_storage').collect(),
+    }))
+  }
+
+  test('abandoning the form leaves no orphaned food and no stored picture', async () => {
+    const t = await signedIn()
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify(product), { status: 200 })),
+    )
+
+    try {
+      const mapped = await t
+        .withIdentity(asAlice)
+        .action(api.foodsLookup.lookupBarcode, { barcode: '3017620422003' })
+
+      // The form is filled from this, so it really did resolve the product —
+      // what follows is about a lookup that worked, not one that quietly
+      // did nothing.
+      expect(mapped?.name).toBe('Nutella')
+      expect(mapped?.imageUrl).toBeTruthy()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+
+    // …and then the person closed the form. Nothing was written, including the
+    // picture, which is still only a URL on Open Food Facts' servers.
+    const after = await contents(t)
+    expect(after.foods).toEqual([])
+    expect(after.files).toEqual([])
+  })
+
+  test('saving is what imports the food, and it carries the review’s answer', async () => {
+    const t = await signedIn()
+
+    // No picture on this product, so nothing is fetched — the same call the
+    // review form makes when it saves, minus the network. The person corrected
+    // a figure while reviewing, so the food must not go on claiming the
+    // numbers came off a packet.
+    const id = await t
+      .withIdentity(asAlice)
+      .action(api.foodsLookup.importFromOff, {
+        barcode: '3017620422003',
+        name: 'Nutella',
+        brand: 'Ferrero',
+        baseUnit: 'g',
+        nutritionPer100: { calories: 530 },
+        nutritionSource: 'manual',
+      })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.name).toBe('Nutella')
+    expect(food?.source).toBe('openfoodfacts')
+    expect(food?.nutritionSource).toBe('manual')
+  })
+
+  test('an import accepted as it stands still says the figures were imported', async () => {
+    const t = await signedIn()
+
+    const id = await t
+      .withIdentity(asAlice)
+      .action(api.foodsLookup.importFromOff, {
+        barcode: '3017620422003',
+        name: 'Nutella',
+        baseUnit: 'g',
+        nutritionPer100: { calories: 539 },
+      })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.nutritionSource).toBe('imported')
   })
 })

--- a/convex/foodsLookup.ts
+++ b/convex/foodsLookup.ts
@@ -5,7 +5,7 @@ import { api } from './_generated/api'
 import type { ActionCtx } from './_generated/server'
 import { action } from './_generated/server'
 import type { Id } from './_generated/dataModel'
-import { nutritionValidator } from './lib/nutrition'
+import { nutritionSourceValidator, nutritionValidator } from './lib/nutrition'
 import { fetchOffProduct, searchOffProducts } from './lib/offFetch'
 import { mapOffProduct, mapOffSearchResults } from './lib/offMapping'
 import { servingValidator } from './lib/servings'
@@ -143,6 +143,11 @@ export const importFromOff = action({
     nutritionPer100: nutritionValidator,
     servings: v.optional(v.array(servingValidator)),
     imageUrl: v.optional(v.string()),
+    // Carried through rather than assumed: every import is now reviewed in the
+    // food form before it is saved (#93), and somebody who corrected a figure
+    // in that form arrives here saying `manual`. Absent still means `imported`,
+    // which `foods.upsertFromOff` is the one to decide.
+    nutritionSource: v.optional(nutritionSourceValidator),
   },
   handler: async (ctx, args): Promise<Id<'foods'>> => {
     const identity = await ctx.auth.getUserIdentity()

--- a/src/components/foods/FoodForm.test.tsx
+++ b/src/components/foods/FoodForm.test.tsx
@@ -264,6 +264,49 @@ test('clearing the last figure takes the source note with it', () => {
   )
 })
 
+/**
+ * Open Food Facts holds products with no `product_name` at all, and
+ * `mapOffProduct` maps them rather than rejecting them — deliberately leaving
+ * the name "to the user on the confirmation screen". This form is that screen
+ * (#93), so the one thing it must not do is let a food called "" through.
+ */
+test('a product Open Food Facts has no name for cannot be saved unnamed', () => {
+  const onSubmit = vi.fn()
+  renderWithI18n(
+    <FoodForm
+      onSubmit={onSubmit}
+      submitting={false}
+      initial={{
+        name: '',
+        brand: 'Plus',
+        barcode: '8712345678901',
+        nutritionPer100: { calories: 78 },
+        nutritionSource: 'imported',
+      }}
+      sourceNote="From Open Food Facts — review before saving."
+    />,
+  )
+  // It arrives with the name empty and asked for, rather than filled in with
+  // something nobody chose.
+  const name = screen.getByLabelText('Name')
+  expect(name).toHaveValue('')
+  expect(name).toBeRequired()
+  expect(name).toBeInvalid()
+
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+  expect(onSubmit).not.toHaveBeenCalled()
+
+  fireEvent.change(name, { target: { value: 'Volkoren crackers' } })
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+  expect(onSubmit).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: 'Volkoren crackers',
+      barcode: '8712345678901',
+      nutritionSource: 'imported',
+    }),
+  )
+})
+
 test('a serving can be taken off again', () => {
   const onSubmit = vi.fn()
   renderWithI18n(

--- a/src/components/foods/FoodsPage.tsx
+++ b/src/components/foods/FoodsPage.tsx
@@ -32,7 +32,7 @@ export function FoodsPage({ nav }: { nav: FoodNav }) {
       <div className="mb-6 rounded-xl border p-4">
         <p className="mb-2 text-sm font-medium">{list.scanHeading}</p>
         <BarcodeScanner
-          onDetected={(barcode) => navigate(nav.create(barcode))}
+          onDetected={(barcode) => navigate(nav.create({ barcode }))}
         />
       </div>
 

--- a/src/components/foods/NewFoodPage.test.tsx
+++ b/src/components/foods/NewFoodPage.test.tsx
@@ -1,0 +1,196 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { beforeEach, expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
+import { groupFoodNav } from './foodNav'
+import { NewFoodPage } from './NewFoodPage'
+
+/**
+ * The one food editor, reached from three directions.
+ *
+ * Adding a food from the Foods module lands here, and so now do both of the
+ * routes the add sheet grew: reviewing an Open Food Facts result before it is
+ * imported (#93) and adding a food a search matched nothing for (#79). No
+ * second editor was built for either — what they supply is a prefill and a way
+ * back, and this is where both are answered.
+ */
+
+/** What `foodsLookup.lookupBarcode` finds on Open Food Facts. */
+const offProduct = vi.hoisted(() => ({ value: null as unknown }))
+/** What `foods.getByBarcode` finds locally. */
+const existingFood = vi.hoisted(() => ({ value: null as unknown }))
+const calls = vi.hoisted(() => ({ value: [] as Array<[string, unknown]> }))
+const navigated = vi.hoisted(() => ({ value: [] as unknown[] }))
+
+vi.mock('convex/react', () => ({
+  useMutation: (name: string) => async (args: unknown) => {
+    calls.value.push([name, args])
+    return 'food-new'
+  },
+  useAction: (name: string) => async (args: unknown) => {
+    if (name === 'foodsLookup:lookupBarcode') return offProduct.value
+    calls.value.push([name, args])
+    return 'food-new'
+  },
+  useConvex: () => ({ query: async () => existingFood.value }),
+}))
+
+vi.mock('../../../convex/_generated/api', () => ({
+  api: {
+    foods: {
+      get: 'foods:get',
+      getByBarcode: 'foods:getByBarcode',
+      create: 'foods:create',
+      upsertFromOff: 'foods:upsertFromOff',
+    },
+    foodsLookup: {
+      lookupBarcode: 'foodsLookup:lookupBarcode',
+      importFromOff: 'foodsLookup:importFromOff',
+    },
+  },
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => (link: unknown) => {
+    navigated.value.push(link)
+  },
+}))
+
+const nav = groupFoodNav('jansen-household')
+
+/** Where the add sheet for breakfast on the 18th sends somebody, and expects them back. */
+const returnsToBreakfast = (foodId: string) => ({
+  to: '/g/$groupSlug/nutrition/add' as const,
+  params: { groupSlug: 'jansen-household' },
+  search: { date: '2026-07-18', meal: 'breakfast' as const, food: foodId },
+})
+
+beforeEach(() => {
+  calls.value = []
+  navigated.value = []
+  offProduct.value = null
+  existingFood.value = null
+})
+
+test('the words a search found nothing for arrive as the name', async () => {
+  renderWithI18n(
+    <NewFoodPage name="hagelslag" after={returnsToBreakfast} nav={nav} />,
+  )
+
+  // Prefilled, not decided: it is a starting point somebody can type over.
+  expect(screen.getByLabelText('Name')).toHaveValue('hagelslag')
+  // Nothing has been written by arriving here.
+  expect(calls.value).toEqual([])
+})
+
+test('saving hands the person back to the meal they were adding to', async () => {
+  renderWithI18n(
+    <NewFoodPage name="hagelslag" after={returnsToBreakfast} nav={nav} />,
+  )
+  fireEvent.change(screen.getByLabelText('Calories (kcal)'), {
+    target: { value: '500' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+
+  await waitFor(() => expect(calls.value).toHaveLength(1))
+  expect(calls.value[0][0]).toBe('foods:create')
+  // Back to breakfast on the same day, carrying the food that now exists —
+  // not to the Catalog, and not to the diary in general.
+  await waitFor(() => expect(navigated.value).toHaveLength(1))
+  expect(navigated.value[0]).toEqual(returnsToBreakfast('food-new'))
+})
+
+test('with nowhere to go back to, a new food still lands on its own page', async () => {
+  // The Foods module's own "add manually", unchanged by any of this.
+  renderWithI18n(<NewFoodPage nav={nav} />)
+  fireEvent.change(screen.getByLabelText('Name'), {
+    target: { value: 'Hagelslag' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+
+  await waitFor(() => expect(navigated.value).toHaveLength(1))
+  expect(navigated.value[0]).toEqual(nav.detail('food-new'))
+})
+
+test('an Open Food Facts import is written only by the save, picture and all', async () => {
+  offProduct.value = {
+    name: 'Nutella',
+    brand: 'Ferrero',
+    nutritionPer100: { calories: 539 },
+    servings: [],
+    imageUrl: 'https://images.openfoodfacts.org/images/products/front.jpg',
+  }
+  renderWithI18n(
+    <NewFoodPage
+      barcode="3017620422003"
+      after={returnsToBreakfast}
+      nav={nav}
+    />,
+  )
+
+  await waitFor(() => expect(screen.getByDisplayValue('Nutella')).toBeDefined())
+  expect(screen.getByText(/From Open Food Facts/)).toBeDefined()
+  expect(screen.getByText('Barcode: 3017620422003')).toBeDefined()
+  // Looking at it is not importing it: leaving now leaves nothing behind, and
+  // the picture is still only a URL somewhere else.
+  expect(calls.value).toEqual([])
+
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+
+  await waitFor(() => expect(calls.value).toHaveLength(1))
+  // The action rather than the mutation, because the action is what fetches
+  // and stores the picture (#69) — which is how it still arrives with the food
+  // even though nothing was fetched until now.
+  expect(calls.value[0][0]).toBe('foodsLookup:importFromOff')
+  expect(calls.value[0][1]).toMatchObject({
+    barcode: '3017620422003',
+    name: 'Nutella',
+    brand: 'Ferrero',
+    nutritionPer100: { calories: 539 },
+    nutritionSource: 'imported',
+    imageUrl: 'https://images.openfoodfacts.org/images/products/front.jpg',
+  })
+  expect(navigated.value[0]).toEqual(returnsToBreakfast('food-new'))
+})
+
+test('a correction made while reviewing is what the import records', async () => {
+  offProduct.value = {
+    name: 'Nutella',
+    nutritionPer100: { calories: 539 },
+    servings: [],
+  }
+  renderWithI18n(<NewFoodPage barcode="3017620422003" nav={nav} />)
+  await waitFor(() => expect(screen.getByDisplayValue('Nutella')).toBeDefined())
+
+  fireEvent.change(screen.getByLabelText('Calories (kcal)'), {
+    target: { value: '530' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+
+  await waitFor(() => expect(calls.value).toHaveLength(1))
+  expect(calls.value[0][1]).toMatchObject({
+    nutritionPer100: { calories: 530 },
+    // The figures are the person's now, and the food must not go on saying
+    // they came off a packet.
+    nutritionSource: 'manual',
+  })
+})
+
+test('a scanned barcode you already have skips the review it has nothing to review', async () => {
+  existingFood.value = { _id: 'food9', name: 'Volle melk' }
+  renderWithI18n(
+    <NewFoodPage
+      barcode="8712345678901"
+      after={returnsToBreakfast}
+      nav={nav}
+    />,
+  )
+
+  await waitFor(() => expect(navigated.value).toHaveLength(1))
+  // Straight back to the meal with that food ready to log — not the food's
+  // page, which is not where somebody logging breakfast was going.
+  expect(navigated.value[0]).toMatchObject({
+    ...returnsToBreakfast('food9'),
+    replace: true,
+  })
+  expect(calls.value).toEqual([])
+})

--- a/src/components/foods/NewFoodPage.tsx
+++ b/src/components/foods/NewFoodPage.tsx
@@ -3,48 +3,73 @@ import { useAction, useConvex, useMutation } from 'convex/react'
 import { ConvexError } from 'convex/values'
 import { useEffect, useRef, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import type { AppLink } from '../../lib/appLink'
 import { useMessages } from '../../lib/i18n'
 import { FoodForm, type FoodFormValues } from './FoodForm'
 import type { FoodNav } from './foodNav'
 
 export interface NewFoodSearch {
   barcode?: string
+  name?: string
+  /** Where the add sheet that sent us here lives, so saving can go back (#93/#79). */
+  returnDate?: string
+  returnMeal?: string
 }
 
-/**
- * The scanned barcode, validated identically on both routes.
- *
- * The router's default search codec JSON.parses raw query values, so a
- * hand-typed/bookmarked/QR-code URL's bare-digit barcode (e.g.
- * `?barcode=3017620422003`, valid JSON as a *number*) parses as a number, not a
- * string — accept both so external deep links work the same as the in-app scan
- * flow's own JSON-quoted `navigate({ search: { barcode } })`.
- */
+/** A query value that is text, however the router's JSON codec read it. */
+function asString(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  // The router's default search codec JSON.parses raw query values, so a
+  // hand-typed/bookmarked/QR-code URL's bare-digit barcode (e.g.
+  // `?barcode=3017620422003`, valid JSON as a *number*) parses as a number, not
+  // a string — accept both so external deep links work the same as the in-app
+  // scan flow's own JSON-quoted `navigate({ search: { barcode } })`.
+  if (typeof value === 'number') return String(value)
+  return undefined
+}
+
+/** What the new-food route may be opened with, validated identically everywhere. */
 export function validateNewFoodSearch(
   search: Record<string, unknown>,
 ): NewFoodSearch {
   return {
-    barcode:
-      typeof search.barcode === 'string'
-        ? search.barcode
-        : typeof search.barcode === 'number'
-          ? String(search.barcode)
-          : undefined,
+    barcode: asString(search.barcode),
+    name: asString(search.name),
+    returnDate: asString(search.returnDate),
+    returnMeal: asString(search.returnMeal),
   }
 }
 
 export interface NewFoodPageProps {
   barcode?: string
+  /** Prefills the name, for a search that matched nothing (#79). */
+  name?: string
+  /**
+   * Where saving hands the person back to, given the food that now exists.
+   *
+   * Absent means the food's own page, which is where adding a food from the
+   * Foods module has always landed. The add sheet supplies one so that
+   * importing or adding a food *while logging breakfast* returns to breakfast
+   * with the food ready to log, rather than stranding somebody in the Catalog
+   * (#93, #79). Built by the route, which is the only thing that knows both
+   * Modules' addresses.
+   */
+  after?: (foodId: Id<'foods'>) => AppLink
   nav: FoodNav
 }
 
 /** Adding a food to the Catalog, whole. Shared by both `new` routes. */
-export function NewFoodPage({ barcode, nav }: NewFoodPageProps) {
+export function NewFoodPage({ barcode, name, after, nav }: NewFoodPageProps) {
   const navigate = useNavigate()
   const convex = useConvex()
   const lookupBarcode = useAction(api.foodsLookup.lookupBarcode)
   const create = useMutation(api.foods.create)
-  const upsertFromOff = useMutation(api.foods.upsertFromOff)
+  // An action rather than the mutation, because an Open Food Facts save is
+  // where the product's picture is fetched and stored (#69). Fetching it here,
+  // at the save, rather than when the form was opened, is what makes abandoning
+  // the review leave no stored picture behind (#93).
+  const importFromOff = useAction(api.foodsLookup.importFromOff)
   const { create: createText, form } = useMessages().foods
 
   const [submitting, setSubmitting] = useState(false)
@@ -53,8 +78,12 @@ export function NewFoodPage({ barcode, nav }: NewFoodPageProps) {
   const [prefill, setPrefill] = useState<{
     values: Partial<FoodFormValues>
     version: number
-  }>({ values: { barcode }, version: 0 })
+  }>({ values: { barcode, name }, version: 0 })
   const [sourceNote, setSourceNote] = useState<string | undefined>()
+  // Where Open Food Facts keeps this product's picture. Held rather than
+  // fetched: nothing is stored until the save, so a review that is abandoned
+  // leaves no blob behind (#93).
+  const [offImageUrl, setOffImageUrl] = useState<string | undefined>()
   // Non-blocking — shown alongside the (still fully usable) blank form when
   // OFF times out or is unreachable, per spec §6 ("same as not-found, plus
   // a non-blocking error toast"). Distinct from `error`, which is reserved
@@ -72,7 +101,11 @@ export function NewFoodPage({ barcode, nav }: NewFoodPageProps) {
     ;(async () => {
       const existing = await convex.query(api.foods.getByBarcode, { barcode })
       if (existing) {
-        navigate({ ...nav.detail(existing._id), replace: true })
+        // A barcode you already have is not an import, so there is nothing to
+        // review — and if somebody came from the add sheet to log it, that is
+        // where they wanted to be, not on the food's page (#93).
+        const to = after ? after(existing._id) : nav.detail(existing._id)
+        navigate({ ...to, replace: true })
         return
       }
       try {
@@ -91,6 +124,7 @@ export function NewFoodPage({ barcode, nav }: NewFoodPageProps) {
             },
             version: Date.now(),
           })
+          setOffImageUrl(mapped.imageUrl)
           setSourceNote(createText.fromOff)
         }
       } catch {
@@ -131,13 +165,14 @@ export function NewFoodPage({ barcode, nav }: NewFoodPageProps) {
           setSubmitting(true)
           setError(null)
           try {
-            const id = sourceNote
-              ? await upsertFromOff({
+            const id: Id<'foods'> = sourceNote
+              ? await importFromOff({
                   ...values,
                   barcode: values.barcode as string,
+                  imageUrl: offImageUrl,
                 })
               : await create(values)
-            navigate(nav.detail(id))
+            navigate(after ? after(id) : nav.detail(id))
           } catch (err) {
             setError(
               err instanceof ConvexError

--- a/src/components/foods/foodNav.ts
+++ b/src/components/foods/foodNav.ts
@@ -39,13 +39,20 @@ export interface FoodNav {
 export function groupFoodNav(groupSlug: string): FoodNav {
   return {
     list: groupLink('foods', groupSlug),
+    // Only the parts there are: a key carrying `undefined` is a query parameter
+    // in some serialisers and nothing in others, and `/foods/new` with no
+    // intent is one address rather than four spellings of it.
     create: (intent) => ({
       ...groupLink('newFood', groupSlug),
       search: {
-        barcode: intent?.barcode,
-        name: intent?.name,
-        returnDate: intent?.returnTo?.date,
-        returnMeal: intent?.returnTo?.meal,
+        ...(intent?.barcode ? { barcode: intent.barcode } : {}),
+        ...(intent?.name ? { name: intent.name } : {}),
+        ...(intent?.returnTo
+          ? {
+              returnDate: intent.returnTo.date,
+              returnMeal: intent.returnTo.meal,
+            }
+          : {}),
       },
     }),
     detail: (foodId) => groupLink('food', groupSlug, { foodId }),

--- a/src/components/foods/foodNav.ts
+++ b/src/components/foods/foodNav.ts
@@ -9,10 +9,29 @@ import { groupLink } from '../../lib/groupPaths'
  * It still has to be carried, because leaving it out would silently drop
  * whoever followed the link out of the Group they were browsing.
  */
+/**
+ * What is already known about the food somebody is about to add.
+ *
+ * All three parts are optional and independent: a scan knows the barcode, a
+ * search that found nothing knows the words that were typed, and either can
+ * have been reached from somewhere that wants the person back afterwards.
+ *
+ * `returnTo` is deliberately the *day and meal*, not a URL: the only place that
+ * sends anyone here expecting them back is the add sheet, which is addressable
+ * by exactly those two (#66). Keeping it as data rather than as a serialised
+ * link is what stops an arbitrary destination riding in on a query string.
+ */
+export interface NewFoodIntent {
+  barcode?: string
+  /** Prefills the name — the term a search matched nothing for (#79). */
+  name?: string
+  returnTo?: { date: string; meal: string }
+}
+
 export interface FoodNav {
   list: AppLink
-  /** Adding a food, optionally prefilled from a scanned barcode. */
-  create: (barcode?: string) => AppLink
+  /** Adding a food, optionally prefilled and optionally with a way back. */
+  create: (intent?: NewFoodIntent) => AppLink
   detail: (foodId: string) => AppLink
   edit: (foodId: string) => AppLink
 }
@@ -20,9 +39,14 @@ export interface FoodNav {
 export function groupFoodNav(groupSlug: string): FoodNav {
   return {
     list: groupLink('foods', groupSlug),
-    create: (barcode) => ({
+    create: (intent) => ({
       ...groupLink('newFood', groupSlug),
-      search: { barcode },
+      search: {
+        barcode: intent?.barcode,
+        name: intent?.name,
+        returnDate: intent?.returnTo?.date,
+        returnMeal: intent?.returnTo?.meal,
+      },
     }),
     detail: (foodId) => groupLink('food', groupSlug, { foodId }),
     edit: (foodId) => groupLink('editFood', groupSlug, { foodId }),

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -62,6 +62,8 @@ const offResults = vi.hoisted(() => ({
 }))
 /** What `foods.getByBarcode` finds, for the "this is already in your library" path. */
 const existingFood = vi.hoisted(() => ({ value: null as unknown }))
+/** What `foods.get` finds for the food a review form just handed back. */
+const justAddedFood = vi.hoisted(() => ({ value: null as unknown }))
 /** What `foodsLookup.lookupBarcode` finds on Open Food Facts. */
 const offProduct = vi.hoisted(() => ({ value: null as unknown }))
 const calls = vi.hoisted(() => ({ value: [] as Array<[string, unknown]> }))
@@ -77,6 +79,9 @@ vi.mock('convex/react', () => ({
     }
     if (name === 'foods:getByBarcode') {
       return args === 'skip' ? undefined : existingFood.value
+    }
+    if (name === 'foods:get') {
+      return args === 'skip' ? undefined : justAddedFood.value
     }
     if (name === 'recipes:listAcrossMyGroups') return recipes.value
     if (name === 'combos:list') return combos.value
@@ -121,17 +126,58 @@ vi.mock('../../../convex/_generated/api', () => ({
   },
 }))
 
+/** Where a `<Link>` or a `navigate()` would have taken us. */
+const navigated = vi.hoisted(() => ({ value: [] as unknown[] }))
+
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children }: { children: React.ReactNode }) => (
-    <a href="/">{children}</a>
+  Link: ({
+    children,
+    to,
+    params,
+    search,
+  }: {
+    children: React.ReactNode
+    to: string
+    params?: Record<string, string>
+    search?: Record<string, string>
+  }) => (
+    <a href={href({ to, params, search })} data-search={JSON.stringify(search)}>
+      {children}
+    </a>
   ),
+  useNavigate: () => (link: unknown) => {
+    navigated.value.push(link)
+  },
 }))
+
+function href({
+  to,
+  params,
+  search,
+}: {
+  to: string
+  params?: Record<string, string>
+  search?: Record<string, string>
+}) {
+  const path = Object.entries(params ?? {}).reduce(
+    (acc, [key, value]) => acc.replace(`$${key}`, value),
+    to,
+  )
+  const query = new URLSearchParams(search ?? {}).toString()
+  return query ? `${path}?${query}` : path
+}
 
 const nav = groupNutritionNav('jansen-household')
 
-function renderSheet(onClose = vi.fn()) {
+function renderSheet(onClose = vi.fn(), justAddedFoodId?: string) {
   renderWithI18n(
-    <AddSheet date="2026-07-18" meal="breakfast" nav={nav} onClose={onClose} />,
+    <AddSheet
+      date="2026-07-18"
+      meal="breakfast"
+      justAddedFoodId={justAddedFoodId}
+      nav={nav}
+      onClose={onClose}
+    />,
   )
   return onClose
 }
@@ -144,11 +190,30 @@ async function search(term: string) {
 
 beforeEach(() => {
   calls.value = []
+  navigated.value = []
   loggedAmounts.value = []
   combos.value = []
   existingFood.value = null
+  justAddedFood.value = null
   offProduct.value = null
+  // jsdom has no `navigator.mediaDevices`, which is what the scanner asks for
+  // first. A stand-in that refuses is the state a phone with the camera denied
+  // is in, and it leaves the manual barcode entry — the part this suite drives.
+  if (!navigator.mediaDevices) {
+    Object.defineProperty(navigator, 'mediaDevices', {
+      value: { getUserMedia: vi.fn().mockRejectedValue(new Error('no camera')) },
+      configurable: true,
+    })
+  }
 })
+
+/** Drive the scanner the way a phone would, minus the camera. */
+async function scan(barcode: string) {
+  fireEvent.click(screen.getByText('Scan'))
+  const field = await screen.findByLabelText('Or enter the barcode number')
+  fireEvent.change(field, { target: { value: barcode } })
+  fireEvent.click(screen.getByText('Look up'))
+}
 
 test('a barcode you already have is shown from your own rows', async () => {
   // Somebody edited these figures after importing this row once. Typing the
@@ -239,9 +304,28 @@ test('digits still being typed are an ordinary search, not a lookup', async () =
   expect(screen.queryByText('Volle melk')).toBeNull()
 })
 
-test('an Open Food Facts result already in your library logs that food’s own figures', async () => {
-  // Somebody corrected this row by hand after importing it; the entry has to
-  // snapshot the food it references, not the search result it was picked from.
+test('choosing an Open Food Facts result opens the review form and writes nothing', async () => {
+  renderSheet()
+  await search('volle melk')
+  await waitFor(() => expect(screen.getByText('Open Food Facts')).toBeDefined())
+  fireEvent.click(screen.getByText('Volle melk'))
+
+  // No serving picker, no confirm: there is nothing to log yet, because there
+  // is no food yet. What is offered is the review that would make one.
+  expect(screen.queryByText('Add to diary')).toBeNull()
+  const review = screen.getByText('Check and add')
+  expect(review).toHaveAttribute(
+    'href',
+    '/g/jansen-household/foods/new?barcode=8712345678901&returnDate=2026-07-18&returnMeal=breakfast',
+  )
+  // Following it is a navigation, not a write. Nothing has been imported and
+  // nothing has been logged.
+  expect(calls.value).toEqual([])
+})
+
+test('a scanned barcode you already have skips review entirely', async () => {
+  // The one-tap path #63/#66 built: this is not an import, so it does not go
+  // anywhere — it opens where it stands, ready to log.
   existingFood.value = {
     _id: 'food9',
     name: 'Volle melk',
@@ -249,21 +333,77 @@ test('an Open Food Facts result already in your library logs that food’s own f
     nutritionPer100: { calories: 100 },
   }
   renderSheet()
-  await search('volle melk')
-  await waitFor(() => expect(screen.getByText('Volle melk')).toBeDefined())
-  fireEvent.click(screen.getByText('Volle melk'))
-  fireEvent.change(screen.getByLabelText('Amount'), {
-    target: { value: '200' },
+  await scan('8712345678901')
+
+  await waitFor(() => expect(screen.getByText('Scanned')).toBeDefined())
+  expect(navigated.value).toEqual([])
+  fireEvent.click(screen.getByText('Add to diary'))
+
+  await waitFor(() => expect(calls.value).toHaveLength(1))
+  expect(calls.value[0][1]).toMatchObject({ foodId: 'food9' })
+})
+
+test('a scanned product nobody has is reviewed before anything is written', async () => {
+  offProduct.value = {
+    name: 'Nutella',
+    brand: 'Ferrero',
+    nutritionPer100: { calories: 539 },
+  }
+  renderSheet()
+  await scan('3017620422003')
+
+  await waitFor(() => expect(navigated.value).toHaveLength(1))
+  expect(navigated.value[0]).toMatchObject({
+    to: '/g/$groupSlug/foods/new',
+    search: {
+      barcode: '3017620422003',
+      returnDate: '2026-07-18',
+      returnMeal: 'breakfast',
+    },
   })
+  expect(calls.value).toEqual([])
+})
+
+test('a scanned product with no name is asked about rather than imported as ""', async () => {
+  // `mapOffProduct` maps a product with no `product_name` rather than
+  // rejecting it, deliberately leaving the name "to the user on the
+  // confirmation screen". This path used to have no confirmation screen, and
+  // sent the mapping straight to the import — silently saving a food called
+  // "". The review form *is* that screen, and its name field is required, so
+  // the name is supplied before anything is written.
+  offProduct.value = { name: '', brand: 'Plus', nutritionPer100: {} }
+  renderSheet()
+  await scan('8712345678901')
+
+  await waitFor(() => expect(navigated.value).toHaveLength(1))
+  expect(navigated.value[0]).toMatchObject({
+    to: '/g/$groupSlug/foods/new',
+    search: { barcode: '8712345678901' },
+  })
+  expect(calls.value).toEqual([])
+})
+
+test('the food a review form just saved comes back expanded and ready to log', async () => {
+  justAddedFood.value = {
+    _id: 'food9',
+    name: 'Volle melk',
+    baseUnit: 'ml',
+    nutritionPer100: { calories: 64 },
+  }
+  renderSheet(vi.fn(), 'food9')
+
+  await waitFor(() => expect(screen.getByText('Just added')).toBeDefined())
+  // Already open: the amount is on screen without anybody tapping the card.
+  expect(screen.getAllByLabelText('Amount')[0]).toHaveValue('100')
   fireEvent.click(screen.getByText('Add to diary'))
 
   await waitFor(() => expect(calls.value).toHaveLength(1))
   expect(calls.value[0][1]).toMatchObject({
     foodId: 'food9',
-    quantity: 200,
+    label: 'Volle melk',
+    quantity: 100,
     quantityUnit: 'ml',
-    // 200 ml of the *food's* 100 kcal/100 ml, not the result's 64.
-    nutrition: { calories: 200 },
+    nutrition: { calories: 64 },
   })
 })
 
@@ -380,6 +520,26 @@ test('a search matching nothing offers the typed term as a one-off', async () =>
     quantityUnit: 'piece',
     nutrition: { calories: 400 },
   })
+})
+
+test('a search matching nothing also offers adding it as a food', async () => {
+  // A one-off is right for a restaurant meal and wrong for a product you will
+  // eat again next week: logged once, never findable, so the same search finds
+  // nothing again. Both routes carry the words already typed (#79).
+  renderSheet()
+  await search('hagelslag')
+
+  await waitFor(() =>
+    expect(screen.getByText('Nothing found for “hagelslag”')).toBeDefined(),
+  )
+  expect(screen.getByText('Log “hagelslag” as a one-off')).toBeDefined()
+  const addFood = screen.getByText('Add “hagelslag” to my foods')
+  expect(addFood).toHaveAttribute(
+    'href',
+    '/g/jansen-household/foods/new?name=hagelslag&returnDate=2026-07-18&returnMeal=breakfast',
+  )
+  // Offering it is not taking it: nothing is written by looking at the choice.
+  expect(calls.value).toEqual([])
 })
 
 test('a food’s named servings are the way an amount is chosen', async () => {

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -201,7 +201,9 @@ beforeEach(() => {
   // is in, and it leaves the manual barcode entry — the part this suite drives.
   if (!navigator.mediaDevices) {
     Object.defineProperty(navigator, 'mediaDevices', {
-      value: { getUserMedia: vi.fn().mockRejectedValue(new Error('no camera')) },
+      value: {
+        getUserMedia: vi.fn().mockRejectedValue(new Error('no camera')),
+      },
       configurable: true,
     })
   }

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@tanstack/react-router'
+import { Link, useNavigate } from '@tanstack/react-router'
 import { useAction, useConvex, useMutation, useQuery } from 'convex/react'
 import { type ReactNode, useRef, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
@@ -11,12 +11,10 @@ import {
 } from '../../../convex/lib/consumption'
 import type { NutritionFacts } from '../../../convex/lib/nutrition'
 import { barcodeTerm } from '../../../convex/lib/offFetch'
-import type {
-  OffMappedFood,
-  OffSearchResult,
-} from '../../../convex/lib/offMapping'
+import type { OffSearchResult } from '../../../convex/lib/offMapping'
 import type { Serving } from '../../../convex/lib/servings'
 import { offeredServings, resolveAmount } from '../../../convex/lib/servings'
+import type { AppLink } from '../../lib/appLink'
 import { errorMessage } from '../../lib/errorMessage'
 import { fmt, useMessages } from '../../lib/i18n'
 import { BarcodeScanner } from '../foods/BarcodeScanner'
@@ -68,6 +66,12 @@ interface FoodSummary {
 interface Props {
   date: string
   meal: MealName
+  /**
+   * The food a review form just saved and handed back (#93/#79). It opens
+   * expanded and ready to log, so reviewing an import reads as a step inside
+   * logging rather than a detour through the Catalog.
+   */
+  justAddedFoodId?: string
   nav: NutritionNav
   onClose: () => void
 }
@@ -82,17 +86,30 @@ interface Props {
  * it is what the empty result offers you, with the term you already typed as
  * the label.
  */
-export function AddSheet({ date, meal, nav, onClose }: Props) {
+export function AddSheet({
+  date,
+  meal,
+  justAddedFoodId,
+  nav,
+  onClose,
+}: Props) {
   const search = useFoodSearch()
   const term = search.term.trim()
   const recipes = useQuery(api.recipes.listAcrossMyGroups, {})
   const combos = useQuery(api.combos.list, {})
+  // The food a review form just saved. Read back rather than carried in the
+  // URL, because what is logged has to be the row as it was written — the form
+  // is where somebody may have corrected the figures.
+  const justAdded = useQuery(
+    api.foods.get,
+    justAddedFoodId ? { id: justAddedFoodId as Id<'foods'> } : 'skip',
+  )
   const createEntry = useMutation(api.consumption.create)
   const createEntries = useMutation(api.consumption.createMany)
   const replaceComboItems = useMutation(api.combos.replaceItems)
-  const importFromOff = useAction(api.foodsLookup.importFromOff)
   const lookupBarcode = useAction(api.foodsLookup.lookupBarcode)
   const convex = useConvex()
+  const navigate = useNavigate()
   const { announce } = useJustLogged()
   const messages = useMessages()
   const { add, foodAdd, meals } = {
@@ -101,7 +118,9 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
   }
 
   const searchRef = useRef<HTMLInputElement>(null)
-  const [expanded, setExpanded] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState<string | null>(
+    justAddedFoodId ? `food:${justAddedFoodId}` : null,
+  )
   const [comboBusy, setComboBusy] = useState(false)
   const [comboError, setComboError] = useState<string | null>(null)
   const [promotions, setPromotions] = useState(0)
@@ -129,31 +148,28 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
     onClose()
   }
 
-  // A barcode's product may already have a local row that a name search would
-  // not have surfaced. Reuse it rather than importing over it — the import
-  // would replace its name, nutrition and base unit with the mapped data.
-  async function importOff(
-    mapped: OffMappedFood,
-    barcode: string,
-  ): Promise<FoodSummary> {
-    const existing = await convex.query(api.foods.getByBarcode, { barcode })
-    if (existing) return existing
-    // An action rather than the mutation, because this is where the product's
-    // picture is fetched and stored (#69).
-    const id = await importFromOff({
-      barcode,
-      name: mapped.name,
-      brand: mapped.brand,
-      baseUnit: 'g',
-      nutritionPer100: mapped.nutritionPer100,
-      servings: mapped.servings,
-      imageUrl: mapped.imageUrl,
-    })
-    const saved = await convex.query(api.foods.get, { id })
-    if (!saved) throw new Error(foodAdd.addFailed)
-    return saved
+  /**
+   * Reviewing a food before it exists: the pre-filled form, with the day and
+   * the meal along for the ride so saving comes back here (#93/#79).
+   *
+   * There is no second editor and no second prefill. `NewFoodPage` already
+   * resolves a barcode against Open Food Facts and fills the form from the
+   * mapping, so an import is a *link to it*, not a copy of it.
+   */
+  function review(intent: { barcode?: string; name?: string }) {
+    return nav.createFood({ ...intent, returnTo: { date, meal } })
   }
 
+  /**
+   * A scanned barcode.
+   *
+   * A product you already have is not an import: it goes straight to the
+   * expanded card, ready to log, which is the one-tap path #63/#66 built. A
+   * product that is *new* is an import, and every import is reviewed before
+   * anything is written (#93) — including the Open Food Facts products that
+   * carry no `product_name` at all, which used to be imported under the name
+   * `""` because nothing on this path ever asked.
+   */
   async function onBarcode(barcode: string) {
     setScanFailure(null)
     try {
@@ -170,10 +186,8 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
         setScanFailure({ barcode })
         return
       }
-      const imported = await importOff(mapped, barcode)
-      setScanned(imported)
-      setExpanded(`food:${imported._id}`)
       setScanning(false)
+      navigate(review({ barcode }))
     } catch {
       setScanFailure({ message: foodAdd.barcodeFailed })
     }
@@ -337,7 +351,7 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
       {scanFailure && (
         <p className="mb-3 text-xs opacity-60">
           {scanFailure.message ?? (
-            <NoSuchBarcode barcode={scanFailure.barcode} nav={nav} />
+            <NoSuchBarcode barcode={scanFailure.barcode} createFood={review} />
           )}
         </p>
       )}
@@ -356,6 +370,17 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
               onLog={(counts, modified) => logCombo(combo, counts, modified)}
             />
           ))}
+        </Section>
+      )}
+
+      {justAdded && (
+        <Section title={add.sections.justAdded}>
+          <FoodCard
+            food={justAdded}
+            expanded={expanded === `food:${justAdded._id}`}
+            onToggle={() => toggle(`food:${justAdded._id}`)}
+            onLog={log}
+          />
         </Section>
       )}
 
@@ -417,8 +442,7 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
               result={result}
               expanded={expanded === `off:${result.barcode}`}
               onToggle={() => toggle(`off:${result.barcode}`)}
-              onImport={importOff}
-              onLog={log}
+              reviewLink={review({ barcode: result.barcode })}
             />
           ))}
         </Section>
@@ -427,9 +451,15 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
       {foundNothing &&
         (searchedBarcode ? (
           <p className="py-2 text-xs opacity-60">
-            <NoSuchBarcode barcode={searchedBarcode} nav={nav} />
+            <NoSuchBarcode barcode={searchedBarcode} createFood={review} />
           </p>
         ) : (
+          // Two routes, both carrying the words already typed. A one-off is
+          // right for a restaurant meal and wrong for a product you will eat
+          // again next week — that one is logged once and can never be found
+          // again, so the next search for the same words offers a one-off
+          // again (#79). Which of the two this is is a thing only the person
+          // knows, so both are offered rather than guessed at.
           <Section title={fmt(add.nothingFound, { term })}>
             <OneOffCard
               term={term}
@@ -437,6 +467,14 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
               onToggle={() => toggle('one-off')}
               onLog={log}
             />
+            <li>
+              <Link
+                {...review({ name: term })}
+                className="flex min-h-14 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 py-2 text-sm no-underline"
+              >
+                {fmt(add.addAsFood, { term })}
+              </Link>
+            </li>
           </Section>
         ))}
 
@@ -456,16 +494,16 @@ export function AddSheet({ date, meal, nav, onClose }: Props) {
  */
 function NoSuchBarcode({
   barcode,
-  nav,
+  createFood,
 }: {
   barcode: string | undefined
-  nav: NutritionNav
+  createFood: (intent: { barcode?: string }) => AppLink
 }) {
   const { foodAdd } = useMessages().nutrition.diary
   return (
     <>
       {foodAdd.notFound}{' '}
-      <Link {...nav.createFood(barcode)} className="underline">
+      <Link {...createFood({ barcode })} className="underline">
         {foodAdd.addToLibrary}
       </Link>{' '}
       {foodAdd.addToLibraryAfter}
@@ -700,33 +738,28 @@ function RecipeCard({
 }
 
 /**
- * An Open Food Facts result is not a food yet. Confirming imports it — which is
- * what puts it in your own library for next time — and then logs it.
+ * An Open Food Facts result is not a food yet, and choosing one does not make
+ * it one: it opens the food form pre-filled from the mapping, and *saving* is
+ * what imports the food and logs the entry (#93).
+ *
+ * This card writes nothing at all, which is the whole point. Open Food Facts
+ * data is thin often enough — a missing nutrient, no serving, an unhelpful or
+ * absent name — that logging something wrong quickly is worse than logging
+ * something right slowly. The one-tap path is still there through your own
+ * foods and Combos, which is where repeats live.
  */
 function OffCard({
   result,
   expanded,
   onToggle,
-  onImport,
-  onLog,
+  reviewLink,
 }: {
   result: OffSearchResult
   expanded: boolean
   onToggle: () => void
-  onImport: (mapped: OffMappedFood, barcode: string) => Promise<FoodSummary>
-  onLog: LogFn
+  reviewLink: AppLink
 }) {
-  const { add, foodAdd } = useMessages().nutrition.diary
-  // An Open Food Facts result is always in grams: it is not a food of yours
-  // yet, so it has no base unit of its own and no history behind it.
-  const offUnit = { ...result, baseUnit: 'g' as const }
-  const offered = offeredServings(offUnit)
-  const [selection, setSelection] = useState<ServingSelection | null>(null)
-  const current = selection ?? initialSelection(offered)
-  const { busy, error, run } = useLogging()
-
-  const choice = toChoice(offered, current)
-  const resolved = choice ? resolveAmount(offUnit, choice) : undefined
+  const { foodAdd } = useMessages().nutrition.diary
 
   return (
     <ResultCard
@@ -743,45 +776,15 @@ function OffCard({
       expanded={expanded}
       onToggle={onToggle}
     >
-      <ServingPicker
-        baseUnit="g"
-        offered={offered}
-        selection={current}
-        onSelect={setSelection}
-      />
+      {/* What Open Food Facts has, per 100, before anybody agrees to it —
+          which is exactly what the review form opens holding. */}
+      <NutritionBreakdown facts={result.nutritionPer100} />
+      <p className="mt-3 text-xs opacity-60">{foodAdd.reviewHint}</p>
       <div className="mt-3">
-        <NutritionBreakdown facts={resolved?.nutrition ?? {}} />
+        <Link {...reviewLink} className={`${confirmClass} inline-block py-2.5`}>
+          {foodAdd.review}
+        </Link>
       </div>
-      <Confirm
-        disabled={!resolved}
-        reason={add.enterAmount}
-        busy={busy}
-        error={error}
-        onConfirm={() =>
-          run(async () => {
-            if (!resolved) return
-            const food = await onImport(result, result.barcode)
-            // The import may hand back a row that already existed — one
-            // somebody has since corrected by hand, or that carries different
-            // figures from this result's. The entry must snapshot the food it
-            // references, not the search result it was chosen from, or a later
-            // quantity edit recomputes to figures the entry never had.
-            const logged = resolveAmount(food, {
-              kind: 'custom',
-              value: resolved.amount,
-              unit: 'base',
-            })
-            if (!logged) return
-            await onLog({
-              foodId: food._id,
-              label: food.name,
-              quantity: logged.amount,
-              quantityUnit: food.baseUnit,
-              nutrition: logged.nutrition,
-            })
-          })
-        }
-      />
     </ResultCard>
   )
 }

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -86,13 +86,7 @@ interface Props {
  * it is what the empty result offers you, with the term you already typed as
  * the label.
  */
-export function AddSheet({
-  date,
-  meal,
-  justAddedFoodId,
-  nav,
-  onClose,
-}: Props) {
+export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
   const search = useFoodSearch()
   const term = search.term.trim()
   const recipes = useQuery(api.recipes.listAcrossMyGroups, {})

--- a/src/components/nutrition/nutritionNav.ts
+++ b/src/components/nutrition/nutritionNav.ts
@@ -46,7 +46,10 @@ export function groupNutritionNav(groupSlug: string): NutritionNav {
     createFood: foods.create,
     addEntry: (date, meal, foodId) => ({
       ...groupLink('addFood', groupSlug),
-      search: { date, meal, food: foodId },
+      // The food only when there is one: a key carrying `undefined` is a query
+      // parameter in some serialisers and nothing in others, and the sheet's
+      // address should not depend on which.
+      search: { date, meal, ...(foodId ? { food: foodId } : {}) },
     }),
   }
 }

--- a/src/components/nutrition/nutritionNav.ts
+++ b/src/components/nutrition/nutritionNav.ts
@@ -1,7 +1,7 @@
 import type { MealName } from '../../../convex/lib/consumption'
 import type { AppLink } from '../../lib/appLink'
 import { groupLink } from '../../lib/groupPaths'
-import { groupFoodNav } from '../foods/foodNav'
+import { groupFoodNav, type NewFoodIntent } from '../foods/foodNav'
 import { groupRecipeNav } from '../recipes/recipeNav'
 
 /**
@@ -16,15 +16,25 @@ import { groupRecipeNav } from '../recipes/recipeNav'
 export interface NutritionNav {
   recipe: (recipeId: string) => AppLink
   food: (foodId: string) => AppLink
-  /** Adding a scanned barcode the Catalog does not have yet. */
-  createFood: (barcode?: string) => AppLink
+  /**
+   * Adding a food the Catalog does not have yet — a scanned barcode, an Open
+   * Food Facts result being reviewed before it is saved (#93), or the words a
+   * search matched nothing for (#79). `returnTo` is what brings the person
+   * back to the meal they were adding to once it is saved.
+   */
+  createFood: (intent?: NewFoodIntent) => AppLink
   /**
    * The add sheet, which is an address of its own carrying the day and the
    * meal. It is inside Nutrition rather than out of it, but it arrives the same
    * way as the rest for the same reason: the page has no slug to build one
    * with.
+   *
+   * `foodId` is the food a just-finished form handed back: the sheet opens with
+   * that card expanded and ready to log, which is what makes reviewing an
+   * import feel like a step in logging rather than a detour through the
+   * Catalog.
    */
-  addEntry: (date: string, meal: MealName) => AppLink
+  addEntry: (date: string, meal: MealName, foodId?: string) => AppLink
 }
 
 export function groupNutritionNav(groupSlug: string): NutritionNav {
@@ -34,9 +44,9 @@ export function groupNutritionNav(groupSlug: string): NutritionNav {
     recipe: recipes.detail,
     food: foods.detail,
     createFood: foods.create,
-    addEntry: (date, meal) => ({
+    addEntry: (date, meal, foodId) => ({
       ...groupLink('addFood', groupSlug),
-      search: { date, meal },
+      search: { date, meal, food: foodId },
     }),
   }
 }

--- a/src/lib/groupNav.test.ts
+++ b/src/lib/groupNav.test.ts
@@ -81,11 +81,6 @@ describe('links built for a Group', () => {
   test('a search param survives being given the Group treatment', () => {
     expect(
       groupFoodNav(SLUG).create({ barcode: '3017620422003' }).search,
-    ).toEqual({
-      barcode: '3017620422003',
-      name: undefined,
-      returnDate: undefined,
-      returnMeal: undefined,
-    })
+    ).toEqual({ barcode: '3017620422003' })
   })
 })

--- a/src/lib/groupNav.test.ts
+++ b/src/lib/groupNav.test.ts
@@ -25,7 +25,7 @@ function foodDestinations(nav: FoodNav): AppLink[] {
   return [
     nav.list,
     nav.create(),
-    nav.create('3017620422003'),
+    nav.create({ barcode: '3017620422003' }),
     nav.detail('f1'),
     nav.edit('f1'),
   ]
@@ -79,8 +79,13 @@ describe('links built for a Group', () => {
   })
 
   test('a search param survives being given the Group treatment', () => {
-    expect(groupFoodNav(SLUG).create('3017620422003').search).toEqual({
+    expect(
+      groupFoodNav(SLUG).create({ barcode: '3017620422003' }).search,
+    ).toEqual({
       barcode: '3017620422003',
+      name: undefined,
+      returnDate: undefined,
+      returnMeal: undefined,
     })
   })
 })

--- a/src/lib/i18n/messages/en/nutrition.ts
+++ b/src/lib/i18n/messages/en/nutrition.ts
@@ -70,6 +70,8 @@ export const diary = {
     hideScanner: 'Hide scanner',
     sections: {
       scanned: 'Scanned',
+      /** The food a review form just saved, handed back ready to log (#93/#79). */
+      justAdded: 'Just added',
       foods: 'Your foods',
       recipes: 'Recipes',
       off: 'Open Food Facts',
@@ -85,6 +87,12 @@ export const diary = {
     nothingFound: 'Nothing found for “{term}”',
     oneOffTitle: 'Log “{term}” as a one-off',
     oneOffHint: 'Fill in whatever figures you have — a partial record is fine.',
+    /**
+     * The other half of an empty result (#79). A one-off is right for a
+     * restaurant meal and wrong for a product you will eat again, which is
+     * something only the person typing knows.
+     */
+    addAsFood: 'Add “{term}” to my foods',
     logged: '{label} logged',
     undo: 'Undo',
     undoFailed: 'Could not undo that',
@@ -121,8 +129,11 @@ export const diary = {
 
   foodAdd: {
     barcodeFailed: 'Couldn’t look up that barcode — try again.',
-    addFailed: 'Couldn’t add that item — try again.',
     notFound: 'Not found.',
+    /** What choosing an Open Food Facts result does now: opens it, saves nothing (#93). */
+    review: 'Check and add',
+    reviewHint:
+      'Open Food Facts data is often incomplete. Check it, then saving adds the food and logs it.',
     addToLibrary: 'Add it to the foods library',
     addToLibraryAfter: 'first.',
     searching: 'Searching Open Food Facts…',

--- a/src/lib/i18n/messages/en/nutrition.ts
+++ b/src/lib/i18n/messages/en/nutrition.ts
@@ -133,7 +133,7 @@ export const diary = {
     /** What choosing an Open Food Facts result does now: opens it, saves nothing (#93). */
     review: 'Check and add',
     reviewHint:
-      'Open Food Facts data is often incomplete. Check it, then saving adds the food and logs it.',
+      'Open Food Facts data is often incomplete. Check it, then saving adds the food and brings you back here to log it.',
     addToLibrary: 'Add it to the foods library',
     addToLibraryAfter: 'first.',
     searching: 'Searching Open Food Facts…',

--- a/src/lib/i18n/messages/nl/nutrition.ts
+++ b/src/lib/i18n/messages/nl/nutrition.ts
@@ -57,6 +57,7 @@ export const diary = {
     hideScanner: 'Scanner verbergen',
     sections: {
       scanned: 'Gescand',
+      justAdded: 'Net toegevoegd',
       foods: 'Jouw voedingsmiddelen',
       recipes: 'Recepten',
       off: 'Open Food Facts',
@@ -72,6 +73,7 @@ export const diary = {
     oneOffTitle: '“{term}” eenmalig noteren',
     oneOffHint:
       'Vul in wat je weet — een gedeeltelijke notitie is beter dan niets.',
+    addAsFood: '“{term}” toevoegen aan mijn voedingsmiddelen',
     logged: '{label} genoteerd',
     undo: 'Ongedaan maken',
     undoFailed: 'Kon dat niet ongedaan maken',
@@ -103,8 +105,10 @@ export const diary = {
 
   foodAdd: {
     barcodeFailed: 'Kon die barcode niet opzoeken — probeer het opnieuw.',
-    addFailed: 'Kon dat item niet toevoegen — probeer het opnieuw.',
     notFound: 'Niet gevonden.',
+    review: 'Controleren en toevoegen',
+    reviewHint:
+      'Gegevens van Open Food Facts zijn vaak onvolledig. Controleer ze; bij opslaan wordt het voedingsmiddel toegevoegd en genoteerd.',
     addToLibrary: 'Voeg het toe aan de voedingsmiddelen',
     addToLibraryAfter: 'en probeer het dan opnieuw.',
     searching: 'Zoeken bij Open Food Facts…',

--- a/src/lib/i18n/messages/nl/nutrition.ts
+++ b/src/lib/i18n/messages/nl/nutrition.ts
@@ -108,7 +108,7 @@ export const diary = {
     notFound: 'Niet gevonden.',
     review: 'Controleren en toevoegen',
     reviewHint:
-      'Gegevens van Open Food Facts zijn vaak onvolledig. Controleer ze; bij opslaan wordt het voedingsmiddel toegevoegd en genoteerd.',
+      'Gegevens van Open Food Facts zijn vaak onvolledig. Controleer ze; bij opslaan wordt het voedingsmiddel toegevoegd en kom je hier terug om het te noteren.',
     addToLibrary: 'Voeg het toe aan de voedingsmiddelen',
     addToLibraryAfter: 'en probeer het dan opnieuw.',
     searching: 'Zoeken bij Open Food Facts…',

--- a/src/routes/_app/g/$groupSlug/foods/new.tsx
+++ b/src/routes/_app/g/$groupSlug/foods/new.tsx
@@ -1,9 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
+import {
+  MEAL_NAMES,
+  type MealName,
+} from '../../../../../../convex/lib/consumption'
 import { groupFoodNav } from '../../../../../components/foods/foodNav'
 import {
   NewFoodPage,
   validateNewFoodSearch,
 } from '../../../../../components/foods/NewFoodPage'
+import { groupNutritionNav } from '../../../../../components/nutrition/nutritionNav'
 
 export const Route = createFileRoute('/_app/g/$groupSlug/foods/new')({
   component: GroupNewFood,
@@ -12,7 +17,26 @@ export const Route = createFileRoute('/_app/g/$groupSlug/foods/new')({
 
 function GroupNewFood() {
   const { groupSlug } = Route.useParams()
-  const { barcode } = Route.useSearch()
+  const { barcode, name, returnDate, returnMeal } = Route.useSearch()
 
-  return <NewFoodPage barcode={barcode} nav={groupFoodNav(groupSlug)} />
+  // The one place that knows both Modules' addresses. A day and a meal in the
+  // search mean somebody came from the add sheet — reviewing an Open Food Facts
+  // import (#93) or adding a food a search found nothing for (#79) — and saving
+  // hands them back to that meal with the new food ready to log, rather than
+  // leaving them in the Catalog holding a food they came here to eat.
+  const meal: MealName | undefined = MEAL_NAMES.find((m) => m === returnMeal)
+  const nutrition = groupNutritionNav(groupSlug)
+  const after =
+    returnDate && meal
+      ? (foodId: string) => nutrition.addEntry(returnDate, meal, foodId)
+      : undefined
+
+  return (
+    <NewFoodPage
+      barcode={barcode}
+      name={name}
+      after={after}
+      nav={groupFoodNav(groupSlug)}
+    />
+  )
 }

--- a/src/routes/_app/g/$groupSlug/nutrition/add.tsx
+++ b/src/routes/_app/g/$groupSlug/nutrition/add.tsx
@@ -7,12 +7,19 @@ import { AddSheet } from '../../../../../components/nutrition/AddSheet'
 import { todayLocal } from '../../../../../components/nutrition/NutritionPage'
 import { groupNutritionNav } from '../../../../../components/nutrition/nutritionNav'
 
-/** The meal being added to, defaulting to the first slot for a hand-typed URL. */
+/**
+ * The meal being added to, defaulting to the first slot for a hand-typed URL,
+ * and optionally the food a just-saved form handed back (#93/#79).
+ */
 function validateAddSearch(search: Record<string, unknown>): {
   meal: MealName
+  food?: string
 } {
   const meal = MEAL_NAMES.find((name) => name === search.meal)
-  return { meal: meal ?? 'breakfast' }
+  return {
+    meal: meal ?? 'breakfast',
+    food: typeof search.food === 'string' ? search.food : undefined,
+  }
 }
 
 /**
@@ -31,13 +38,14 @@ export const Route = createFileRoute('/_app/g/$groupSlug/nutrition/add')({
 
 function AddToMeal() {
   const { groupSlug } = Route.useParams()
-  const { date, meal } = Route.useSearch()
+  const { date, meal, food } = Route.useSearch()
   const navigate = useNavigate()
 
   return (
     <AddSheet
       date={date || todayLocal()}
       meal={meal}
+      justAddedFoodId={food}
       nav={groupNutritionNav(groupSlug)}
       onClose={() =>
         navigate({


### PR DESCRIPTION
Closes #93
Closes #79

**Targets `main`.** This was originally stacked on #95 and #97 via a `claude/base-95-97` integration branch, because #95 changed the add sheet's search and scan handling and #97 changed `FoodForm.tsx` — the file this work routes an import through. Both have since merged, so the base is now `main` directly and the diff below is only this PR's work. (The `claude/base-95-97` branch is now redundant and can be deleted; I could not delete it from here — the git proxy refuses branch deletes with a 403.)

## Why the two issues are one PR

Both issues said so. Each needs the same thing: a way for the food form to hand the person **back to the add sheet for the same date and meal**, with the new food's card expanded and ready to log. Whichever landed first was to build it and the second to use it — building them together is what stops that path being invented twice.

## The shared return path

The add sheet is an addressable route carrying the day and the meal (#66), so there is somewhere specific to come back to rather than the diary in general.

- `FoodNav.create` now takes a `NewFoodIntent` — `{ barcode?, name?, returnTo? }` — instead of a bare barcode. `returnTo` is the *day and meal*, not a serialised URL: the only place that sends anyone to the form expecting them back is the add sheet, and keeping it as data is what stops an arbitrary destination riding in on a query string.
- `/foods/new` carries it as `returnDate` / `returnMeal`. The route shim is the one thing that knows both Modules' addresses, so it turns those into an `after(foodId)` link and hands it to `NewFoodPage`; with no `returnTo`, saving still lands on the food's own page exactly as before.
- `NutritionNav.addEntry` takes an optional food id, and `/nutrition/add` reads it as a `food` search param. The sheet opens with that card expanded, in a **Just added** section.

The same path answers a *scanned* barcode that turns out to already be in the library: it goes back to the meal with that food ready to log, rather than to the food's page, which is not where somebody logging breakfast was going.

## #93 — routing the import through the form, with no second editor

`NewFoodPage` already resolves a barcode against Open Food Facts and fills `FoodForm` from the mapping — that screen has existed since the scanner did. So an import is now **a link to it**, not a copy of it: `OffCard`'s confirm is gone, and choosing a result opens the form pre-filled. No second editor exists afterwards.

Nothing is written before the save, and the picture is the reason that matters. The save calls the `importFromOff` **action** rather than the `upsertFromOff` mutation — the action is what fetches and stores the product picture (#69). Fetching it at the save rather than when the form opens is what makes an abandoned review leave no orphaned food **and no stored blob**. `importFromOff` also carries `nutritionSource` through, so a figure corrected in the review saves as `manual` (#97) instead of the food going on claiming the numbers came off a packet.

A scanned barcode matching a food you **already have** is not an import and keeps today's behaviour — straight to the expanded card, ready to log. Only a new product is reviewed.

**Saving imports the food and returns you here ready to log it; it does not write the diary entry.** #93's acceptance criteria contradicted each other on this ("logs the entry" vs "returns … ready to log") and this PR implemented the latter, because logging needs an amount and this form has no portion field — it defines servings, it does not choose one. Confirmed as the wanted behaviour during review. The forced-review cost has since been revisited: **#112** makes review the secondary action rather than the only way through.

## The nameless-product hole this closes

Pre-existing, and #93 is the right place for it. `mapOffProduct` deliberately maps an Open Food Facts product with no `product_name`, returning `name: ''`, because its comment says it "leaves that decision to the user on the confirmation screen". `onBarcode` had no confirmation screen and sent that mapping straight to `importFromOff` — so scanning such a product **silently imported a food called `""`**.

The review screen *is* that confirmation screen, so this is fixed properly rather than filtered: the product reaches the form with an empty name field, and `FoodForm`'s name input is `required`, so it is saveable only once named. (#95 fixed the sibling symptom on the *typed-barcode* path by dropping nameless products from the results list, because that path has no confirmation screen. This one does, so it keeps the product and asks.) #112 preserves this: a nameless product still goes through review even on the fast path.

## #79 — an empty result offers two routes

Both carry the words already typed: today's `OneOffCard`, unchanged, and "Add “{term}” to my foods" — the same `FoodForm`, with the term as the name and the same way back. A one-off is right for a restaurant meal and wrong for a product you will eat again next week, because it is logged once with no `foodId`, so the next search for the same words finds nothing and offers a one-off again.

Review of the preview has since asked for both routes to be **permanently reachable** rather than only offered once a search has failed — that is **#113**.

## Tests

`pnpm typecheck`, `pnpm test` (1071 passing) and `pnpm check` all pass.

- **Convex boundary**, real in-memory backend with injected identity — *abandoning the form leaves no orphaned food and no stored picture*: after a real `lookupBarcode` that resolves a product (including its image URL), the `foods` table and `_storage` are both empty. Plus `importFromOff` carrying the review's `nutritionSource` answer, both ways.
- **Component**, through `renderWithI18n` — the OFF card offers a review link and writes nothing; a scanned barcode you already have skips review; a new scanned product routes to the form; a nameless scanned product routes to the form rather than being imported; the returned food comes back expanded and logs its own figures; the empty result offers both routes with the right hrefs.
- `FoodForm` — a nameless import cannot be saved unnamed, and can be saved once named.
- `NewFoodPage` — the typed term arrives as the name, saving returns to the meal, saving with no `returnTo` still lands on the food's page, an import writes only at the save (picture URL and all), and a correction saves as `manual`.

The scanner is driven through its manual barcode entry, which is the path a phone with camera permission denied takes anyway.

## Acceptance criteria I could not verify

- **"Driven on a phone"** — required by *both* issues, and not something the build environment can do. Since verified by review of the preview, which produced #112 and #113. Still unverified here: the real camera path into `onBarcode` (the tests use the manual barcode field; jsdom cannot answer for `getUserMedia`), and the round trip against the real Open Food Facts API including a genuinely nameless product.
- **"The picture fetched at import still arrives with the food"** — verified as far as the boundary (the save calls `importFromOff` with the mapped `imageUrl`, and the existing suite covers that action storing and attaching the blob), but not end-to-end against Open Food Facts' image servers.