### PR TITLE
feat(foods): give a food or a one-off an icon

### DIFF
--- a/convex/combos.test.ts
+++ b/convex/combos.test.ts
@@ -359,4 +359,60 @@ describe('logging a Combo', () => {
     expect(after.components[0]).toMatchObject({ quantity: 140 })
     expect(after.name).toBe('Usual breakfast')
   })
+
+  /**
+   * Saving a Combo keeps a one-off's icon; editing one has to keep it too.
+   *
+   * `replaceItems` deletes and recreates every row, so any field the payload
+   * does not carry is lost the first time somebody changes a count — silently,
+   * and long after the save that appeared to work. The initial-save test two
+   * blocks up would go on passing throughout.
+   */
+  test('a one-off’s icon survives editing the Combo', async () => {
+    const { t } = await loggedBreakfast()
+    await t.withIdentity(asAlice).mutation(api.consumption.create, {
+      date: DAY,
+      meal: 'breakfast',
+      label: 'Stroopwafel from the market',
+      quantity: 1,
+      quantityUnit: 'piece',
+      nutrition: { calories: 150 },
+      icon: '🍪',
+    })
+    const comboId = await t
+      .withIdentity(asAlice)
+      .mutation(api.combos.saveFromMeal, {
+        date: DAY,
+        meal: 'breakfast',
+        name: 'Usual breakfast',
+      })
+
+    const [before] = await t.withIdentity(asAlice).query(api.combos.list, {})
+    const saved = before.components.find(
+      (c) => c.label === 'Stroopwafel from the market',
+    )
+    expect(saved?.icon).toBe('🍪')
+
+    // Exactly what the add sheet sends when a count changed and the offer to
+    // update was taken: every component rebuilt from what was logged.
+    await t.withIdentity(asAlice).mutation(api.combos.replaceItems, {
+      id: comboId,
+      components: comboEntries(before.components).map((entry) => ({
+        foodId: entry.foodId as Id<'foods'> | undefined,
+        recipeId: entry.recipeId as Id<'recipes'> | undefined,
+        label: entry.label,
+        quantity: entry.quantity,
+        quantityUnit: entry.quantityUnit,
+        nutrition:
+          entry.foodId || entry.recipeId ? undefined : entry.nutrition,
+        icon: entry.foodId || entry.recipeId ? undefined : entry.icon,
+      })),
+    })
+
+    const [after] = await t.withIdentity(asAlice).query(api.combos.list, {})
+    const rebuilt = after.components.find(
+      (c) => c.label === 'Stroopwafel from the market',
+    )
+    expect(rebuilt?.icon).toBe('🍪')
+  })
 })

--- a/convex/combos.test.ts
+++ b/convex/combos.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import { testConvex } from '../test/convexHarness'
 import { api } from './_generated/api'
 import type { Id } from './_generated/dataModel'
+import { comboEntries } from './lib/combos'
 
 /**
  * A Combo is Personal (ADR-0003, ADR-0012): it belongs to a person, follows
@@ -108,6 +109,49 @@ async function saveBreakfast() {
 }
 
 describe('saving a meal slot as a Combo', () => {
+  /**
+   * A one-off's icon has to be captured with it, for the same reason its
+   * figures are: there is no food and no recipe behind it to read one back
+   * from later. Without this the icon survives the first log and disappears
+   * on every log made through the Combo afterwards — the shortcut quietly
+   * producing a worse entry than the thing it was a shortcut for.
+   */
+  test('a one-off’s icon is captured and still there when it is logged again', async () => {
+    const { t } = await loggedBreakfast()
+    await t.withIdentity(asAlice).mutation(api.consumption.create, {
+      date: DAY,
+      meal: 'breakfast',
+      label: 'Stroopwafel from the market',
+      quantity: 1,
+      quantityUnit: 'piece',
+      nutrition: { calories: 150 },
+      icon: '🍪',
+    })
+    await t.withIdentity(asAlice).mutation(api.combos.saveFromMeal, {
+      date: DAY,
+      meal: 'breakfast',
+      name: 'Usual breakfast',
+    })
+
+    const [combo] = await t.withIdentity(asAlice).query(api.combos.list, {})
+    const saved = combo.components.find(
+      (c) => c.label === 'Stroopwafel from the market',
+    )
+    expect(saved?.icon).toBe('🍪')
+
+    // And through to what the log actually writes — the pure function the
+    // client and the mutation share, so this is the entry either would send.
+    const logged = comboEntries(combo.components).find(
+      (e) => e.label === 'Stroopwafel from the market',
+    )
+    expect(logged?.icon).toBe('🍪')
+
+    // The other half of the rule: a food carries its own icon, so the Combo
+    // does not keep a stale copy of one.
+    const bread = combo.components.find((c) => c.label === 'Wholemeal bread')
+    expect(bread?.icon).toBeUndefined()
+  })
+
   test('captures all three kinds of entry', async () => {
     const { t, foodId, recipeId } = await saveBreakfast()
 

--- a/convex/combos.ts
+++ b/convex/combos.ts
@@ -41,6 +41,7 @@ async function resolveComponent(
     quantity: item.quantity,
     quantityUnit: item.quantityUnit,
     nutrition: item.nutrition,
+    icon: item.icon,
   }
   if (item.foodId) {
     const food = await ctx.db.get(item.foodId)
@@ -163,6 +164,10 @@ export const saveFromMeal = mutation({
         // later. A food or a Recipe is re-read on every log, deliberately.
         nutrition:
           entry.foodId || entry.recipeId ? undefined : entry.nutrition,
+        // Same rule for the icon (#94): a food's travels with the food, so
+        // changing it there changes every future log. A one-off's has nowhere
+        // else to live, and without this a Combo would quietly drop it.
+        icon: entry.foodId || entry.recipeId ? undefined : entry.icon,
       })
     }
     return comboId

--- a/convex/combos.ts
+++ b/convex/combos.ts
@@ -115,6 +115,10 @@ const componentFields = {
   quantity: v.number(),
   quantityUnit: quantityUnitValidator,
   nutrition: v.optional(nutritionValidator),
+  // Travels with the figures, and for the same reason (#94): `replaceItems`
+  // deletes and recreates every row, so a field missing here is a field the
+  // Combo loses the moment anybody edits it — even though saving it kept it.
+  icon: v.optional(v.string()),
 }
 
 /**

--- a/convex/consumption.test.ts
+++ b/convex/consumption.test.ts
@@ -479,3 +479,53 @@ describe('the amounts you have logged for a food', () => {
     ).toEqual([])
   })
 })
+
+/**
+ * The emoji on a one-off (#94).
+ *
+ * A one-off has no `foodId` and no `recipeId`, so there is nothing behind it to
+ * read a picture from and there never will be — this is the only picture it can
+ * have. An entry logged without one is stored exactly as entries always were.
+ */
+describe('a one-off’s icon', () => {
+  async function signedIn() {
+    const t = testConvex()
+    await t.withIdentity(asAlice).mutation(api.users.ensureUser, {})
+    return t
+  }
+
+  const oneOff = {
+    date: DAY,
+    meal: 'breakfast' as const,
+    label: 'Poffertjes at the fair',
+    quantity: 1,
+    quantityUnit: 'piece' as const,
+    nutrition: { calories: 400 },
+  }
+
+  test('is written with the entry and comes back on the day', async () => {
+    const t = await signedIn()
+
+    await t
+      .withIdentity(asAlice)
+      .mutation(api.consumption.create, { ...oneOff, icon: '🍬' })
+
+    const entries = await t
+      .withIdentity(asAlice)
+      .query(api.consumption.listForDay, { date: DAY })
+    expect(entries.map((e) => [e.label, e.icon])).toEqual([
+      ['Poffertjes at the fair', '🍬'],
+    ])
+  })
+
+  test('an entry logged without one has no field at all', async () => {
+    const t = await signedIn()
+
+    const id = await t
+      .withIdentity(asAlice)
+      .mutation(api.consumption.create, oneOff)
+
+    const row = await t.run(async (ctx) => ctx.db.get(id))
+    expect(row && 'icon' in row).toBe(false)
+  })
+})

--- a/convex/consumption.ts
+++ b/convex/consumption.ts
@@ -103,6 +103,10 @@ export const create = mutation({
     quantity: v.number(),
     quantityUnit: quantityUnitValidator,
     nutrition: nutritionValidator,
+    // An emoji, for a one-off (#94). Sent only by the card that writes one:
+    // an entry that references a food or a recipe has something behind it to
+    // show, and reads that instead of carrying a copy.
+    icon: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx)

--- a/convex/consumption.ts
+++ b/convex/consumption.ts
@@ -143,6 +143,7 @@ export const createMany = mutation({
         quantity: v.number(),
         quantityUnit: quantityUnitValidator,
         nutrition: nutritionValidator,
+        icon: v.optional(v.string()),
       }),
     ),
   },

--- a/convex/foods.test.ts
+++ b/convex/foods.test.ts
@@ -589,3 +589,174 @@ describe('reviewing an import before it is saved', () => {
     expect(food?.nutritionSource).toBe('imported')
   })
 })
