### PR TITLE
fix(nutrition): import named OFF results directly

### DIFF
--- a/convex/foods.test.ts
+++ b/convex/foods.test.ts
@@ -482,9 +482,9 @@ describe('where a food’s figures came from', () => {
 })
 
 /**
- * Every Open Food Facts import is reviewed before it is saved (#93): choosing a
- * result opens the pre-filled form, and *saving* is what imports the food and
- * logs the entry.
+ * A person may check an Open Food Facts result before it is saved (#112).
+ * Choosing that secondary action opens the pre-filled form, and *saving* is
+ * what imports the food and logs the entry.
  *
  * The property that makes that safe is the first one below — the lookup that
  * fills the form is a read, all the way down. Somebody who opens the review and

--- a/convex/foods.test.ts
+++ b/convex/foods.test.ts
@@ -59,6 +59,19 @@ describe('the food Catalog', () => {
     expect(await t.query(api.foods.get, { id: hagelslag })).toBeNull()
     expect(await t.query(api.foods.search, { term: 'hagelslag' })).toEqual([])
   })
+
+  test('refuses an edit from somebody other than the creator', async () => {
+    const { t, hagelslag } = await seed()
+
+    await expect(
+      t.withIdentity(asBob).mutation(api.foods.update, {
+        id: hagelslag,
+        name: 'Bob’s hagelslag',
+        baseUnit: 'g',
+        nutritionPer100: { calories: 500 },
+      }),
+    ).rejects.toThrow('Only the person who created this food can edit it.')
+  })
 })
 
 /**
@@ -175,6 +188,52 @@ describe('a food’s picture', () => {
     const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
     expect(food?.name).toBe('Nutella')
     expect(food?.imageUrl).toBeNull()
+  })
+
+  test('a background OFF picture attaches after the food is ready to log', async () => {
+    const t = testConvex()
+    await t.withIdentity(asAlice).mutation(api.users.ensureUser, {})
+    const id = await t.withIdentity(asAlice).mutation(api.foods.upsertFromOff, {
+      barcode: '3017620422003',
+      name: 'Nutella',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 539 },
+    })
+    const imageId = await storedImage(t, 'nutella')
+
+    await t
+      .withIdentity(asAlice)
+      .mutation(api.foods.attachOffImage, { id, imageId })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.imageId).toBe(imageId)
+    expect(food?.imageUrl).toBeTruthy()
+  })
+
+  test('a background OFF picture cannot overwrite a local edit', async () => {
+    const t = testConvex()
+    await t.withIdentity(asAlice).mutation(api.users.ensureUser, {})
+    const id = await t.withIdentity(asAlice).mutation(api.foods.upsertFromOff, {
+      barcode: '3017620422003',
+      name: 'Nutella',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 539 },
+    })
+    await t.withIdentity(asAlice).mutation(api.foods.update, {
+      id,
+      name: 'My Nutella',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 530 },
+    })
+    const imageId = await storedImage(t, 'too late')
+
+    await t
+      .withIdentity(asAlice)
+      .mutation(api.foods.attachOffImage, { id, imageId })
+
+    const food = await t.withIdentity(asAlice).query(api.foods.get, { id })
+    expect(food?.imageId).toBeUndefined()
+    expect(await t.run(async (ctx) => ctx.db.system.get(imageId))).toBeNull()
   })
 
   test('re-importing with a new picture deletes the one it replaces', async () => {

--- a/convex/foods.ts
+++ b/convex/foods.ts
@@ -179,6 +179,9 @@ export const update = mutation({
     const food = await ctx.db.get(id)
     if (!food) throw new Error('Food not found')
     assertNotCatalog(food)
+    if (food.createdBy !== user._id) {
+      throw new ConvexError('Only the person who created this food can edit it.')
+    }
     await ctx.db.patch(id, {
       ...rest,
       // An absent `servings` means "none" rather than "leave what is there":
@@ -216,8 +219,8 @@ export const upsertFromOff = mutation({
   args: {
     ...savedFoodFields,
     barcode: v.string(),
-    // Already fetched and stored by `foodsLookup.importFromOff`, which is the
-    // only thing that can make the network call this needs.
+    // Either already fetched by `foodsLookup.importFromOff`, or omitted for
+    // a fast add-sheet import whose picture follows in the background.
     imageId: v.optional(v.id('_storage')),
     // A direct import uses `imported`; a person who checked first and
     // corrected the figures sends `manual` instead, and the food says the
@@ -272,6 +275,35 @@ export const upsertFromOff = mutation({
       source: 'openfoodfacts',
       createdBy: user._id,
     })
+  },
+})
+
+/**
+ * Attaches an OFF image after its food is already available to log.
+ *
+ * An import writes its row before downloading the optional image so the
+ * external host never delays the add-sheet return. If a row gained an image
+ * while the fetch was in flight, keep that newer one and delete this
+ * unreachable blob instead.
+ */
+export const attachOffImage = mutation({
+  args: { id: v.id('foods'), imageId: v.id('_storage') },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx)
+    if (!user) throw new Error('Not authenticated')
+    const food = await ctx.db.get(args.id)
+    if (!food) {
+      await deleteStoredFile(ctx, args.imageId)
+      return
+    }
+    // The upload may finish after somebody corrects the food in the add sheet.
+    // Treat that exactly like the rescan path: their local edit wins, and this
+    // no-longer-needed file is removed.
+    if (food.seedKey !== undefined || food.localEdited || food.imageId) {
+      await deleteStoredFile(ctx, args.imageId)
+      return
+    }
+    await ctx.db.patch(food._id, { imageId: args.imageId })
   },
 })
 