+
+/**
+ * The emoji a person picked for a food (#94).
+ *
+ * Content, stored rather than translated, and optional in both directions:
+ * nothing is backfilled, and taking one off has to be a thing the row can
+ * actually record. The tier below it in the tile is the generic glyph, and an
+ * icon stored as `''` would stand in front of that glyph rendering nothing —
+ * so "cleared" has to mean an absent field, which is what these check.
+ */
+describe('a food’s icon', () => {
+  async function signedIn() {
+    const t = testConvex()
+    await t.withIdentity(asAlice).mutation(api.users.ensureUser, {})
+    return t
+  }
+
+  test('is saved with the food, and read back with it', async () => {
+    const t = await signedIn()
+
+    const id = await t.withIdentity(asAlice).mutation(api.foods.create, {
+      name: 'Hagelslag',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 500 },
+      icon: '🍫',
+    })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.icon).toBe('🍫')
+  })
+
+  test('a food nobody gave one has no field at all', async () => {
+    const t = await signedIn()
+
+    const id = await t.withIdentity(asAlice).mutation(api.foods.create, {
+      name: 'Hagelslag',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 500 },
+    })
+
+    const row = await t.run(async (ctx) => ctx.db.get(id))
+    expect(row && 'icon' in row).toBe(false)
+  })
+
+  test('can be changed', async () => {
+    const t = await signedIn()
+    const id = await t.withIdentity(asAlice).mutation(api.foods.create, {
+      name: 'Melk',
+      baseUnit: 'ml',
+      nutritionPer100: { calories: 46 },
+      icon: '🥛',
+    })
+
+    await t.withIdentity(asAlice).mutation(api.foods.update, {
+      id,
+      name: 'Melk',
+      baseUnit: 'ml',
+      nutritionPer100: { calories: 46 },
+      icon: '🧀',
+    })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.icon).toBe('🧀')
+  })
+
+  // The one that would fail silently: an optional argument nobody sent is not
+  // a key on the arguments at all, so a save that only spread them would keep
+  // the old icon forever and clearing would look like it had worked.
+  test('clearing it removes the field rather than storing an empty string', async () => {
+    const t = await signedIn()
+    const id = await t.withIdentity(asAlice).mutation(api.foods.create, {
+      name: 'Melk',
+      baseUnit: 'ml',
+      nutritionPer100: { calories: 46 },
+      icon: '🥛',
+    })
+
+    // Exactly what the form sends once the icon has been taken off: every
+    // other field, and no icon.
+    await t.withIdentity(asAlice).mutation(api.foods.update, {
+      id,
+      name: 'Melk',
+      baseUnit: 'ml',
+      nutritionPer100: { calories: 46 },
+    })
+
+    const row = await t.run(async (ctx) => ctx.db.get(id))
+    expect(row?.icon).toBeUndefined()
+    expect(row && 'icon' in row).toBe(false)
+  })
+
+  // The path most likely to drop it: an import goes through the *action*, not
+  // the mutation, because of the picture. A field the action does not carry is
+  // lost at the save with nothing saying so.
+  test('survives an Open Food Facts import, which is where it is picked', async () => {
+    const t = await signedIn()
+
+    const id = await t
+      .withIdentity(asAlice)
+      .action(api.foodsLookup.importFromOff, {
+        barcode: '8712345678901',
+        name: 'Volkoren crackers',
+        brand: 'Plus',
+        baseUnit: 'g',
+        nutritionPer100: {},
+        // A product with no photograph and no figures — the review screen's
+        // whole reason for existing, and the row an icon does the most for.
+        icon: '🍞',
+      })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.icon).toBe('🍞')
+    expect(food?.source).toBe('openfoodfacts')
+  })
+
+  test('a refresh from Open Food Facts leaves the one you chose alone', async () => {
+    const t = await signedIn()
+    const id = await t.withIdentity(asAlice).mutation(api.foods.upsertFromOff, {
+      barcode: '3017620422003',
+      name: 'Nutella',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 539 },
+      icon: '🍫',
+    })
+
+    // Open Food Facts has no emoji, so a refresh has nothing to overwrite it
+    // with — and the icon was yours, not theirs.
+    await t.withIdentity(asAlice).mutation(api.foods.applyOffRefresh, {
+      id,
+      barcode: '3017620422003',
+      name: 'Nutella',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 546 },
+    })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.icon).toBe('🍫')
+    expect(food?.nutritionPer100.calories).toBe(546)
+  })
+
+  test('a Catalog food carries the fixture’s icon and still refuses every write', async () => {
+    const t = await signedIn()
+    const id = await t.run(async (ctx) =>
+      ctx.db.insert('foods', {
+        name: 'Banana',
+        baseUnit: 'g',
+        nutritionPer100: { calories: 89 },
+        source: 'seed',
+        seedKey: 'banana',
+        icon: '🍌',
+      }),
+    )
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.icon).toBe('🍌')
+    // A fixture setting an icon is not the same as making these rows editable
+    // (ADR 0004) — `assertNotCatalog` still guards the write path.
+    await expect(
+      t.withIdentity(asAlice).mutation(api.foods.update, {
+        id,
+        name: 'Banana',
+        baseUnit: 'g',
+        nutritionPer100: { calories: 89 },
+        icon: '🍎',
+      }),
+    ).rejects.toThrow()
+
+    const after = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(after?.icon).toBe('🍌')
+  })
+})

--- a/convex/foods.test.ts
+++ b/convex/foods.test.ts
@@ -667,17 +667,44 @@ describe('a food’s icon', () => {
     })
 
     // Exactly what the form sends once the icon has been taken off: every
-    // other field, and no icon.
+    // other field, and `null` for the icon. Not an omitted argument — Convex
+    // drops those before they arrive, so the mutation could not tell a clear
+    // from a caller that simply had nothing to say.
     await t.withIdentity(asAlice).mutation(api.foods.update, {
       id,
       name: 'Melk',
       baseUnit: 'ml',
       nutritionPer100: { calories: 46 },
+      icon: null,
     })
 
     const row = await t.run(async (ctx) => ctx.db.get(id))
     expect(row?.icon).toBeUndefined()
     expect(row && 'icon' in row).toBe(false)
+  })
+
+  // The other half of that contract, and the one a caller gets wrong silently:
+  // saying nothing about the icon has to leave it alone. Without this an edit
+  // that touched only the name would take the icon off on its way past.
+  test('an update that says nothing about the icon leaves it alone', async () => {
+    const t = await signedIn()
+    const id = await t.withIdentity(asAlice).mutation(api.foods.create, {
+      name: 'Melk',
+      baseUnit: 'ml',
+      nutritionPer100: { calories: 46 },
+      icon: '🥛',
+    })
+
+    await t.withIdentity(asAlice).mutation(api.foods.update, {
+      id,
+      name: 'Halfvolle melk',
+      baseUnit: 'ml',
+      nutritionPer100: { calories: 46 },
+    })
+
+    const row = await t.run(async (ctx) => ctx.db.get(id))
+    expect(row?.name).toBe('Halfvolle melk')
+    expect(row?.icon).toBe('🥛')
   })
 
   // The path most likely to drop it: an import goes through the *action*, not

--- a/convex/foods.ts
+++ b/convex/foods.ts
@@ -34,10 +34,29 @@ const foodFields = {
  * Absent means none. It is never stored as an empty string — a set-but-empty
  * icon would sit in front of the generic glyph in the tile's fallback chain
  * and render nothing at all.
+ *
+ * Three states, not two, which is why `null` is in the type. Convex drops an
+ * argument whose value is `undefined` before it reaches the server, so an
+ * optional string can only say "a person chose this one" or nothing at all —
+ * and "nothing at all" would have to mean both *leave what is there* and
+ * *take it off*. `null` is the clear, because it survives the wire; omitting
+ * the field leaves the icon alone, which is what any caller that does not
+ * know about icons should do.
  */
 const savedFoodFields = {
   ...foodFields,
-  icon: v.optional(v.string()),
+  icon: v.optional(v.union(v.string(), v.null())),
+}
+
+/**
+ * The patch fragment for an icon argument, given the three states above.
+ *
+ * `{}` when omitted, so a spread leaves the stored icon untouched; a written
+ * key of `undefined` when cleared, because writing `undefined` is what makes
+ * Convex *remove* a field rather than skip it.
+ */
+function iconPatch(icon: string | null | undefined) {
+  return icon === undefined ? {} : { icon: icon ?? undefined }
 }
 
 /**
@@ -131,6 +150,9 @@ export const create = mutation({
     }
     return await ctx.db.insert('foods', {
       ...args,
+      // Nothing to leave alone on a new row: both "omitted" and "cleared" are
+      // simply no icon.
+      icon: args.icon ?? undefined,
       nutritionSource: hasNutritionFigures(args.nutritionPer100)
         ? (args.nutritionSource ?? 'manual')
         : undefined,
@@ -153,7 +175,7 @@ export const update = mutation({
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx)
     if (!user) throw new Error('Not authenticated')
-    const { id, ...rest } = args
+    const { id, icon, ...rest } = args
     const food = await ctx.db.get(id)
     if (!food) throw new Error('Food not found')
     assertNotCatalog(food)
@@ -163,13 +185,11 @@ export const update = mutation({
       // the form sends nothing once every row has been removed, and a patch
       // that skipped the field would make the last serving undeletable.
       servings: rest.servings ?? [],
-      // Named rather than left to the spread above, for the same reason and
-      // with the opposite remedy: an optional argument nobody sent is not a
-      // key on `rest` at all, so a spread would silently keep the old icon and
-      // clearing one would never take. Writing the key with `undefined` is
-      // what makes Convex *remove* the field — which is the only clearing that
-      // leaves the tile's fallback chain reading correctly.
-      icon: rest.icon,
+      // The icon reads the opposite way round, and has to say which it means
+      // rather than leave it to whether the key arrived: the edit form clears
+      // one by sending `null`, and a caller that says nothing about icons
+      // keeps the one that is there.
+      ...iconPatch(icon),
       searchText: foodSearchText(rest),
       // Decided here, from the figures themselves, rather than accepted as an
       // argument — this mutation is the one place a person can type over a
@@ -208,7 +228,7 @@ export const upsertFromOff = mutation({
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx)
     if (!user) throw new Error('Not authenticated')
-    const { barcode, nutritionSource, ...withoutSource } = args
+    const { barcode, nutritionSource, icon, ...withoutSource } = args
     const rest = {
       ...withoutSource,
       nutritionSource: hasNutritionFigures(args.nutritionPer100)
@@ -234,10 +254,11 @@ export const upsertFromOff = mutation({
       await ctx.db.patch(existing._id, {
         ...rest,
         searchText: foodSearchText(rest),
-        // Named for the same reason as in `update`: the review form states what
-        // this food is, icon included, so an import that chose none has to be
-        // able to take one off rather than silently inherit the old one.
-        icon: rest.icon,
+        // Handled the same way as in `update`: the review form states what this
+        // food is, icon included, so an import whose reviewer took the icon off
+        // sends `null` and it goes, while an import that never mentions one
+        // leaves what is there.
+        ...iconPatch(icon),
       })
       await replaceStoredFile(ctx, previousImageId, rest.imageId)
       return existing._id
@@ -245,6 +266,9 @@ export const upsertFromOff = mutation({
     return await ctx.db.insert('foods', {
       ...rest,
       searchText: foodSearchText(rest),
+      // A new row has nothing to leave alone, so both "omitted" and "cleared"
+      // are simply no icon.
+      icon: icon ?? undefined,
       barcode,
       source: 'openfoodfacts',
       createdBy: user._id,

--- a/convex/foods.ts
+++ b/convex/foods.ts
@@ -22,6 +22,25 @@ const foodFields = {
 }
 
 /**
+ * The fields a *person* saves, which is `foodFields` plus the emoji they
+ * picked (#94).
+ *
+ * Separate from `foodFields` because of the one write that is not a person
+ * saying what this food is: `applyOffRefresh` replaces a row wholesale with
+ * Open Food Facts' answer, and Open Food Facts has no emoji. A refresh
+ * therefore leaves the icon you chose exactly where it was, rather than
+ * clearing it on your behalf.
+ *
+ * Absent means none. It is never stored as an empty string — a set-but-empty
+ * icon would sit in front of the generic glyph in the tile's fallback chain
+ * and render nothing at all.
+ */
+const savedFoodFields = {
+  ...foodFields,
+  icon: v.optional(v.string()),
+}
+
+/**
  * Catalog entries are owned by nobody and read-only (ADR 0004). Every write
  * path into `foods` goes through this, not just the edit form: these are
  * public mutations, so a client can call any of them with any food id
@@ -92,7 +111,7 @@ export const getByBarcode = query({
 // row per barcode" invariant applies here too, not just to `upsertFromOff`.
 export const create = mutation({
   args: {
-    ...foodFields,
+    ...savedFoodFields,
     barcode: v.optional(v.string()),
     // What the person was looking at when they pressed save: figures they
     // typed are `manual`, figures something filled in for them and they
@@ -126,7 +145,11 @@ export const create = mutation({
 // point on, a rescan of this barcode must never silently overwrite what the
 // user typed, until they explicitly ask to refresh.
 export const update = mutation({
-  args: { id: v.id('foods'), ...foodFields, barcode: v.optional(v.string()) },
+  args: {
+    id: v.id('foods'),
+    ...savedFoodFields,
+    barcode: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx)
     if (!user) throw new Error('Not authenticated')
@@ -140,6 +163,13 @@ export const update = mutation({
       // the form sends nothing once every row has been removed, and a patch
       // that skipped the field would make the last serving undeletable.
       servings: rest.servings ?? [],
+      // Named rather than left to the spread above, for the same reason and
+      // with the opposite remedy: an optional argument nobody sent is not a
+      // key on `rest` at all, so a spread would silently keep the old icon and
+      // clearing one would never take. Writing the key with `undefined` is
+      // what makes Convex *remove* the field — which is the only clearing that
+      // leaves the tile's fallback chain reading correctly.
+      icon: rest.icon,
       searchText: foodSearchText(rest),
       // Decided here, from the figures themselves, rather than accepted as an
       // argument — this mutation is the one place a person can type over a
@@ -164,7 +194,7 @@ export const update = mutation({
 // overwrite local edits.
 export const upsertFromOff = mutation({
   args: {
-    ...foodFields,
+    ...savedFoodFields,
     barcode: v.string(),
     // Already fetched and stored by `foodsLookup.importFromOff`, which is the
     // only thing that can make the network call this needs.
@@ -204,6 +234,10 @@ export const upsertFromOff = mutation({
       await ctx.db.patch(existing._id, {
         ...rest,
         searchText: foodSearchText(rest),
+        // Named for the same reason as in `update`: the review form states what
+        // this food is, icon included, so an import that chose none has to be
+        // able to take one off rather than silently inherit the old one.
+        icon: rest.icon,
       })
       await replaceStoredFile(ctx, previousImageId, rest.imageId)
       return existing._id

--- a/convex/foodsLookup.ts
+++ b/convex/foodsLookup.ts
@@ -153,7 +153,7 @@ export const importFromOff = action({
     // is exactly the food with nothing else to show. Every field of the review
     // reaches the row through this action, so an icon that stopped here would
     // be dropped at the save without anything saying so.
-    icon: v.optional(v.string()),
+    icon: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args): Promise<Id<'foods'>> => {
     const identity = await ctx.auth.getUserIdentity()

--- a/convex/foodsLookup.ts
+++ b/convex/foodsLookup.ts
@@ -148,6 +148,12 @@ export const importFromOff = action({
     // in that form arrives here saying `manual`. Absent still means `imported`,
     // which `foods.upsertFromOff` is the one to decide.
     nutritionSource: v.optional(nutritionSourceValidator),
+    // The emoji picked while reviewing (#94) — which is where one is most
+    // obviously missing, because an Open Food Facts product with no photograph
+    // is exactly the food with nothing else to show. Every field of the review
+    // reaches the row through this action, so an icon that stopped here would
+    // be dropped at the save without anything saying so.
+    icon: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<Id<'foods'>> => {
     const identity = await ctx.auth.getUserIdentity()

--- a/convex/lib/combos.ts
+++ b/convex/lib/combos.ts
@@ -33,6 +33,8 @@ export interface ComboComponent {
   recipe?: { nutrition: NutritionFacts }
   /** Figures of its own — only a one-off has these, because only a one-off needs them. */
   nutrition?: NutritionFacts
+  /** An icon of its own, for the same reason and on the same rows (#94). */
+  icon?: string
   available: boolean
 }
 