--- a/convex/foods.ts
+++ b/convex/foods.ts
@@ -219,10 +219,9 @@ export const upsertFromOff = mutation({
     // Already fetched and stored by `foodsLookup.importFromOff`, which is the
     // only thing that can make the network call this needs.
     imageId: v.optional(v.id('_storage')),
-    // Every import is reviewed before it is saved (spec §6), so "imported" is
-    // the default rather than the certainty: a person who corrected the
-    // figures in that review form sends `manual` instead, and the food says
-    // the true thing about the numbers it actually carries.
+    // A direct import uses `imported`; a person who checked first and
+    // corrected the figures sends `manual` instead, and the food says the
+    // true thing about the numbers it actually carries (#112).
     nutritionSource: v.optional(nutritionSourceValidator),
   },
   handler: async (ctx, args) => {

--- a/convex/foodsLookup.ts
+++ b/convex/foodsLookup.ts
@@ -41,9 +41,9 @@ export function isOffImageUrl(url: string): boolean {
   }
 }
 
-// Fetches + maps a barcode from Open Food Facts, without saving anything —
-// the client shows the result for review and calls `foods.upsertFromOff`
-// (or falls back to a blank manual form) only once the user confirms.
+// Fetches + maps a barcode from Open Food Facts, without saving anything. The
+// client may import a named result directly, or show it for review first; a
+// nameless result always needs that required-name form.
 export const lookupBarcode = action({
   args: { barcode: v.string() },
   handler: async (ctx, args) => {
@@ -143,10 +143,9 @@ export const importFromOff = action({
     nutritionPer100: nutritionValidator,
     servings: v.optional(v.array(servingValidator)),
     imageUrl: v.optional(v.string()),
-    // Carried through rather than assumed: every import is now reviewed in the
-    // food form before it is saved (#93), and somebody who corrected a figure
-    // in that form arrives here saying `manual`. Absent still means `imported`,
-    // which `foods.upsertFromOff` is the one to decide.
+    // A direct import carries its figures as `imported`; somebody who checks
+    // first and corrects one arrives here saying `manual`. Absent still means
+    // `imported`, which `foods.upsertFromOff` is the one to decide (#112).
     nutritionSource: v.optional(nutritionSourceValidator),
     // The emoji picked while reviewing (#94) — which is where one is most
     // obviously missing, because an Open Food Facts product with no photograph

--- a/convex/foodsLookup.ts
+++ b/convex/foodsLookup.ts
@@ -23,8 +23,9 @@ const MAX_IMAGE_BYTES = 2 * 1024 * 1024
 /**
  * Where a food picture may come from.
  *
- * `importFromOff` is a public action, so the `imageUrl` it is handed is
- * whatever a caller sent — not necessarily what our own search returned.
+ * `importFromOff` and `storeOffImage` are public actions, so the `imageUrl`
+ * each is handed is whatever a caller sent — not necessarily what our own
+ * search returned.
  * `safeFetch` already refuses private and loopback addresses, which closes
  * SSRF; this closes the other half, which is gather's storage being used to
  * mirror arbitrary files off the public internet. Only Open Food Facts.
@@ -103,7 +104,7 @@ export const refreshFromOff = action({
  * is not a thumbnail). A `content-length` that lies is caught by measuring the
  * blob after, before anything is stored.
  */
-async function storeOffImage(
+async function fetchAndStoreOffImage(
   ctx: ActionCtx,
   url: string | undefined,
 ): Promise<Id<'_storage'> | undefined> {
@@ -158,11 +159,35 @@ export const importFromOff = action({
     const identity = await ctx.auth.getUserIdentity()
     if (!identity) throw new ConvexError('Not authenticated')
     const { imageUrl, ...fields } = args
-    const imageId = await storeOffImage(ctx, imageUrl)
+    const imageId = await fetchAndStoreOffImage(ctx, imageUrl)
     // The mutation decides whether this blob is used at all — an existing row
     // somebody has edited keeps what it has — and deletes it if not, so a
     // refused import leaves nothing behind in storage.
     return await ctx.runMutation(api.foods.upsertFromOff, { ...fields, imageId })
+  },
+})
+
+/**
+ * Fetches an OFF picture after the food has already been saved. Image failures
+ * are intentionally silent: the food's data is usable without one, and the
+ * add sheet must not wait for an external image host before logging.
+ */
+export const storeOffImage = action({
+  args: { id: v.id('foods'), imageUrl: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity) throw new ConvexError('Not authenticated')
+    // This public action fetches before it can know whether storage will
+    // accept the blob. Reject an absent or read-only target first, otherwise a
+    // caller could leave an unreachable file behind by naming a Catalog row.
+    const food = await ctx.runQuery(api.foods.get, { id: args.id })
+    if (!food || food.seedKey !== undefined) return
+    const imageId = await fetchAndStoreOffImage(ctx, args.imageUrl)
+    if (!imageId) return
+    await ctx.runMutation(api.foods.attachOffImage, {
+      id: args.id,
+      imageId,
+    })
   },
 })
 

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -57,6 +57,7 @@ const offResults = vi.hoisted(() => ({
       name: 'Volle melk',
       brand: 'Zaanse Hoeve',
       nutritionPer100: { calories: 64 },
+      imageUrl: 'https://images.openfoodfacts.org/images/products/front.jpg',
     },
   ],
 }))
@@ -69,6 +70,8 @@ const offProduct = vi.hoisted(() => ({ value: null as unknown }))
 /** Makes the next fast import fail, to exercise the retry state. */
 const offImportFailure = vi.hoisted(() => ({ value: null as Error | null }))
 const calls = vi.hoisted(() => ({ value: [] as Array<[string, unknown]> }))
+const offImageCalls = vi.hoisted(() => ({ value: [] as unknown[] }))
+const currentUser = vi.hoisted(() => ({ value: { _id: 'user1' } as unknown }))
 
 vi.mock('convex/react', () => ({
   useQuery: (name: string, args: { term?: string } | 'skip') => {
@@ -85,6 +88,7 @@ vi.mock('convex/react', () => ({
     if (name === 'foods:get') {
       return args === 'skip' ? undefined : justAddedFood.value
     }
+    if (name === 'users:me') return currentUser.value
     if (name === 'recipes:listAcrossMyGroups') return recipes.value
     if (name === 'combos:list') return combos.value
     if (name === 'consumption:loggedAmountsForFood') {
@@ -94,14 +98,17 @@ vi.mock('convex/react', () => ({
   },
   useMutation: (name: string) => async (args: unknown) => {
     calls.value.push([name, args])
+    if (name === 'foods:upsertFromOff') {
+      if (offImportFailure.value) throw offImportFailure.value
+      return 'food9'
+    }
     return 'entry1'
   },
   useAction: (name: string) => async (args: { term?: string }) => {
     if (name === 'foodsLookup:lookupBarcode') return offProduct.value
-    if (name === 'foodsLookup:importFromOff') {
-      calls.value.push([name, args])
-      if (offImportFailure.value) throw offImportFailure.value
-      return 'food9'
+    if (name === 'foodsLookup:storeOffImage') {
+      offImageCalls.value.push(args)
+      return undefined
     }
     if (name !== 'foodsLookup:searchByName') return null
     const term = (args.term ?? '').toLowerCase()
@@ -117,14 +124,16 @@ vi.mock('../../../convex/_generated/api', () => ({
       get: 'foods:get',
       getByBarcode: 'foods:getByBarcode',
       upsertFromOff: 'foods:upsertFromOff',
+      update: 'foods:update',
     },
     foodsLookup: {
       searchByName: 'foodsLookup:searchByName',
       lookupBarcode: 'foodsLookup:lookupBarcode',
-      importFromOff: 'foodsLookup:importFromOff',
+      storeOffImage: 'foodsLookup:storeOffImage',
     },
     recipes: { listAcrossMyGroups: 'recipes:listAcrossMyGroups' },
     combos: { list: 'combos:list', replaceItems: 'combos:replaceItems' },
+    users: { me: 'users:me' },
     consumption: {
       create: 'consumption:create',
       createMany: 'consumption:createMany',
@@ -205,6 +214,8 @@ beforeEach(() => {
   justAddedFood.value = null
   offProduct.value = null
   offImportFailure.value = null
+  offImageCalls.value = []
+  currentUser.value = { _id: 'user1' }
   // jsdom has no `navigator.mediaDevices`, which is what the scanner asks for
   // first. A stand-in that refuses is the state a phone with the camera denied
   // is in, and it leaves the manual barcode entry — the part this suite drives.
@@ -324,7 +335,7 @@ test('choosing an Open Food Facts result imports it and returns ready to log', a
   await waitFor(() => expect(calls.value).toHaveLength(1))
   expect(calls.value).toEqual([
     [
-      'foodsLookup:importFromOff',
+      'foods:upsertFromOff',
       {
         barcode: '8712345678901',
         name: 'Volle melk',
@@ -340,6 +351,12 @@ test('choosing an Open Food Facts result imports it and returns ready to log', a
       to: '/g/$groupSlug/nutrition/add',
       params: { groupSlug: 'jansen-household' },
       search: { date: '2026-07-18', meal: 'breakfast', food: 'food9' },
+    },
+  ])
+  expect(offImageCalls.value).toEqual([
+    {
+      id: 'food9',
+      imageUrl: 'https://images.openfoodfacts.org/images/products/front.jpg',
     },
   ])
 })
@@ -410,7 +427,7 @@ test('a scanned product nobody has imports and returns ready to log', async () =
 
   await waitFor(() => expect(calls.value).toHaveLength(1))
   expect(calls.value[0]).toEqual([
-    'foodsLookup:importFromOff',
+    'foods:upsertFromOff',
     {
       barcode: '3017620422003',
       name: 'Nutella',
@@ -428,6 +445,24 @@ test('a scanned product nobody has imports and returns ready to log', async () =
       food: 'food9',
     },
   })
+})
+
+test('a failed scanned import tells the person what happened', async () => {
+  offImportFailure.value = new Error('offline')
+  offProduct.value = {
+    name: 'Nutella',
+    brand: 'Ferrero',
+    nutritionPer100: { calories: 539 },
+  }
+  renderSheet()
+  await scan('3017620422003')
+
+  await waitFor(() =>
+    expect(
+      screen.getByText('Couldn’t add this food — try again.'),
+    ).toBeDefined(),
+  )
+  expect(navigated.value).toEqual([])
 })
 
 test('a scanned product with no name is asked about rather than imported as ""', async () => {
@@ -471,6 +506,130 @@ test('the food a review form just saved comes back expanded and ready to log', a
     quantityUnit: 'ml',
     nutrition: { calories: 64 },
   })
+})
+
+test('a food returned through the same add-sheet route opens after its search changes', async () => {
+  const { rerender } = renderWithI18n(
+    <AddSheet date="2026-07-18" meal="breakfast" nav={nav} onClose={vi.fn()} />,
+  )
+  justAddedFood.value = {
+    _id: 'food9',
+    name: 'Volle melk',
+    baseUnit: 'ml',
+    nutritionPer100: { calories: 64 },
+  }
+
+  rerender(
+    <AddSheet
+      date="2026-07-18"
+      meal="breakfast"
+      justAddedFoodId="food9"
+      nav={nav}
+      onClose={vi.fn()}
+    />,
+  )
+
+  await waitFor(() => expect(screen.getByText('Just added')).toBeDefined())
+  expect(screen.getAllByLabelText('Amount')[0]).toHaveValue('100')
+})
+
+test('a just-added food is not repeated in its matching search results', async () => {
+  justAddedFood.value = {
+    _id: 'food1',
+    name: 'Halfvolle melk',
+    brand: 'Campina',
+    baseUnit: 'ml',
+    nutritionPer100: { calories: 46, protein: 3.5 },
+  }
+  renderSheet(vi.fn(), 'food1')
+  await search('melk')
+
+  await waitFor(() => expect(screen.getByText('Just added')).toBeDefined())
+  expect(screen.getAllByText('Halfvolle melk')).toHaveLength(1)
+})
+
+test('returning from a second import starts with a fresh food card', async () => {
+  const { rerender } = renderWithI18n(
+    <AddSheet
+      date="2026-07-18"
+      meal="breakfast"
+      justAddedFoodId="food9"
+      nav={nav}
+      onClose={vi.fn()}
+    />,
+  )
+  justAddedFood.value = {
+    _id: 'food9',
+    name: 'First milk',
+    baseUnit: 'ml',
+    nutritionPer100: { calories: 64 },
+    createdBy: 'user1',
+  }
+  rerender(
+    <AddSheet
+      date="2026-07-18"
+      meal="breakfast"
+      justAddedFoodId="food9"
+      nav={nav}
+      onClose={vi.fn()}
+    />,
+  )
+  await waitFor(() => expect(screen.getByText('First milk')).toBeDefined())
+  fireEvent.click(screen.getByText('Edit food details'))
+  expect(screen.getByText('Save food')).toBeDefined()
+
+  justAddedFood.value = {
+    _id: 'food10',
+    name: 'Second milk',
+    baseUnit: 'ml',
+    nutritionPer100: { calories: 64 },
+    createdBy: 'user1',
+  }
+  rerender(
+    <AddSheet
+      date="2026-07-18"
+      meal="breakfast"
+      justAddedFoodId="food10"
+      nav={nav}
+      onClose={vi.fn()}
+    />,
+  )
+
+  await waitFor(() => expect(screen.getByText('Second milk')).toBeDefined())
+  expect(screen.queryByText('Save food')).toBeNull()
+})
+
+test('an expanded food card edits the full food before it is logged', async () => {
+  justAddedFood.value = {
+    _id: 'food9',
+    name: 'Volle melk',
+    barcode: '8712345678901',
+    baseUnit: 'ml',
+    nutritionPer100: { calories: 64 },
+    nutritionSource: 'imported',
+    createdBy: 'user1',
+  }
+  renderSheet(vi.fn(), 'food9')
+
+  await waitFor(() => expect(screen.getByText('Just added')).toBeDefined())
+  fireEvent.click(screen.getByText('Edit food details'))
+  fireEvent.change(screen.getByLabelText('Name'), {
+    target: { value: 'Corrected milk' },
+  })
+  fireEvent.click(screen.getByText('Save food'))
+
+  await waitFor(() =>
+    expect(calls.value).toContainEqual([
+      'foods:update',
+      expect.objectContaining({
+        id: 'food9',
+        name: 'Corrected milk',
+        barcode: '8712345678901',
+        baseUnit: 'ml',
+        nutritionPer100: { calories: 64 },
+      }),
+    ]),
+  )
 })
 
 test('the search field offers a clear only while there is something to clear', async () => {

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -66,6 +66,8 @@ const existingFood = vi.hoisted(() => ({ value: null as unknown }))
 const justAddedFood = vi.hoisted(() => ({ value: null as unknown }))
 /** What `foodsLookup.lookupBarcode` finds on Open Food Facts. */
 const offProduct = vi.hoisted(() => ({ value: null as unknown }))
+/** Makes the next fast import fail, to exercise the retry state. */
+const offImportFailure = vi.hoisted(() => ({ value: null as Error | null }))
 const calls = vi.hoisted(() => ({ value: [] as Array<[string, unknown]> }))
 
 vi.mock('convex/react', () => ({
@@ -96,6 +98,11 @@ vi.mock('convex/react', () => ({
   },
   useAction: (name: string) => async (args: { term?: string }) => {
     if (name === 'foodsLookup:lookupBarcode') return offProduct.value
+    if (name === 'foodsLookup:importFromOff') {
+      calls.value.push([name, args])
+      if (offImportFailure.value) throw offImportFailure.value
+      return 'food9'
+    }
     if (name !== 'foodsLookup:searchByName') return null
     const term = (args.term ?? '').toLowerCase()
     return offResults.value.filter((r) => r.name.toLowerCase().includes(term))
@@ -114,6 +121,7 @@ vi.mock('../../../convex/_generated/api', () => ({
     foodsLookup: {
       searchByName: 'foodsLookup:searchByName',
       lookupBarcode: 'foodsLookup:lookupBarcode',
+      importFromOff: 'foodsLookup:importFromOff',
     },
     recipes: { listAcrossMyGroups: 'recipes:listAcrossMyGroups' },
     combos: { list: 'combos:list', replaceItems: 'combos:replaceItems' },
@@ -196,6 +204,7 @@ beforeEach(() => {
   existingFood.value = null
   justAddedFood.value = null
   offProduct.value = null
+  offImportFailure.value = null
   // jsdom has no `navigator.mediaDevices`, which is what the scanner asks for
   // first. A stand-in that refuses is the state a phone with the camera denied
   // is in, and it leaves the manual barcode entry — the part this suite drives.
@@ -306,23 +315,68 @@ test('digits still being typed are an ordinary search, not a lookup', async () =
   expect(screen.queryByText('Volle melk')).toBeNull()
 })
 
-test('choosing an Open Food Facts result opens the review form and writes nothing', async () => {
+test('choosing an Open Food Facts result imports it and returns ready to log', async () => {
   renderSheet()
   await search('volle melk')
   await waitFor(() => expect(screen.getByText('Open Food Facts')).toBeDefined())
   fireEvent.click(screen.getByText('Volle melk'))
 
-  // No serving picker, no confirm: there is nothing to log yet, because there
-  // is no food yet. What is offered is the review that would make one.
-  expect(screen.queryByText('Add to diary')).toBeNull()
-  const review = screen.getByText('Check and add')
+  await waitFor(() => expect(calls.value).toHaveLength(1))
+  expect(calls.value).toEqual([
+    [
+      'foodsLookup:importFromOff',
+      {
+        barcode: '8712345678901',
+        name: 'Volle melk',
+        brand: 'Zaanse Hoeve',
+        baseUnit: 'g',
+        nutritionPer100: { calories: 64 },
+        nutritionSource: 'imported',
+      },
+    ],
+  ])
+  expect(navigated.value).toEqual([
+    {
+      to: '/g/$groupSlug/nutrition/add',
+      params: { groupSlug: 'jansen-household' },
+      search: { date: '2026-07-18', meal: 'breakfast', food: 'food9' },
+    },
+  ])
+})
+
+test('checking an Open Food Facts result first still opens review without importing', async () => {
+  renderSheet()
+  await search('volle melk')
+  await waitFor(() => expect(screen.getByText('Open Food Facts')).toBeDefined())
+
+  const review = screen.getByText('Check first')
   expect(review).toHaveAttribute(
     'href',
     '/g/jansen-household/foods/new?barcode=8712345678901&returnDate=2026-07-18&returnMeal=breakfast',
   )
-  // Following it is a navigation, not a write. Nothing has been imported and
-  // nothing has been logged.
   expect(calls.value).toEqual([])
+})
+
+test('a failed Open Food Facts import stays put and can be retried', async () => {
+  offImportFailure.value = new Error('offline')
+  renderSheet()
+  await search('volle melk')
+  await waitFor(() => expect(screen.getByText('Open Food Facts')).toBeDefined())
+
+  fireEvent.click(screen.getByText('Volle melk'))
+
+  await waitFor(() =>
+    expect(
+      screen.getByText('Couldn’t add this food — try again.'),
+    ).toBeDefined(),
+  )
+  expect(navigated.value).toEqual([])
+
+  offImportFailure.value = null
+  fireEvent.click(screen.getByText('Volle melk'))
+
+  await waitFor(() => expect(navigated.value).toHaveLength(1))
+  expect(calls.value).toHaveLength(2)
 })
 
 test('a scanned barcode you already have skips review entirely', async () => {
@@ -345,7 +399,7 @@ test('a scanned barcode you already have skips review entirely', async () => {
   expect(calls.value[0][1]).toMatchObject({ foodId: 'food9' })
 })
 
-test('a scanned product nobody has is reviewed before anything is written', async () => {
+test('a scanned product nobody has imports and returns ready to log', async () => {
   offProduct.value = {
     name: 'Nutella',
     brand: 'Ferrero',
@@ -354,16 +408,26 @@ test('a scanned product nobody has is reviewed before anything is written', asyn
   renderSheet()
   await scan('3017620422003')
 
-  await waitFor(() => expect(navigated.value).toHaveLength(1))
-  expect(navigated.value[0]).toMatchObject({
-    to: '/g/$groupSlug/foods/new',
-    search: {
+  await waitFor(() => expect(calls.value).toHaveLength(1))
+  expect(calls.value[0]).toEqual([
+    'foodsLookup:importFromOff',
+    {
       barcode: '3017620422003',
-      returnDate: '2026-07-18',
-      returnMeal: 'breakfast',
+      name: 'Nutella',
+      brand: 'Ferrero',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 539 },
+      nutritionSource: 'imported',
+    },
+  ])
+  expect(navigated.value[0]).toMatchObject({
+    to: '/g/$groupSlug/nutrition/add',
+    search: {
+      date: '2026-07-18',
+      meal: 'breakfast',
+      food: 'food9',
     },
   })
-  expect(calls.value).toEqual([])
 })
 
 test('a scanned product with no name is asked about rather than imported as ""', async () => {

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -105,6 +105,9 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
   const createEntries = useMutation(api.consumption.createMany)
   const replaceComboItems = useMutation(api.combos.replaceItems)
   const lookupBarcode = useAction(api.foodsLookup.lookupBarcode)
+  // This is deliberately the action, not `foods.upsertFromOff`: it fetches and
+  // stores Open Food Facts' picture as part of the import (#69).
+  const importFromOff = useAction(api.foodsLookup.importFromOff)
   const convex = useConvex()
   const navigate = useNavigate()
   const { announce } = useJustLogged()
@@ -127,6 +130,15 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
     barcode?: string
     message?: string
   } | null>(null)
+  const [importing, setImporting] = useState(false)
+  const [importError, setImportError] = useState<{
+    barcode: string
+    message: string
+  } | null>(null)
+  // State only updates after React handles this event. The ref closes the gap
+  // between two quick taps so they cannot start two imports before the buttons
+  // rerender disabled.
+  const importInFlight = useRef(false)
 
   const toggle = (key: string) =>
     setExpanded((current) => (current === key ? null : key))
@@ -160,14 +172,46 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
   }
 
   /**
+   * The fast OFF path: create the food, including its picture, then reopen
+   * this same meal with its stored card expanded for the amount choice.
+   *
+   * OFF supplies figures per 100g and no reliable unit signal, which is the
+   * same `g` default the review form starts with. Checking first remains how a
+   * person changes that default or any imported figure before writing.
+   */
+  async function importOff(result: OffSearchResult) {
+    if (importInFlight.current) return
+    importInFlight.current = true
+    setImporting(true)
+    setImportError(null)
+    try {
+      const id = await importFromOff({
+        barcode: result.barcode,
+        name: result.name,
+        brand: result.brand,
+        baseUnit: 'g',
+        nutritionPer100: result.nutritionPer100,
+        nutritionSource: 'imported',
+        ...(result.servings?.length ? { servings: result.servings } : {}),
+        ...(result.imageUrl ? { imageUrl: result.imageUrl } : {}),
+      })
+      navigate(nav.addEntry(date, meal, id))
+    } catch {
+      setImportError({ barcode: result.barcode, message: foodAdd.importFailed })
+    } finally {
+      importInFlight.current = false
+      setImporting(false)
+    }
+  }
+
+  /**
    * A scanned barcode.
    *
    * A product you already have is not an import: it goes straight to the
    * expanded card, ready to log, which is the one-tap path #63/#66 built. A
-   * product that is *new* is an import, and every import is reviewed before
-   * anything is written (#93) — including the Open Food Facts products that
-   * carry no `product_name` at all, which used to be imported under the name
-   * `""` because nothing on this path ever asked.
+   * named product that is *new* takes the fast import path. A product with no
+   * `product_name` still opens review, whose required name field prevents an
+   * import under the name `""` (#112).
    */
   async function onBarcode(barcode: string) {
     setScanFailure(null)
@@ -186,7 +230,11 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
         return
       }
       setScanning(false)
-      navigate(review({ barcode }))
+      if (!mapped.name.trim()) {
+        navigate(review({ barcode }))
+        return
+      }
+      await importOff({ ...mapped, barcode })
     } catch {
       setScanFailure({ message: foodAdd.barcodeFailed })
     }
@@ -444,8 +492,13 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
             <OffCard
               key={result.barcode}
               result={result}
-              expanded={expanded === `off:${result.barcode}`}
-              onToggle={() => toggle(`off:${result.barcode}`)}
+              importing={importing}
+              error={
+                importError?.barcode === result.barcode
+                  ? importError.message
+                  : null
+              }
+              onImport={() => importOff(result)}
               reviewLink={review({ barcode: result.barcode })}
             />
           ))}
@@ -751,54 +804,64 @@ function RecipeCard({
 }
 
 /**
- * An Open Food Facts result is not a food yet, and choosing one does not make
- * it one: it opens the food form pre-filled from the mapping, and *saving* is
- * what imports the food and logs the entry (#93).
- *
- * This card writes nothing at all, which is the whole point. Open Food Facts
- * data is thin often enough — a missing nutrient, no serving, an unhelpful or
- * absent name — that logging something wrong quickly is worse than logging
- * something right slowly. The one-tap path is still there through your own
- * foods and Combos, which is where repeats live.
+ * Tapping an Open Food Facts result imports it, then returns to this meal with
+ * the newly stored card expanded for its amount. Review remains available as a
+ * secondary action for the times its incomplete data needs correcting (#112).
  */
 function OffCard({
   result,
-  expanded,
-  onToggle,
+  importing,
+  error,
+  onImport,
   reviewLink,
 }: {
   result: OffSearchResult
-  expanded: boolean
-  onToggle: () => void
+  importing: boolean
+  error: string | null
+  onImport: () => void
   reviewLink: AppLink
 }) {
   const { foodAdd } = useMessages().nutrition.diary
 
   return (
-    <ResultCard
-      thumbnail={<FoodThumbnail src={result.imageUrl} alt={result.name} />}
-      title={result.name}
-      subtitle={result.brand}
-      meta={
-        result.nutritionPer100.calories !== undefined
-          ? fmt(foodAdd.perHundred, {
-              calories: Math.round(result.nutritionPer100.calories),
-            })
-          : undefined
-      }
-      expanded={expanded}
-      onToggle={onToggle}
-    >
-      {/* What Open Food Facts has, per 100, before anybody agrees to it —
-          which is exactly what the review form opens holding. */}
-      <NutritionBreakdown facts={result.nutritionPer100} />
-      <p className="mt-3 text-xs opacity-60">{foodAdd.reviewHint}</p>
-      <div className="mt-3">
-        <Link {...reviewLink} className={`${confirmClass} inline-block py-2.5`}>
+    <li className="min-w-0 rounded-[var(--app-radius)] border border-[var(--app-border)]">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <button
+          type="button"
+          disabled={importing}
+          onClick={onImport}
+          className="flex min-h-11 min-w-0 flex-1 items-center gap-3 text-left disabled:opacity-60"
+        >
+          <FoodThumbnail src={result.imageUrl} alt={result.name} />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-sm font-medium">
+              {result.name}
+            </span>
+            {result.brand && (
+              <span className="block truncate text-xs opacity-60">
+                {result.brand}
+              </span>
+            )}
+          </span>
+          {result.nutritionPer100.calories !== undefined && (
+            <span className="shrink-0 text-xs opacity-60">
+              {fmt(foodAdd.perHundred, {
+                calories: Math.round(result.nutritionPer100.calories),
+              })}
+            </span>
+          )}
+        </button>
+        <Link
+          {...reviewLink}
+          className="flex min-h-11 shrink-0 items-center text-sm underline"
+        >
           {foodAdd.review}
         </Link>
       </div>
-    </ResultCard>
+      <p className="border-t border-[var(--app-border)] px-3 py-2 text-xs opacity-60">
+        {error ?? foodAdd.reviewHint}
+      </p>
+    </li>
   )
 }
 

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate } from '@tanstack/react-router'
 import { useAction, useConvex, useMutation, useQuery } from 'convex/react'
-import { type ReactNode, useRef, useState } from 'react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import { type ComboCounts, comboEntries } from '../../../convex/lib/combos'
@@ -9,7 +9,10 @@ import {
   type MealName,
   type QuantityUnit,
 } from '../../../convex/lib/consumption'
-import type { NutritionFacts } from '../../../convex/lib/nutrition'
+import type {
+  NutritionFacts,
+  NutritionSource,
+} from '../../../convex/lib/nutrition'
 import { barcodeTerm } from '../../../convex/lib/offFetch'
 import type { OffSearchResult } from '../../../convex/lib/offMapping'
 import type { Serving } from '../../../convex/lib/servings'
@@ -18,6 +21,7 @@ import type { AppLink } from '../../lib/appLink'
 import { errorMessage } from '../../lib/errorMessage'
 import { fmt, useMessages } from '../../lib/i18n'
 import { BarcodeScanner } from '../foods/BarcodeScanner'
+import { FoodForm } from '../foods/FoodForm'
 import { IconPicker } from '../foods/IconPicker'
 import { BottomSheet } from './BottomSheet'
 import { ComboCard, type ComboSummary } from './ComboCard'
@@ -57,13 +61,19 @@ interface FoodSummary {
   _id: Id<'foods'>
   name: string
   brand?: string
+  barcode?: string
   baseUnit: 'g' | 'ml'
   nutritionPer100: NutritionFacts
+  nutritionSource?: NutritionSource
   servings?: Serving[]
   /** Resolved by the query from the stored file; null when there is no picture. */
   imageUrl?: string | null
   /** The emoji somebody picked for it, shown when there is no picture (#94). */
   icon?: string
+  /** Catalog rows are read-only, so they never get the editor. */
+  seedKey?: string
+  /** User-created foods can only be changed by their creator. */
+  createdBy?: Id<'users'>
 }
 
 interface Props {
@@ -94,6 +104,7 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
   const term = search.term.trim()
   const recipes = useQuery(api.recipes.listAcrossMyGroups, {})
   const combos = useQuery(api.combos.list, {})
+  const me = useQuery(api.users.me)
   // The food a review form just saved. Read back rather than carried in the
   // URL, because what is logged has to be the row as it was written — the form
   // is where somebody may have corrected the figures.
@@ -105,9 +116,8 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
   const createEntries = useMutation(api.consumption.createMany)
   const replaceComboItems = useMutation(api.combos.replaceItems)
   const lookupBarcode = useAction(api.foodsLookup.lookupBarcode)
-  // This is deliberately the action, not `foods.upsertFromOff`: it fetches and
-  // stores Open Food Facts' picture as part of the import (#69).
-  const importFromOff = useAction(api.foodsLookup.importFromOff)
+  const upsertFromOff = useMutation(api.foods.upsertFromOff)
+  const storeOffImage = useAction(api.foodsLookup.storeOffImage)
   const convex = useConvex()
   const navigate = useNavigate()
   const { announce } = useJustLogged()
@@ -121,6 +131,12 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
   const [expanded, setExpanded] = useState<string | null>(
     justAddedFoodId ? `food:${justAddedFoodId}` : null,
   )
+  // The add sheet stays mounted when its `food` search parameter changes. A
+  // state initializer only sees the first value, so follow later return trips
+  // too (#112).
+  useEffect(() => {
+    if (justAddedFoodId) setExpanded(`food:${justAddedFoodId}`)
+  }, [justAddedFoodId])
   const [comboBusy, setComboBusy] = useState(false)
   const [comboError, setComboError] = useState<string | null>(null)
   const [promotions, setPromotions] = useState(0)
@@ -172,20 +188,21 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
   }
 
   /**
-   * The fast OFF path: create the food, including its picture, then reopen
-   * this same meal with its stored card expanded for the amount choice.
+   * The fast OFF path writes the food first, then reopens this same meal with
+   * its stored card expanded for the amount choice. Its photograph follows in
+   * the background: an unreliable remote image must not hold up logging.
    *
    * OFF supplies figures per 100g and no reliable unit signal, which is the
    * same `g` default the review form starts with. Checking first remains how a
    * person changes that default or any imported figure before writing.
    */
-  async function importOff(result: OffSearchResult) {
-    if (importInFlight.current) return
+  async function importOff(result: OffSearchResult): Promise<boolean> {
+    if (importInFlight.current) return false
     importInFlight.current = true
     setImporting(true)
     setImportError(null)
     try {
-      const id = await importFromOff({
+      const id = await upsertFromOff({
         barcode: result.barcode,
         name: result.name,
         brand: result.brand,
@@ -193,11 +210,18 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
         nutritionPer100: result.nutritionPer100,
         nutritionSource: 'imported',
         ...(result.servings?.length ? { servings: result.servings } : {}),
-        ...(result.imageUrl ? { imageUrl: result.imageUrl } : {}),
       })
       navigate(nav.addEntry(date, meal, id))
+      if (result.imageUrl) {
+        void storeOffImage({ id, imageUrl: result.imageUrl }).catch(() => {
+          // A picture is decoration. The food already exists and is ready to
+          // log, so a failed OFF fetch must remain invisible to that flow.
+        })
+      }
+      return true
     } catch {
       setImportError({ barcode: result.barcode, message: foodAdd.importFailed })
+      return false
     } finally {
       importInFlight.current = false
       setImporting(false)
@@ -234,7 +258,9 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
         navigate(review({ barcode }))
         return
       }
-      await importOff({ ...mapped, barcode })
+      if (!(await importOff({ ...mapped, barcode }))) {
+        setScanFailure({ message: foodAdd.importFailed })
+      }
     } catch {
       setScanFailure({ message: foodAdd.barcodeFailed })
     }
@@ -309,7 +335,12 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
   const matchingCombos = (combos ?? []).filter(
     (combo) => !term || combo.name.toLowerCase().includes(term.toLowerCase()),
   )
-  const foods = search.results ?? []
+  // Returning from an OFF name search preserves the typed term. Its saved row
+  // will now match that term too, but it belongs in the focused "Just added"
+  // slot rather than twice in the list.
+  const foods = (search.results ?? []).filter(
+    (food) => food._id !== justAdded?._id,
+  )
   const withNutrition = (recipes ?? []).filter((r) => r.nutrition)
   const matchingRecipes = term
     ? withNutrition.filter((r) =>
@@ -428,10 +459,12 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
       {justAdded && (
         <Section title={add.sections.justAdded}>
           <FoodCard
+            key={justAdded._id}
             food={justAdded}
             expanded={expanded === `food:${justAdded._id}`}
             onToggle={() => toggle(`food:${justAdded._id}`)}
             onLog={log}
+            canEdit={justAdded.createdBy === me?._id}
           />
         </Section>
       )}
@@ -443,6 +476,7 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
             expanded={expanded === `food:${scanned._id}`}
             onToggle={() => toggle(`food:${scanned._id}`)}
             onLog={log}
+            canEdit={scanned.createdBy === me?._id}
           />
         </Section>
       )}
@@ -456,6 +490,7 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
               expanded={expanded === `food:${food._id}`}
               onToggle={() => toggle(`food:${food._id}`)}
               onLog={log}
+              canEdit={food.createdBy === me?._id}
             />
           ))}
         </Section>
@@ -660,13 +695,16 @@ function FoodCard({
   expanded,
   onToggle,
   onLog,
+  canEdit,
 }: {
   food: FoodSummary
   expanded: boolean
   onToggle: () => void
   onLog: LogFn
+  canEdit: boolean
 }) {
-  const { add, foodAdd } = useMessages().nutrition.diary
+  const messages = useMessages()
+  const { add, foodAdd } = messages.nutrition.diary
   // Your own past amounts for this food, which is what covers a Catalog food
   // nobody may edit and a food whose authored list is empty. Only asked for
   // once the card is open — a list of twenty results should not be twenty
@@ -677,6 +715,10 @@ function FoodCard({
   )
   const offered = offeredServings(food, loggedAmounts ?? [])
   const [selection, setSelection] = useState<ServingSelection | null>(null)
+  const [editing, setEditing] = useState(false)
+  const [editBusy, setEditBusy] = useState(false)
+  const [editError, setEditError] = useState<string | null>(null)
+  const updateFood = useMutation(api.foods.update)
   const current = selection ?? initialSelection(offered)
   const { busy, error, run } = useLogging()
 
@@ -709,6 +751,58 @@ function FoodCard({
       <div className="mt-3">
         <NutritionBreakdown facts={resolved?.nutrition ?? {}} />
       </div>
+      {food.seedKey === undefined && canEdit && (
+        <div className="mt-3 border-t border-[var(--app-border)] pt-3">
+          <button
+            type="button"
+            onClick={() => {
+              setEditing((value) => !value)
+              setEditError(null)
+            }}
+            className="min-h-11 rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm"
+          >
+            {editing ? messages.common.actions.cancel : foodAdd.editFood}
+          </button>
+          {editing && (
+            <div className="mt-3">
+              {editError && (
+                <p className="mb-3 text-sm text-red-700">{editError}</p>
+              )}
+              <FoodForm
+                key={food._id}
+                submitting={editBusy}
+                initial={{
+                  name: food.name,
+                  brand: food.brand,
+                  barcode: food.barcode,
+                  baseUnit: food.baseUnit,
+                  icon: food.icon,
+                  nutritionPer100: food.nutritionPer100,
+                  servings: food.servings,
+                  nutritionSource: food.nutritionSource,
+                }}
+                onSubmit={async ({
+                  nutritionSource: _decidedByTheServer,
+                  ...values
+                }) => {
+                  setEditBusy(true)
+                  setEditError(null)
+                  try {
+                    await updateFood({ id: food._id, ...values })
+                    setEditing(false)
+                  } catch (err) {
+                    setEditError(
+                      errorMessage(err, messages.foods.form.saveFailed),
+                    )
+                  } finally {
+                    setEditBusy(false)
+                  }
+                }}
+              />
+            </div>
+          )}
+        </div>
+      )}
       <Confirm
         disabled={!resolved}
         reason={add.enterAmount}

--- a/src/lib/i18n/messages/en/nutrition.ts
+++ b/src/lib/i18n/messages/en/nutrition.ts
@@ -130,10 +130,10 @@ export const diary = {
   foodAdd: {
     barcodeFailed: 'Couldn’t look up that barcode — try again.',
     notFound: 'Not found.',
-    /** What choosing an Open Food Facts result does now: opens it, saves nothing (#93). */
-    review: 'Check and add',
+    review: 'Check first',
     reviewHint:
-      'Open Food Facts data is often incomplete. Check it, then saving adds the food and brings you back here to log it.',
+      'Imports this food with Open Food Facts’ figures. Check first to review or correct them.',
+    importFailed: 'Couldn’t add this food — try again.',
     addToLibrary: 'Add it to the foods library',
     addToLibraryAfter: 'first.',
     searching: 'Searching Open Food Facts…',

--- a/src/lib/i18n/messages/en/nutrition.ts
+++ b/src/lib/i18n/messages/en/nutrition.ts
@@ -134,6 +134,7 @@ export const diary = {
     reviewHint:
       'Imports this food with Open Food Facts’ figures. Check first to review or correct them.',
     importFailed: 'Couldn’t add this food — try again.',
+    editFood: 'Edit food details',
     addToLibrary: 'Add it to the foods library',
     addToLibraryAfter: 'first.',
     searching: 'Searching Open Food Facts…',

--- a/src/lib/i18n/messages/nl/nutrition.ts
+++ b/src/lib/i18n/messages/nl/nutrition.ts
@@ -106,9 +106,11 @@ export const diary = {
   foodAdd: {
     barcodeFailed: 'Kon die barcode niet opzoeken — probeer het opnieuw.',
     notFound: 'Niet gevonden.',
-    review: 'Controleren en toevoegen',
+    review: 'Eerst controleren',
     reviewHint:
-      'Gegevens van Open Food Facts zijn vaak onvolledig. Controleer ze; bij opslaan wordt het voedingsmiddel toegevoegd en kom je hier terug om het te noteren.',
+      'Voegt dit voedingsmiddel toe met gegevens van Open Food Facts. Controleer het eerst om ze na te kijken of te wijzigen.',
+    importFailed:
+      'Kon dit voedingsmiddel niet toevoegen — probeer het opnieuw.',
     addToLibrary: 'Voeg het toe aan de voedingsmiddelen',
     addToLibraryAfter: 'en probeer het dan opnieuw.',
     searching: 'Zoeken bij Open Food Facts…',

--- a/src/lib/i18n/messages/nl/nutrition.ts
+++ b/src/lib/i18n/messages/nl/nutrition.ts
@@ -111,6 +111,7 @@ export const diary = {
       'Voegt dit voedingsmiddel toe met gegevens van Open Food Facts. Controleer het eerst om ze na te kijken of te wijzigen.',
     importFailed:
       'Kon dit voedingsmiddel niet toevoegen — probeer het opnieuw.',
+    editFood: 'Voedingsmiddelgegevens bewerken',
     addToLibrary: 'Voeg het toe aan de voedingsmiddelen',
     addToLibraryAfter: 'en probeer het dan opnieuw.',
     searching: 'Zoeken bij Open Food Facts…',


### PR DESCRIPTION
Closes #112\n\n- Import named Open Food Facts results directly and return to the selected meal ready to log\n- Keep Check first as the no-write review path\n- Preserve review for nameless products and direct existing-barcode behavior\n\nTests: pnpm run typecheck, pnpm run check, pnpm run test