@@ -44,6 +46,7 @@ export interface ComboEntryInput {
   quantity: number
   quantityUnit: QuantityUnit
   nutrition: NutritionFacts
+  icon?: string
 }
 
 /**
@@ -90,6 +93,7 @@ export function comboEntries(
       quantity,
       quantityUnit: component.quantityUnit,
       nutrition,
+      icon: component.icon,
     })
   }
   return entries

--- a/convex/lib/seed/apply.ts
+++ b/convex/lib/seed/apply.ts
@@ -92,6 +92,7 @@ export async function applyCatalog(ctx: MutationCtx) {
 
     const fields = {
       name: food.name,
+      icon: food.icon,
       baseUnit: food.baseUnit,
       nutritionPer100: food.nutritionPer100,
       servings: food.servings,

--- a/convex/lib/seed/catalogFoods.ts
+++ b/convex/lib/seed/catalogFoods.ts
@@ -16,6 +16,20 @@ import type { Serving } from '../servings'
  */
 export interface CatalogFood {
   seedKey: string
+  /**
+   * The emoji this food shows where there is no photograph of it (#94) — and
+   * there never is one here, because a Catalog entry is generic and a picture
+   * would be of somebody's particular packet. So this is the tier of the
+   * tile's fallback these rows actually live in.
+   *
+   * Content, so it is not translated (ADR-0011), and picked from the same
+   * curated set the picker offers (`src/components/foods/IconPicker.tsx`) so
+   * that a Catalog food never wears something nobody could have chosen.
+   *
+   * Setting one here does not make these rows editable: they are still
+   * read-only in the app and `assertNotCatalog` still refuses every write.
+   */
+  icon?: string
   name: string
   baseUnit: 'g' | 'ml'
   nutritionPer100: NutritionFacts
@@ -35,6 +49,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   // Store cupboard
   {
     seedKey: 'flour-plain',
+    icon: '🌾',
     name: 'Flour, plain',
     baseUnit: 'g',
     nutritionPer100: {
@@ -54,6 +69,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'sugar-granulated',
+    icon: '🍬',
     name: 'Sugar, granulated',
     baseUnit: 'g',
     nutritionPer100: {
@@ -73,6 +89,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'rice-white-dry',
+    icon: '🍚',
     name: 'Rice, white long grain (dry)',
     baseUnit: 'g',
     nutritionPer100: {
@@ -92,6 +109,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'pasta-dry',
+    icon: '🍝',
     name: 'Pasta, dried',
     baseUnit: 'g',
     nutritionPer100: {
@@ -110,6 +128,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'lentils-dry',
+    icon: '🫘',
     name: 'Lentils, dried',
     baseUnit: 'g',
     nutritionPer100: {
@@ -128,6 +147,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'chickpeas-tinned',
+    icon: '🫘',
     name: 'Chickpeas, tinned (drained)',
     baseUnit: 'g',
     nutritionPer100: {
@@ -147,6 +167,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'chopped-tomatoes-tinned',
+    icon: '🍅',
     name: 'Chopped tomatoes, tinned',
     baseUnit: 'g',
     nutritionPer100: {
@@ -166,6 +187,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'olive-oil',
+    icon: '🫒',
     name: 'Olive oil',
     baseUnit: 'ml',
     nutritionPer100: {
@@ -185,6 +207,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'peanut-butter',
+    icon: '🥜',
     name: 'Peanut butter',
     baseUnit: 'g',
     nutritionPer100: {
@@ -206,6 +229,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   // Dairy and eggs
   {
     seedKey: 'egg-whole',
+    icon: '🥚',
     name: 'Egg, whole',
     baseUnit: 'g',
     nutritionPer100: {
@@ -225,6 +249,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'milk-whole',
+    icon: '🥛',
     name: 'Milk, whole',
     baseUnit: 'ml',
     nutritionPer100: {
@@ -245,6 +270,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'milk-semi-skimmed',
+    icon: '🥛',
     name: 'Milk, semi-skimmed',
     baseUnit: 'ml',
     nutritionPer100: {
@@ -265,6 +291,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'butter-unsalted',
+    icon: '🧈',
     name: 'Butter, unsalted',
     baseUnit: 'g',
     nutritionPer100: {
@@ -284,6 +311,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'yoghurt-greek-natural',
+    icon: '🥣',
     name: 'Greek yoghurt, natural',
     baseUnit: 'g',
     nutritionPer100: {
@@ -303,6 +331,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'cheese-cheddar',
+    icon: '🧀',
     name: 'Cheddar',
     baseUnit: 'g',
     nutritionPer100: {
@@ -322,6 +351,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'cheese-parmesan',
+    icon: '🧀',
     name: 'Parmesan',
     baseUnit: 'g',
     nutritionPer100: {
@@ -341,6 +371,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'feta',
+    icon: '🧀',
     name: 'Feta',
     baseUnit: 'g',
     nutritionPer100: {
@@ -362,6 +393,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   // Meat and fish
   {
     seedKey: 'chicken-breast-raw',
+    icon: '🍗',
     name: 'Chicken breast, raw',
     baseUnit: 'g',
     nutritionPer100: {
@@ -380,6 +412,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'beef-mince-5',
+    icon: '🥩',
     name: 'Beef mince, 5% fat',
     baseUnit: 'g',
     nutritionPer100: {
@@ -399,6 +432,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'salmon-fillet-raw',
+    icon: '🐟',
     name: 'Salmon fillet, raw',
     baseUnit: 'g',
     nutritionPer100: {
@@ -419,6 +453,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   // Fruit and vegetables
   {
     seedKey: 'potato',
+    icon: '🥔',
     name: 'Potato',
     baseUnit: 'g',
     nutritionPer100: {
@@ -438,6 +473,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'onion',
+    icon: '🧅',
     name: 'Onion',
     baseUnit: 'g',
     nutritionPer100: {
@@ -457,6 +493,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'garlic',
+    icon: '🧄',
     name: 'Garlic',
     baseUnit: 'g',
     nutritionPer100: {
@@ -475,6 +512,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'tomato',
+    icon: '🍅',
     name: 'Tomato',
     baseUnit: 'g',
     nutritionPer100: {
@@ -494,6 +532,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'carrot',
+    icon: '🥕',
     name: 'Carrot',
     baseUnit: 'g',
     nutritionPer100: {
@@ -512,6 +551,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'bell-pepper-red',
+    icon: '🫑',
     name: 'Bell pepper, red',
     baseUnit: 'g',
     nutritionPer100: {
@@ -531,6 +571,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'spinach',
+    icon: '🥬',
     name: 'Spinach',
     baseUnit: 'g',
     nutritionPer100: {
@@ -550,6 +591,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'banana',
+    icon: '🍌',
     name: 'Banana',
     baseUnit: 'g',
     nutritionPer100: {
@@ -569,6 +611,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'apple',
+    icon: '🍎',
     name: 'Apple',
     baseUnit: 'g',
     nutritionPer100: {
@@ -589,6 +632,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   // Bakery
   {
     seedKey: 'bread-wholemeal',
+    icon: '🍞',
     name: 'Bread, wholemeal',
     baseUnit: 'g',
     nutritionPer100: {
@@ -608,6 +652,7 @@ export const CATALOG_FOODS: CatalogFood[] = [
   },
   {
     seedKey: 'oats-rolled',
+    icon: '🥣',
     name: 'Oats, rolled',
     baseUnit: 'g',
     nutritionPer100: {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -178,6 +178,12 @@ export default defineSchema({
     // photograph a person took: that would need the prepare-on-upload pipeline
     // (ADR-0010) and is deliberately not offered.
     imageId: v.optional(v.id('_storage')),
+    // An emoji somebody picked, for a food with no picture behind it (#94).
+    // Content, not a display string, so it is stored rather than translated
+    // (ADR-0011) — exactly like a serving's `label`. Optional and nothing
+    // backfills it: a food with none renders the generic glyph it always did.
+    // A tile prefers the photograph, then this, then that glyph.
+    icon: v.optional(v.string()),
   })
     .index('by_barcode', ['barcode'])
     .index('by_seedKey', ['seedKey'])
@@ -193,6 +199,11 @@ export default defineSchema({
     quantity: v.number(),
     quantityUnit: quantityUnitValidator,
     nutrition: nutritionValidator,
+    // An emoji, for a **one-off** — an entry with no `foodId` and no
+    // `recipeId`, which has nothing to inherit a picture from and never will
+    // (#94). An entry that does reference a food reads the food's own icon
+    // instead, so this stays absent there. Content, not a display string.
+    icon: v.optional(v.string()),
   })
     .index('by_user_date', ['userId', 'date'])
     // "Which amounts of this food have I logged before?" — read to offer them

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -243,6 +243,11 @@ export default defineSchema({
     quantity: v.number(),
     quantityUnit: quantityUnitValidator,
     nutrition: v.optional(nutritionValidator),
+    // Kept for the same reason as the figures beside it, and only on the same
+    // rows: a one-off has no food and no recipe to read an icon back from, so
+    // a Combo that does not carry its own would lose it on every future log
+    // (#94).
+    icon: v.optional(v.string()),
   }).index('by_combo', ['comboId']),
 
   babies: defineTable({

--- a/src/components/foods/EditFoodPage.tsx
+++ b/src/components/foods/EditFoodPage.tsx
@@ -67,6 +67,7 @@ export function EditFoodPage({ foodId, nav }: EditFoodPageProps) {
           brand: food.brand,
           barcode: food.barcode,
           baseUnit: food.baseUnit,
+          icon: food.icon,
           nutritionPer100: food.nutritionPer100,
           servings: food.servings,
           nutritionSource: food.nutritionSource,

--- a/src/components/foods/FoodForm.test.tsx
+++ b/src/components/foods/FoodForm.test.tsx
@@ -392,9 +392,10 @@ test('clearing one submits no icon at all', () => {
   fireEvent.click(screen.getByRole('button', { name: 'No icon' }))
   fireEvent.click(screen.getByRole('button', { name: /save food/i }))
 
-  expect(onSubmit).toHaveBeenCalledWith(
-    expect.objectContaining({ icon: undefined }),
-  )
+  // `null`, not `undefined`: Convex drops an undefined argument before it
+  // reaches the mutation, so a cleared icon submitted that way would arrive
+  // indistinguishable from one nobody mentioned, and never take.
+  expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ icon: null }))
 })
 
 test('a food nobody gave an icon submits none', () => {
@@ -405,7 +406,5 @@ test('a food nobody gave an icon submits none', () => {
   })
   fireEvent.click(screen.getByRole('button', { name: /save food/i }))
 
-  expect(onSubmit).toHaveBeenCalledWith(
-    expect.objectContaining({ icon: undefined }),
-  )
+  expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ icon: null }))
 })

--- a/src/components/foods/FoodForm.test.tsx
+++ b/src/components/foods/FoodForm.test.tsx
@@ -331,3 +331,81 @@ test('a serving can be taken off again', () => {
     expect.objectContaining({ servings: undefined }),
   )
 })
+
+/**
+ * The icon (#94). This form is also the Open Food Facts review screen (#93),
+ * which is where an icon is most obviously missing: their products carry a
+ * photograph or they carry nothing at all.
+ */
+test('an icon picked while reviewing is part of what is saved', () => {
+  const onSubmit = vi.fn()
+  renderWithI18n(
+    <FoodForm
+      onSubmit={onSubmit}
+      submitting={false}
+      initial={{
+        name: 'Nutella',
+        nutritionPer100: { calories: 539 },
+        nutritionSource: 'imported',
+      }}
+      sourceNote="From Open Food Facts — review before saving."
+    />,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: '🍫' }))
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+
+  expect(onSubmit).toHaveBeenCalledWith(
+    expect.objectContaining({ icon: '🍫', nutritionSource: 'imported' }),
+  )
+})
+
+test('a food that had one opens holding it, and can be given another', () => {
+  const onSubmit = vi.fn()
+  renderWithI18n(
+    <FoodForm
+      onSubmit={onSubmit}
+      submitting={false}
+      initial={{ name: 'Melk', icon: '🥛', nutritionPer100: {} }}
+    />,
+  )
+  expect(screen.getByRole('button', { name: '🥛' }).ariaPressed).toBe('true')
+
+  fireEvent.click(screen.getByRole('button', { name: '🧀' }))
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+
+  expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ icon: '🧀' }))
+})
+
+// Nothing rather than '': an empty string is set as far as the tile's fallback
+// chain can tell, and would render a blank square in front of the glyph.
+test('clearing one submits no icon at all', () => {
+  const onSubmit = vi.fn()
+  renderWithI18n(
+    <FoodForm
+      onSubmit={onSubmit}
+      submitting={false}
+      initial={{ name: 'Melk', icon: '🥛', nutritionPer100: {} }}
+    />,
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: 'No icon' }))
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+
+  expect(onSubmit).toHaveBeenCalledWith(
+    expect.objectContaining({ icon: undefined }),
+  )
+})
+
+test('a food nobody gave an icon submits none', () => {
+  const onSubmit = vi.fn()
+  renderWithI18n(<FoodForm onSubmit={onSubmit} submitting={false} />)
+  fireEvent.change(screen.getByLabelText('Name'), {
+    target: { value: 'Water' },
+  })
+  fireEvent.click(screen.getByRole('button', { name: /save food/i }))
+
+  expect(onSubmit).toHaveBeenCalledWith(
+    expect.objectContaining({ icon: undefined }),
+  )
+})

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -13,6 +13,7 @@ import {
   parseDecimal,
   toNutrientInputs,
 } from '../nutrition/nutrientInputs'
+import { IconPicker } from './IconPicker'
 
 export interface FoodFormValues {
   name: string
@@ -21,6 +22,14 @@ export interface FoodFormValues {
   baseUnit: 'g' | 'ml'
   nutritionPer100: NutritionFacts
   servings?: Serving[]
+  /**
+   * The emoji this food shows when there is no photograph of it (#94).
+   *
+   * Absent when there is none, and absent is what a cleared icon submits —
+   * never `''`, which would sit in front of the generic glyph in the tile's
+   * fallback chain and render nothing.
+   */
+  icon?: string
   /**
    * Where the figures in this form came from, as the form last knew it —
    * prefilled by a lookup, or `manual` from the moment somebody types over a
@@ -80,6 +89,7 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
   // scan flow's URL param and is read-only display here (see /foods/new.tsx).
   const [barcode] = useState(initial?.barcode ?? '')
   const [baseUnit, setBaseUnit] = useState<'g' | 'ml'>(initial?.baseUnit ?? 'g')
+  const [icon, setIcon] = useState(initial?.icon)
   const [nutritionInputs, setNutritionInputs] = useState(() =>
     toNutrientInputs(initial?.nutritionPer100),
   )
@@ -116,6 +126,7 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
           brand: brand.trim() || undefined,
           barcode: barcode || undefined,
           baseUnit,
+          icon,
           nutritionPer100: facts,
           servings: servings.length > 0 ? servings : undefined,
           // No figures, nothing to say about where they came from.
@@ -173,6 +184,11 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
           </label>
         </div>
       </fieldset>
+      {/* Above the figures, because it answers a different kind of question and
+          a shorter one: what this *is*, rather than what is in it. It is also
+          the field an Open Food Facts review most often has to fill in — their
+          products carry a picture or they carry nothing (#94). */}
+      <IconPicker value={icon} onChange={setIcon} disabled={submitting} />
       <fieldset className="rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">
         <legend className="px-1 text-sm font-medium">
           {fmt(form.nutritionLegend, { unit: baseUnit })}

--- a/src/components/foods/FoodForm.tsx
+++ b/src/components/foods/FoodForm.tsx
@@ -25,11 +25,13 @@ export interface FoodFormValues {
   /**
    * The emoji this food shows when there is no photograph of it (#94).
    *
-   * Absent when there is none, and absent is what a cleared icon submits —
-   * never `''`, which would sit in front of the generic glyph in the tile's
-   * fallback chain and render nothing.
+   * `null` when there is none, which is what a cleared icon submits — never
+   * `''`, which would sit in front of the generic glyph in the tile's fallback
+   * chain and render nothing, and never absent, because Convex drops an
+   * `undefined` argument before it arrives and the mutation would read that as
+   * "say nothing about the icon" rather than "take it off".
    */
-  icon?: string
+  icon?: string | null
   /**
    * Where the figures in this form came from, as the form last knew it —
    * prefilled by a lookup, or `manual` from the moment somebody types over a
@@ -89,7 +91,9 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
   // scan flow's URL param and is read-only display here (see /foods/new.tsx).
   const [barcode] = useState(initial?.barcode ?? '')
   const [baseUnit, setBaseUnit] = useState<'g' | 'ml'>(initial?.baseUnit ?? 'g')
-  const [icon, setIcon] = useState(initial?.icon)
+  // `null` on the way in means the same as absent — no icon. The distinction
+  // only matters on the way out, where it is what clears one.
+  const [icon, setIcon] = useState(initial?.icon ?? undefined)
   const [nutritionInputs, setNutritionInputs] = useState(() =>
     toNutrientInputs(initial?.nutritionPer100),
   )
@@ -126,7 +130,9 @@ export function FoodForm({ initial, submitting, onSubmit, sourceNote }: Props) {
           brand: brand.trim() || undefined,
           barcode: barcode || undefined,
           baseUnit,
-          icon,
+          // Always stated, never omitted: this form is the whole truth about
+          // the food, so "no icon" has to travel as `null` and actually clear.
+          icon: icon ?? null,
           nutritionPer100: facts,
           servings: servings.length > 0 ? servings : undefined,
           // No figures, nothing to say about where they came from.

--- a/src/components/foods/IconPicker.test.tsx
+++ b/src/components/foods/IconPicker.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
+import { FOOD_ICONS, IconPicker } from './IconPicker'
+
+/**
+ * The picker is a curated set, and clearing is a real answer (#94).
+ *
+ * The one behaviour worth defending in a test is what "no icon" is stored as:
+ * `undefined`, never `''`. An empty string is set as far as the tile's fallback
+ * chain can tell, so it would sit in front of the generic glyph and render a
+ * blank square — a bug nobody would find by reading the picker.
+ */
+
+test('the set is curated rather than every emoji there is', () => {
+  // Roughly forty was the decision (#75's triage), not an exact number — this
+  // guards the shape of the answer, so that widening it later is a choice
+  // somebody makes rather than something that drifts.
+  expect(FOOD_ICONS.length).toBeGreaterThanOrEqual(30)
+  expect(FOOD_ICONS.length).toBeLessThanOrEqual(50)
+  expect(new Set(FOOD_ICONS).size).toBe(FOOD_ICONS.length)
+})
+
+test('choosing one reports it', () => {
+  const onChange = vi.fn()
+  renderWithI18n(<IconPicker onChange={onChange} />)
+
+  fireEvent.click(screen.getByRole('button', { name: '🍕' }))
+
+  expect(onChange).toHaveBeenCalledWith('🍕')
+})
+
+test('choosing another replaces the first', () => {
+  const onChange = vi.fn()
+  renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
+
+  fireEvent.click(screen.getByRole('button', { name: '🥗' }))
+
+  expect(onChange).toHaveBeenCalledWith('🥗')
+})
+
+test('the chosen one says so', () => {
+  renderWithI18n(<IconPicker value="🍕" onChange={vi.fn()} />)
+
+  expect(screen.getByRole('button', { name: '🍕' }).ariaPressed).toBe('true')
+  expect(screen.getByRole('button', { name: '🥗' }).ariaPressed).toBe('false')
+})
+
+test('clearing reports nothing at all, not an empty string', () => {
+  const onChange = vi.fn()
+  renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'No icon' }))
+
+  expect(onChange).toHaveBeenCalledWith(undefined)
+})
+
+test('pressing the chosen one again clears it', () => {
+  const onChange = vi.fn()
+  renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
+
+  fireEvent.click(screen.getByRole('button', { name: '🍕' }))
+
+  expect(onChange).toHaveBeenCalledWith(undefined)
+})
+
+test('there is nothing to clear until something is chosen', () => {
+  renderWithI18n(<IconPicker onChange={vi.fn()} />)
+
+  expect(screen.queryByRole('button', { name: 'No icon' })).toBeNull()
+})

--- a/src/components/foods/IconPicker.tsx
+++ b/src/components/foods/IconPicker.tsx
@@ -1,0 +1,138 @@
+import { useMessages } from '../../lib/i18n'
+
+/**
+ * The emoji a food or a one-off may wear, curated (#94, #75).
+ *
+ * Forty, not every emoji there is. A full picker is a large component or a
+ * dependency, with a search box in front of thousands of glyphs that are not
+ * food — and the thing being answered here is "which of the handful of shapes
+ * food comes in is this one?", which a grid answers faster than a search does.
+ * Widening it later costs nothing: what is stored is a string either way, so a
+ * value that is no longer in this list still renders.
+ *
+ * Chosen to cover, in this order: what a kitchen is made of (grains, fruit,
+ * vegetables, pulses, protein, dairy), then what a meal looks like when it is
+ * not an ingredient — which is the one-off case, a restaurant plate with no
+ * food behind it — then drinks and the sweet things people log most. Every
+ * Catalog fixture's icon comes from this list, so a built-in food never wears
+ * something nobody could have picked.
+ *
+ * The emoji themselves are **content, not display strings**: they are stored
+ * on the row and never translated (ADR-0011), exactly like a serving's label.
+ * Only the words around the grid live in the message tree.
+ */
+export const FOOD_ICONS = [
+  // Grains and bread
+  '🍞',
+  '🥐',
+  '🌾',
+  '🍚',
+  '🍝',
+  // Fruit
+  '🍎',
+  '🍌',
+  '🍊',
+  '🍓',
+  '🍇',
+  // Vegetables
+  '🥔',
+  '🥕',
+  '🍅',
+  '🥦',
+  '🥬',
+  // Pulses, aromatics and nuts
+  '🧅',
+  '🧄',
+  '🫑',
+  '🫘',
+  '🥜',
+  // Protein
+  '🥚',
+  '🍗',
+  '🥩',
+  '🐟',
+  '🍤',
+  // Dairy and fats
+  '🥛',
+  '🧀',
+  '🧈',
+  '🫒',
+  // A plate rather than an ingredient — what a one-off usually is
+  '🥣',
+  '🥗',
+  '🥪',
+  '🍕',
+  '🍲',
+  // Drinks and sweet things
+  '💧',
+  '☕',
+  '🍵',
+  '🍷',
+  '🍫',
+  '🍬',
+]
+
+interface Props {
+  /** The chosen emoji, or nothing. Never an empty string. */
+  value?: string
+  /**
+   * `undefined` when it is cleared — never `''`. A set-but-empty icon would
+   * sit in front of the generic glyph in the tile's fallback chain and render
+   * a blank square, so "no icon" has to be the absence of one.
+   */
+  onChange: (icon: string | undefined) => void
+  disabled?: boolean
+}
+
+/**
+ * Pick one, or none.
+ *
+ * A grid of full-size targets rather than a dropdown or a text field: a person
+ * logging lunch is holding a phone in one hand, and every cell here is a
+ * 44px tap target reachable without aiming. Pressing the chosen one again
+ * clears it, and the ✕ that appears alongside says so for anybody who would
+ * not think to try — an always-present clear over an empty grid would be a
+ * control that does nothing, which is the same rule the search field follows.
+ */
+export function IconPicker({ value, onChange, disabled }: Props) {
+  const { icon } = useMessages().common
+
+  return (
+    <fieldset className="rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">
+      <legend className="px-1 text-sm font-medium">{icon.label}</legend>
+      <p className="mb-2 text-xs opacity-60">{icon.hint}</p>
+      <div className="flex flex-wrap gap-1">
+        {FOOD_ICONS.map((candidate) => {
+          const chosen = candidate === value
+          return (
+            <button
+              key={candidate}
+              type="button"
+              disabled={disabled}
+              aria-pressed={chosen}
+              onClick={() => onChange(chosen ? undefined : candidate)}
+              className={`flex min-h-11 min-w-11 items-center justify-center rounded-[var(--app-radius)] border text-xl ${
+                chosen
+                  ? 'border-[var(--app-fg)] bg-[var(--app-bg)]'
+                  : 'border-transparent'
+              }`}
+            >
+              {candidate}
+            </button>
+          )
+        })}
+        {value !== undefined && (
+          <button
+            type="button"
+            disabled={disabled}
+            aria-label={icon.none}
+            onClick={() => onChange(undefined)}
+            className="flex min-h-11 min-w-11 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] text-sm opacity-60"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+    </fieldset>
+  )
+}

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -524,6 +524,46 @@ test('a search matching nothing offers the typed term as a one-off', async () =>
   })
 })
 
+/**
+ * A one-off has no food and no recipe behind it, so an emoji is the only
+ * picture it can ever have — and the diary rows are where it shows (#94).
+ */
+test('a one-off can be given an icon, and it goes to the diary with it', async () => {
+  renderSheet()
+  await search('poffertjes at the fair')
+
+  await waitFor(() =>
+    expect(
+      screen.getByText('Nothing found for “poffertjes at the fair”'),
+    ).toBeDefined(),
+  )
+  fireEvent.click(screen.getByText('Log “poffertjes at the fair” as a one-off'))
+  fireEvent.click(screen.getByRole('button', { name: '🍬' }))
+  fireEvent.click(screen.getByText('Add to diary'))
+
+  await waitFor(() => expect(calls.value).toHaveLength(1))
+  expect(calls.value[0][1]).toMatchObject({
+    label: 'poffertjes at the fair',
+    icon: '🍬',
+  })
+})
+
+test('a one-off nobody decorated carries no icon at all', async () => {
+  renderSheet()
+  await search('poffertjes at the fair')
+
+  await waitFor(() =>
+    expect(
+      screen.getByText('Nothing found for “poffertjes at the fair”'),
+    ).toBeDefined(),
+  )
+  fireEvent.click(screen.getByText('Log “poffertjes at the fair” as a one-off'))
+  fireEvent.click(screen.getByText('Add to diary'))
+
+  await waitFor(() => expect(calls.value).toHaveLength(1))
+  expect((calls.value[0][1] as { icon?: string }).icon).toBeUndefined()
+})
+
 test('a search matching nothing also offers adding it as a food', async () => {
   // A one-off is right for a restaurant meal and wrong for a product you will
   // eat again next week: logged once, never findable, so the same search finds

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -18,6 +18,7 @@ import type { AppLink } from '../../lib/appLink'
 import { errorMessage } from '../../lib/errorMessage'
 import { fmt, useMessages } from '../../lib/i18n'
 import { BarcodeScanner } from '../foods/BarcodeScanner'
+import { IconPicker } from '../foods/IconPicker'
 import { BottomSheet } from './BottomSheet'
 import { ComboCard, type ComboSummary } from './ComboCard'
 import { FoodThumbnail } from './FoodThumbnail'
@@ -61,6 +62,8 @@ interface FoodSummary {
   servings?: Serving[]
   /** Resolved by the query from the stored file; null when there is no picture. */
   imageUrl?: string | null
+  /** The emoji somebody picked for it, shown when there is no picture (#94). */
+  icon?: string
 }
 
 interface Props {
@@ -136,6 +139,8 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
     quantity: number
     quantityUnit: QuantityUnit
     nutrition: NutritionFacts
+    /** Only a one-off sends one — everything else has a row to read it from. */
+    icon?: string
   }) {
     const id = await createEntry({ date, meal, ...entry })
     announce(entry.label, [id])
@@ -523,6 +528,7 @@ type LogFn = (entry: {
   quantity: number
   quantityUnit: QuantityUnit
   nutrition: NutritionFacts
+  icon?: string
 }) => Promise<void>
 
 /**
@@ -615,7 +621,9 @@ function FoodCard({
 
   return (
     <ResultCard
-      thumbnail={<FoodThumbnail src={food.imageUrl} alt={food.name} />}
+      thumbnail={
+        <FoodThumbnail src={food.imageUrl} icon={food.icon} alt={food.name} />
+      }
       title={food.name}
       subtitle={food.brand}
       meta={
@@ -786,6 +794,12 @@ function OffCard({
 /**
  * What a search that matched nothing offers: log the words you already typed,
  * with whatever figures you have. A restaurant meal is not a dead end.
+ *
+ * The icon here is the one case that can never be answered any other way: a
+ * one-off has no food and no recipe behind it, so there is nothing for it to
+ * inherit a picture from and there never will be (#94). It is decoration on
+ * something ephemeral — logged once, never reused — and it earns its place
+ * because the diary rows are where it shows.
  */
 function OneOffCard({
   term,
@@ -800,6 +814,7 @@ function OneOffCard({
 }) {
   const { add } = useMessages().nutrition.diary
   const [inputs, setInputs] = useState(() => toNutrientInputs())
+  const [icon, setIcon] = useState<string | undefined>()
   const { busy, error, run } = useLogging()
 
   return (
@@ -816,6 +831,9 @@ function OneOffCard({
         }
         disabled={busy}
       />
+      <div className="mt-3">
+        <IconPicker value={icon} onChange={setIcon} disabled={busy} />
+      </div>
       <Confirm
         disabled={false}
         reason=""
@@ -828,6 +846,7 @@ function OneOffCard({
               quantity: 1,
               quantityUnit: 'piece',
               nutrition: nutrientInputsToFacts(inputs),
+              icon,
             })
           })
         }

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -239,6 +239,11 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
                       entry.foodId || entry.recipeId
                         ? undefined
                         : entry.nutrition,
+                    // Same rule as the figures beside it: only a one-off keeps
+                    // its own, and this payload rebuilds every row, so leaving
+                    // it out would drop the icon on every Combo edit.
+                    icon:
+                      entry.foodId || entry.recipeId ? undefined : entry.icon,
                   })),
                 })
               },

--- a/src/components/nutrition/ConsumptionEntryRow.test.tsx
+++ b/src/components/nutrition/ConsumptionEntryRow.test.tsx
@@ -157,6 +157,36 @@ test('a failed save keeps the row in edit mode and shows an error', async () => 
   expect(screen.getByText('Save')).toBeDefined()
 })
 
+/**
+ * The diary row is the whole argument for decorating a one-off (#94): it is
+ * logged once and never reused, so this is the only place the icon is ever
+ * seen. An entry that was given none reads exactly as it did before.
+ */
+test('a one-off shows the icon it was logged with', () => {
+  renderWithI18n(
+    <ConsumptionEntryRow
+      nav={nav}
+      entry={{ ...entry, label: 'Poffertjes at the fair', icon: '🍬' }}
+      onUpdate={vi.fn()}
+      onDelete={vi.fn()}
+    />,
+  )
+  expect(screen.getByText('🍬')).toBeDefined()
+  expect(screen.getByText('Poffertjes at the fair')).toBeDefined()
+})
+
+test('an entry with no icon renders exactly as it always did', () => {
+  const { container } = renderWithI18n(
+    <ConsumptionEntryRow
+      nav={nav}
+      entry={entry}
+      onUpdate={vi.fn()}
+      onDelete={vi.fn()}
+    />,
+  )
+  expect(container.querySelector('[aria-hidden="true"]')).toBeNull()
+})
+
 test('an invalid quantity does not call onUpdate', () => {
   const onUpdate = vi.fn()
   renderWithI18n(

--- a/src/components/nutrition/ConsumptionEntryRow.tsx
+++ b/src/components/nutrition/ConsumptionEntryRow.tsx
@@ -16,6 +16,12 @@ export interface ConsumptionEntryData {
   nutrition: NutritionFacts
   recipeId?: string
   foodId?: string
+  /**
+   * The emoji a one-off was given (#94). Only a one-off carries one: an entry
+   * with a food or a recipe behind it has something to read a picture from,
+   * and does not keep a copy of the answer here.
+   */
+  icon?: string
 }
 
 interface Props {
@@ -43,6 +49,14 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
     <li className="py-2 text-sm">
       <div className="flex items-center justify-between gap-2">
         <div>
+          {/* Decoration, and marked as such: the label beside it already says
+              what this is, so a screen reader repeating the emoji's name would
+              only be reading the row twice. */}
+          {entry.icon && (
+            <span aria-hidden="true" className="mr-1.5">
+              {entry.icon}
+            </span>
+          )}
           <span className="font-medium">{entry.label}</span>
           <span className="ml-2 opacity-60">
             {entry.quantity} {units[entry.quantityUnit]}

--- a/src/components/nutrition/FoodThumbnail.test.tsx
+++ b/src/components/nutrition/FoodThumbnail.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { expect, test } from 'vitest'
+import { FoodThumbnail } from './FoodThumbnail'
+
+/**
+ * The tile's fallback chain, all four ways round (#94).
+ *
+ * Pure display logic with nothing behind it — no query, no locale, no router —
+ * so it is tested here rather than through the add sheet, where it would be
+ * one assertion inside a component that has to be mocked into existence first.
+ *
+ * The case worth writing down is the first: a food may have both a photograph
+ * and an icon, and which of the two wins is a decision, not an accident.
+ */
+
+const GLYPH = '🍽'
+
+test('a photograph wins over an icon', () => {
+  render(
+    <FoodThumbnail
+      src="https://example.test/nutella.jpg"
+      icon="🍫"
+      alt="Nutella"
+    />,
+  )
+
+  expect(screen.getByAltText('Nutella')).toBeDefined()
+  expect(screen.queryByText('🍫')).toBeNull()
+  expect(screen.queryByText(GLYPH)).toBeNull()
+})
+
+test('a photograph and nothing else is the photograph', () => {
+  render(<FoodThumbnail src="https://example.test/nutella.jpg" alt="Nutella" />)
+
+  expect(screen.getByAltText('Nutella')).toBeDefined()
+  expect(screen.queryByText(GLYPH)).toBeNull()
+})
+
+test('an icon stands in when there is no photograph', () => {
+  render(<FoodThumbnail icon="🍫" alt="Nutella" />)
+
+  expect(screen.getByText('🍫')).toBeDefined()
+  expect(screen.queryByAltText('Nutella')).toBeNull()
+  expect(screen.queryByText(GLYPH)).toBeNull()
+})
+
+test('neither leaves the generic glyph exactly where it was', () => {
+  render(<FoodThumbnail alt="Nutella" />)
+
+  expect(screen.getByText(GLYPH)).toBeDefined()
+  expect(screen.queryByAltText('Nutella')).toBeNull()
+})
+
+/**
+ * A query that resolved to no stored picture hands back `null`, not
+ * `undefined` — the icon has to answer for that the same way.
+ */
+test('a food whose picture query came back empty still shows its icon', () => {
+  render(<FoodThumbnail src={null} icon="🥛" alt="Milk" />)
+
+  expect(screen.getByText('🥛')).toBeDefined()
+})

--- a/src/components/nutrition/FoodThumbnail.tsx
+++ b/src/components/nutrition/FoodThumbnail.tsx
@@ -5,16 +5,27 @@
  * to the left when a food has no image makes a list of results harder to read
  * than one with no images at all.
  *
- * The source is a URL either way, but not from the same place. A food of your
- * own has its picture stored with it and this is a Convex storage URL; a live
- * Open Food Facts result has nothing stored, so it renders theirs directly and
- * the row stops existing when the search does (#69).
+ * Three tiers, in this order — **photograph, then chosen icon, then the generic
+ * glyph** (#94, superseding the photo-or-glyph fallback #69 shipped as
+ * provisional). Each is a weaker answer to the same question than the one
+ * before it: a photograph is this product, an emoji is what somebody said this
+ * is, and the glyph is only "this is food". A food with a photograph *and* an
+ * icon shows the photograph; the icon does not go anywhere, it just is not
+ * needed while there is something better.
+ *
+ * The picture's source is a URL either way, but not from the same place. A food
+ * of your own has its picture stored with it and this is a Convex storage URL;
+ * a live Open Food Facts result has nothing stored, so it renders theirs
+ * directly and the row stops existing when the search does (#69).
  */
 export function FoodThumbnail({
   src,
+  icon,
   alt,
 }: {
   src?: string | null
+  /** The emoji this food carries, if somebody picked one. */
+  icon?: string
   alt: string
 }) {
   return (
@@ -26,6 +37,13 @@ export function FoodThumbnail({
           loading="lazy"
           className="h-full w-full object-cover"
         />
+      ) : icon ? (
+        // Full opacity, unlike the glyph below it: this one was chosen, and
+        // dimming somebody's answer the way a placeholder is dimmed would say
+        // the wrong thing about it.
+        <span aria-hidden="true" className="text-xl">
+          {icon}
+        </span>
       ) : (
         <span aria-hidden="true" className="text-sm opacity-40">
           🍽

--- a/src/lib/i18n/messages/en/common.ts
+++ b/src/lib/i18n/messages/en/common.ts
@@ -30,6 +30,19 @@ export const common = {
     didNotWork: 'That did not work — try again.',
   },
 
+  /**
+   * The emoji field a food and a one-off both use (#94).
+   *
+   * The emoji themselves are content and are never translated — they are
+   * stored on the row, the way a serving's label is (ADR-0011). Only these
+   * words around the grid are.
+   */
+  icon: {
+    label: 'Icon',
+    hint: 'Shown when there is no picture of this.',
+    none: 'No icon',
+  },
+
   /** The photo field a recipe and a child's profile both use. */
   image: {
     label: 'Photo',

--- a/src/lib/i18n/messages/nl/common.ts
+++ b/src/lib/i18n/messages/nl/common.ts
@@ -24,6 +24,12 @@ export const common = {
     didNotWork: 'Dat lukte niet — probeer het opnieuw.',
   },
 
+  icon: {
+    label: 'Icoon',
+    hint: 'Wordt getoond als er geen foto van is.',
+    none: 'Geen icoon',
+  },
+
   image: {
     label: 'Foto',
     uploading: 'Uploaden…',


### PR DESCRIPTION
Closes #94

**Stacked on #110, which merges first.** (#95 and #97 were the other two in the stack; #95 has merged.)

## What changed

`foods.icon` and `consumptionEntries.icon`, both optional, so nothing is backfilled and no migration is required. `FoodThumbnail`'s fallback chain is now **photograph → chosen icon → generic glyph by `baseUnit`**.

A one-off gets its own field because it has no `foodId` and no `recipeId`, so it has nothing to inherit a picture from, ever.

The stored value is **content, not a display string** — so it is stored, not translated (ADR-0011), the same way a serving's `label` already is. The emoji are not in the message tree; only the labels around the picker are, in both locales.

The picker sits in `FoodForm`, which is what makes the icon available while reviewing an Open Food Facts import — the criterion the issue calls out as where it is most obviously missing. #110 made that form the review screen, so there was no second editor to build.

Catalog rows stay read-only: `icon` goes through `foods.update`, which already calls `assertNotCatalog`. 31 Catalog fixtures set one, which is where an icon shows most since those rows have no photo.

### Where you will actually see one — a known gap

**Correcting an earlier version of this description, which claimed the chain applies "everywhere tiles appear".** That was misleading: tiles barely appear anywhere yet. `FoodThumbnail` is rendered in exactly two places, both in the add sheet — the food card and the Open Food Facts result card.

Not covered by this PR, and raised from review of the preview (#114):

- **The diary** (`ConsumptionEntryRow`) renders `entry.icon` as a bare emoji with no fallback chain, so a row for a *food* that has an icon shows nothing — `entry.icon` is only ever set on one-offs.
- **Recipes and Combos** have no thumbnail at all.
- **The sample household sets no icons**, so a preview cannot really demonstrate the feature. Only Catalog foods, reachable by typing in the add sheet, show one.

This PR delivers the field, the picker, the fallback component and the Catalog fixtures. Putting the tile everywhere a thing without a picture appears is #114.

### An icon argument has three states, not two

Convex drops an argument whose value is `undefined` before it reaches the server. An optional string could therefore only say *this one* or *nothing at all* — and *nothing at all* had to mean both "leave what is there" and "take it off". So:

- **`null` is the clear**, because it survives the wire. **Omitting the field leaves the icon alone**, which is what any caller that knows nothing about icons should do.
- An `iconPatch()` helper produces the patch fragment, so `update` and `upsertFromOff` cannot drift apart. Both create paths normalise `null` to absent, since a new row has nothing to leave alone.
- `FoodForm` always states its answer (`icon ?? null`) — it is the whole truth about the food, so "no icon" has to travel rather than be omitted.

### A Combo keeps a one-off's icon

Carried through the `comboItems` schema, `resolveComponent`, `ComboComponent`, `ComboEntryInput`/`comboEntries` and `createMany`, by the same rule the figures beside it already followed: a food or a Recipe is re-read on every log and needs no copy, while a one-off has nowhere else to keep one. Without it the icon survived the first log and vanished from every log made through the Combo afterwards.

## Tests

`pnpm typecheck`, `pnpm test` (1102 passing, 98 files) and `pnpm check` all pass.

- `FoodThumbnail.test.tsx` — the fallback chain all four ways round, including photo-and-icon-both-set, which is a decision rather than an accident. Plus a `src={null}` case, because a picture query that resolved to nothing hands back `null`, not `undefined`.
- `IconPicker.test.tsx` — the set is curated rather than open-ended, choosing replaces, pressing the chosen one again clears, and there is nothing to clear until something is chosen.
- `convex/foods.test.ts` — saved and read back, absent when nobody chose one, changed, **cleared by sending `null`**, **left alone by an update that says nothing about it**, and surviving an Open Food Facts import.
- `convex/consumption.test.ts` — a one-off's icon written with the entry and coming back on the day.
- `convex/combos.test.ts` — a one-off's icon captured into a Combo and still there when it is logged again, and a food-backed component *not* picking up a stale icon of its own.

Note what the suite could not tell anyone: every one of these passes while the icon is invisible on all but two screens. Coverage at the seams is not coverage of the feature.

## Acceptance criteria I could not verify

- **"The picker is usable one-handed on a phone"** — not verifiable here, and review of the preview has since said it is too large (#115).
- **The curated set itself** — whether these are the right emoji, and whether roughly forty is too many to scan, is a judgement to make while using it.
- **How an icon reads at tile size** next to real photographs in a populated diary — not answerable until #114 puts tiles there.

## Provenance

This branch was written by an agent that was terminated by an account spend limit partway through its test pass. The implementation commit was already pushed; the test commit is its uncommitted work, which I verified and committed rather than discard. It reported no summary, so this description is written from the diff — including, initially, an overclaim about coverage that the preview corrected.

Codex review then found two genuine defects, both fixed in `c4d9889`, and both invisible to the passing suite it arrived with.