### PR TITLE
Collapse the icon picker to the chosen icon

### DIFF
--- a/docs/superpowers/plans/2026-08-10-collapsed-icon-picker.md
+++ b/docs/superpowers/plans/2026-08-10-collapsed-icon-picker.md
@@ -1,0 +1,248 @@
+# Collapsed Icon Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the always-visible food-icon grid with an accessible, collapsed trigger that opens a modal bottom sheet.
+
+**Architecture:** `IconPicker` remains the public component used by food and one-off forms. It owns open/closed state and delegates the modal surface to a portal-rendered `IconPickerSheet`, avoiding layout expansion and conflicts with the existing nutrition sheet. The existing `onChange(icon: string | undefined)` interface is unchanged.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS, Testing Library, Vitest, `@appelent/i18n`.
+
+## Global Constraints
+
+- Keep the curated `FOOD_ICONS` set and `onChange(icon: string | undefined)` contract unchanged.
+- `undefined` remains the picker clear signal; `FoodForm` must continue to submit it as `null`.
+- Add all new chrome strings in both locale dictionaries; stored emoji are content and are not translated.
+- The closed trigger is at least 44px square and shows `🍽️` when no icon is selected.
+- Do not modify the parent nutrition add sheet's gesture behavior.
+
+---
+
+### Task 1: Establish the collapsed trigger contract
+
+**Files:**
+
+- Modify: `src/components/foods/IconPicker.test.tsx`
+- Modify: `src/components/foods/IconPicker.tsx`
+- Modify: `src/lib/i18n/messages/en/common.ts`
+- Modify: `src/lib/i18n/messages/nl/common.ts`
+
+**Interfaces:**
+
+- Consumes: `value?: string`, `onChange(icon: string | undefined): void`, and `disabled?: boolean`.
+- Produces: a trigger button with `aria-expanded`, `aria-haspopup="dialog"`, and selected emoji or `🍽️`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+test('starts collapsed and invites the person to choose an icon', () => {
+  renderWithI18n(<IconPicker onChange={vi.fn()} />)
+  const trigger = screen.getByRole('button', { name: 'Choose icon' })
+  expect(trigger.ariaExpanded).toBe('false')
+  expect(trigger).toHaveTextContent('🍽️')
+  expect(screen.queryByRole('dialog')).toBeNull()
+})
+```
+
+- [ ] **Step 2: Verify the red state**
+
+Run: `pnpm test -- IconPicker`
+
+Expected: the trigger query fails because the current picker renders the grid immediately.
+
+- [ ] **Step 3: Implement the minimal trigger**
+
+```tsx
+const [open, setOpen] = useState(false)
+<button
+  type="button"
+  aria-expanded={open}
+  aria-haspopup="dialog"
+  aria-label={value === undefined ? icon.choose : icon.change}
+  onClick={() => setOpen(true)}
+  className="flex min-h-11 min-w-11 items-center justify-center ..."
+>
+  {value ?? '🍽️'}
+</button>
+```
+
+Add `choose` and `change` to both locale dictionaries.
+
+- [ ] **Step 4: Verify green and commit**
+
+Run: `pnpm test -- IconPicker`
+
+Expected: PASS.
+
+```bash
+git add src/components/foods/IconPicker.tsx src/components/foods/IconPicker.test.tsx src/lib/i18n/messages/en/common.ts src/lib/i18n/messages/nl/common.ts
+git commit -m "feat(foods): collapse icon picker trigger"
+```
+
+### Task 2: Add the portal-rendered icon-picker sheet
+
+**Files:**
+
+- Create: `src/components/foods/IconPickerSheet.tsx`
+- Modify: `src/components/foods/IconPicker.tsx`
+- Modify: `src/components/foods/IconPicker.test.tsx`
+- Modify: `src/lib/i18n/messages/en/common.ts`
+- Modify: `src/lib/i18n/messages/nl/common.ts`
+
+**Interfaces:**
+
+- Consumes: `open: boolean`, `value?: string`, `disabled?: boolean`, `onChoose(icon: string): void`, `onClear(): void`, and `onClose(): void`.
+- Produces: a portal-rendered `role="dialog"`, named by its title, with a backdrop, close button, grid, and conditional clear action.
+
+- [ ] **Step 1: Write the failing selection test**
+
+```tsx
+test('choosing an icon in the sheet reports it and collapses the picker', () => {
+  const onChange = vi.fn()
+  renderWithI18n(<IconPicker onChange={onChange} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
+  expect(screen.getByRole('dialog', { name: 'Choose an icon' })).toBeVisible()
+  fireEvent.click(screen.getByRole('button', { name: '🍕' }))
+  expect(onChange).toHaveBeenCalledWith('🍕')
+  expect(screen.queryByRole('dialog')).toBeNull()
+})
+```
+
+- [ ] **Step 2: Verify the red state**
+
+Run: `pnpm test -- IconPicker`
+
+Expected: the dialog query fails because activating the trigger renders no sheet.
+
+- [ ] **Step 3: Implement the minimal sheet**
+
+```tsx
+return createPortal(
+  <div className="fixed inset-0 z-[60]">
+    <button aria-label={icon.close} onClick={onClose} className="absolute inset-0 ..." />
+    <section role="dialog" aria-modal="true" aria-labelledby="icon-picker-title" className="absolute inset-x-0 bottom-0 ...">
+      <h2 id="icon-picker-title">{icon.chooseTitle}</h2>
+      {FOOD_ICONS.map((candidate) => <button onClick={() => onChoose(candidate)}>{candidate}</button>)}
+    </section>
+  </div>,
+  document.body,
+)
+```
+
+The parent calls `onChange(candidate)` and then closes the sheet.
+
+- [ ] **Step 4: Verify green and commit**
+
+Run: `pnpm test -- IconPicker`
+
+Expected: PASS.
+
+```bash
+git add src/components/foods/IconPicker.tsx src/components/foods/IconPickerSheet.tsx src/components/foods/IconPicker.test.tsx src/lib/i18n/messages/en/common.ts src/lib/i18n/messages/nl/common.ts
+git commit -m "feat(foods): open icon choices in a sheet"
+```
+
+### Task 3: Complete clearing, dismissal, and focus return
+
+**Files:**
+
+- Modify: `src/components/foods/IconPicker.tsx`
+- Modify: `src/components/foods/IconPickerSheet.tsx`
+- Modify: `src/components/foods/IconPicker.test.tsx`
+- Verify: `src/components/foods/FoodForm.test.tsx`
+
+**Interfaces:**
+
+- Consumes: selected `value` and the trigger ref.
+- Produces: explicit clearing with `onChange(undefined)`, unchanged state on dismissal, Escape support, and focus returned to the trigger.
+
+- [ ] **Step 1: Write the failing behavior tests**
+
+```tsx
+test('clearing from the sheet reports undefined and collapses it', () => {
+  const onChange = vi.fn()
+  renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Change icon' }))
+  fireEvent.click(screen.getByRole('button', { name: 'No icon' }))
+  expect(onChange).toHaveBeenCalledWith(undefined)
+  expect(screen.queryByRole('dialog')).toBeNull()
+})
+
+test('Escape dismisses without changing the icon and restores trigger focus', () => {
+  const onChange = vi.fn()
+  renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
+  const trigger = screen.getByRole('button', { name: 'Change icon' })
+  fireEvent.click(trigger)
+  fireEvent.keyDown(window, { key: 'Escape' })
+  expect(onChange).not.toHaveBeenCalled()
+  expect(trigger).toHaveFocus()
+})
+```
+
+- [ ] **Step 2: Verify the red state**
+
+Run: `pnpm test -- IconPicker`
+
+Expected: FAIL because the sheet has no clear action, Escape listener, or focus restoration.
+
+- [ ] **Step 3: Implement the minimal behavior**
+
+```tsx
+const triggerRef = useRef<HTMLButtonElement>(null)
+const close = () => {
+  setOpen(false)
+  requestAnimationFrame(() => triggerRef.current?.focus())
+}
+const clear = () => {
+  onChange(undefined)
+  close()
+}
+```
+
+Register an Escape listener only while open. Render the clear action only when `value !== undefined`.
+
+- [ ] **Step 4: Verify green and commit**
+
+Run: `pnpm test -- IconPicker && pnpm test -- FoodForm`
+
+Expected: PASS; the picker emits `undefined` and the existing form seam still submits `icon: null`.
+
+```bash
+git add src/components/foods/IconPicker.tsx src/components/foods/IconPickerSheet.tsx src/components/foods/IconPicker.test.tsx
+git commit -m "feat(foods): make icon picker sheet dismissible"
+```
+
+### Task 4: Verify and hand off
+
+**Files:**
+
+- Verify: `src/components/foods/IconPicker.tsx`
+- Verify: `src/components/foods/IconPickerSheet.tsx`
+- Verify: `src/components/foods/IconPicker.test.tsx`
+- Verify: `src/components/foods/FoodForm.test.tsx`
+
+- [ ] **Step 1: Run focused tests**
+
+Run: `pnpm test -- IconPicker && pnpm test -- FoodForm`
+
+Expected: PASS with no warnings.
+
+- [ ] **Step 2: Run static checks**
+
+Run: `pnpm typecheck && pnpm check`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `pnpm test`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the plan and completed implementation**
+
+```bash
+git add docs/superpowers/plans/2026-08-10-collapsed-icon-picker.md
+git commit -m "docs: plan collapsed icon picker implementation"
+```
+

--- a/docs/superpowers/specs/2026-08-10-collapsed-icon-picker-design.md
+++ b/docs/superpowers/specs/2026-08-10-collapsed-icon-picker-design.md
@@ -1,0 +1,52 @@
+# Collapsed icon picker
+
+## Decision
+
+`IconPicker` is collapsed by default. Its single trigger shows the selected
+emoji, or the neutral `🍽️` placeholder when no icon is selected. Activating the
+trigger opens a dedicated modal bottom sheet that is rendered outside the form's
+layout.
+
+The component is used by both the food form and the one-off form inside the
+nutrition add sheet. It must therefore not use a food-specific placeholder.
+
+## Interaction
+
+- The trigger is a 44px button and names its action for assistive technology.
+  It reports whether the picker is expanded.
+- The sheet has a visible, accessible title and close action, an icon grid, and
+  an explicit clear action only when an icon is selected.
+- Choosing an icon or clearing it calls the existing `onChange` contract and
+  closes the sheet. Dismissing the sheet does not change the selection.
+- Escape, the close button, and the backdrop dismiss the sheet. Focus returns
+  to the trigger.
+- The icon set, stored values, and `null`-on-submit conversion remain unchanged.
+
+## Architecture
+
+The picker owns only temporary open/closed state. The sheet is portal-rendered
+so it does not expand the food form and does not conflict with the existing
+nutrition add sheet. It is a focused component rather than a nested instance of
+the draggable `BottomSheet`, whose document-level Escape and gesture handling
+is designed for a top-level sheet.
+
+New chrome strings are added in English and Dutch. Emoji remain stored content
+and are not translated.
+
+## Tests
+
+The agreed seams are:
+
+1. The rendered `IconPicker`: initial collapsed state, open/close controls,
+   icon selection, explicit clearing, dismissal, and accessible trigger state.
+2. The existing food-form submission seam: clearing still becomes `null` in the
+   form payload.
+
+The focused picker test file runs during each red/green cycle. Typechecking and
+the full suite run before completion.
+
+## Scope boundaries
+
+- Do not change the curated icon set or backend icon semantics.
+- Do not change the parent nutrition add sheet's gesture behavior.
+- Do not add a second picker for recipes or combos.

--- a/src/components/foods/FoodForm.test.tsx
+++ b/src/components/foods/FoodForm.test.tsx
@@ -352,6 +352,7 @@ test('an icon picked while reviewing is part of what is saved', () => {
     />,
   )
 
+  fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
   fireEvent.click(screen.getByRole('button', { name: '🍫' }))
   fireEvent.click(screen.getByRole('button', { name: /save food/i }))
 
@@ -369,6 +370,7 @@ test('a food that had one opens holding it, and can be given another', () => {
       initial={{ name: 'Melk', icon: '🥛', nutritionPer100: {} }}
     />,
   )
+  fireEvent.click(screen.getByRole('button', { name: 'Change icon' }))
   expect(screen.getByRole('button', { name: '🥛' }).ariaPressed).toBe('true')
 
   fireEvent.click(screen.getByRole('button', { name: '🧀' }))
@@ -389,6 +391,7 @@ test('clearing one submits no icon at all', () => {
     />,
   )
 
+  fireEvent.click(screen.getByRole('button', { name: 'Change icon' }))
   fireEvent.click(screen.getByRole('button', { name: 'No icon' }))
   fireEvent.click(screen.getByRole('button', { name: /save food/i }))
 

--- a/src/components/foods/IconPicker.test.tsx
+++ b/src/components/foods/IconPicker.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { expect, test, vi } from 'vitest'
 import { renderWithI18n } from '../../lib/i18n/testing'
 import { FOOD_ICONS, IconPicker } from './IconPicker'
@@ -60,7 +60,7 @@ test('the chosen one says so', () => {
   expect(screen.getByRole('button', { name: '🥗' }).ariaPressed).toBe('false')
 })
 
-test('clearing reports nothing at all, not an empty string', () => {
+test('clearing from the sheet reports undefined and collapses it', () => {
   const onChange = vi.fn()
   renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
 
@@ -68,6 +68,31 @@ test('clearing reports nothing at all, not an empty string', () => {
   fireEvent.click(screen.getByRole('button', { name: 'No icon' }))
 
   expect(onChange).toHaveBeenCalledWith(undefined)
+  expect(screen.queryByRole('dialog')).toBeNull()
+})
+
+test('Escape dismisses without changing the icon and restores trigger focus', async () => {
+  const onChange = vi.fn()
+  renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
+
+  const trigger = screen.getByRole('button', { name: 'Change icon' })
+  fireEvent.click(trigger)
+  fireEvent.keyDown(window, { key: 'Escape' })
+
+  expect(onChange).not.toHaveBeenCalled()
+  await waitFor(() => expect(trigger).toHaveFocus())
+})
+
+test('closing the sheet leaves the icon unchanged and restores trigger focus', async () => {
+  const onChange = vi.fn()
+  renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
+
+  const trigger = screen.getByRole('button', { name: 'Change icon' })
+  fireEvent.click(trigger)
+  fireEvent.click(screen.getByRole('button', { name: 'Close icon picker' }))
+
+  expect(onChange).not.toHaveBeenCalled()
+  await waitFor(() => expect(trigger).toHaveFocus())
 })
 
 test('pressing the chosen one again clears it', () => {

--- a/src/components/foods/IconPicker.test.tsx
+++ b/src/components/foods/IconPicker.test.tsx
@@ -3,6 +3,15 @@ import { expect, test, vi } from 'vitest'
 import { renderWithI18n } from '../../lib/i18n/testing'
 import { FOOD_ICONS, IconPicker } from './IconPicker'
 
+test('starts collapsed and invites the person to choose an icon', () => {
+  renderWithI18n(<IconPicker onChange={vi.fn()} />)
+
+  const trigger = screen.getByRole('button', { name: 'Choose icon' })
+  expect(trigger.ariaExpanded).toBe('false')
+  expect(trigger).toHaveTextContent('🍽️')
+  expect(screen.queryByRole('dialog')).toBeNull()
+})
+
 /**
  * The picker is a curated set, and clearing is a real answer (#94).
  *
@@ -25,6 +34,7 @@ test('choosing one reports it', () => {
   const onChange = vi.fn()
   renderWithI18n(<IconPicker onChange={onChange} />)
 
+  fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
   fireEvent.click(screen.getByRole('button', { name: '🍕' }))
 
   expect(onChange).toHaveBeenCalledWith('🍕')
@@ -34,6 +44,7 @@ test('choosing another replaces the first', () => {
   const onChange = vi.fn()
   renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
 
+  fireEvent.click(screen.getByRole('button', { name: 'Change icon' }))
   fireEvent.click(screen.getByRole('button', { name: '🥗' }))
 
   expect(onChange).toHaveBeenCalledWith('🥗')
@@ -42,6 +53,7 @@ test('choosing another replaces the first', () => {
 test('the chosen one says so', () => {
   renderWithI18n(<IconPicker value="🍕" onChange={vi.fn()} />)
 
+  fireEvent.click(screen.getByRole('button', { name: 'Change icon' }))
   expect(screen.getByRole('button', { name: '🍕' }).ariaPressed).toBe('true')
   expect(screen.getByRole('button', { name: '🥗' }).ariaPressed).toBe('false')
 })
@@ -50,6 +62,7 @@ test('clearing reports nothing at all, not an empty string', () => {
   const onChange = vi.fn()
   renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
 
+  fireEvent.click(screen.getByRole('button', { name: 'Change icon' }))
   fireEvent.click(screen.getByRole('button', { name: 'No icon' }))
 
   expect(onChange).toHaveBeenCalledWith(undefined)
@@ -59,6 +72,7 @@ test('pressing the chosen one again clears it', () => {
   const onChange = vi.fn()
   renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
 
+  fireEvent.click(screen.getByRole('button', { name: 'Change icon' }))
   fireEvent.click(screen.getByRole('button', { name: '🍕' }))
 
   expect(onChange).toHaveBeenCalledWith(undefined)

--- a/src/components/foods/IconPicker.test.tsx
+++ b/src/components/foods/IconPicker.test.tsx
@@ -95,6 +95,24 @@ test('closing the sheet leaves the icon unchanged and restores trigger focus', a
   await waitFor(() => expect(trigger).toHaveFocus())
 })
 
+test('dismissing the sheet from its backdrop leaves the icon unchanged and restores trigger focus', async () => {
+  const onChange = vi.fn()
+  renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)
+
+  const trigger = screen.getByRole('button', { name: 'Change icon' })
+  fireEvent.click(trigger)
+  const backdrop = screen
+    .getByRole('dialog')
+    .parentElement?.querySelector<HTMLButtonElement>(
+      'button[aria-hidden="true"]',
+    )
+  if (!backdrop) throw new Error('Icon picker backdrop was not rendered')
+  fireEvent.click(backdrop)
+
+  expect(onChange).not.toHaveBeenCalled()
+  await waitFor(() => expect(trigger).toHaveFocus())
+})
+
 test('pressing the chosen one again clears it', () => {
   const onChange = vi.fn()
   renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)

--- a/src/components/foods/IconPicker.test.tsx
+++ b/src/components/foods/IconPicker.test.tsx
@@ -30,14 +30,16 @@ test('the set is curated rather than every emoji there is', () => {
   expect(new Set(FOOD_ICONS).size).toBe(FOOD_ICONS.length)
 })
 
-test('choosing one reports it', () => {
+test('choosing an icon in the sheet reports it and collapses the picker', () => {
   const onChange = vi.fn()
   renderWithI18n(<IconPicker onChange={onChange} />)
 
   fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
+  expect(screen.getByRole('dialog', { name: 'Choose an icon' })).toBeVisible()
   fireEvent.click(screen.getByRole('button', { name: '🍕' }))
 
   expect(onChange).toHaveBeenCalledWith('🍕')
+  expect(screen.queryByRole('dialog')).toBeNull()
 })
 
 test('choosing another replaces the first', () => {
@@ -80,6 +82,8 @@ test('pressing the chosen one again clears it', () => {
 
 test('there is nothing to clear until something is chosen', () => {
   renderWithI18n(<IconPicker onChange={vi.fn()} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
 
   expect(screen.queryByRole('button', { name: 'No icon' })).toBeNull()
 })

--- a/src/components/foods/IconPicker.test.tsx
+++ b/src/components/foods/IconPicker.test.tsx
@@ -83,6 +83,59 @@ test('Escape dismisses without changing the icon and restores trigger focus', as
   await waitFor(() => expect(trigger).toHaveFocus())
 })
 
+test('opening the sheet moves focus to its close button', async () => {
+  renderWithI18n(<IconPicker onChange={vi.fn()} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
+
+  await waitFor(() =>
+    expect(
+      screen.getByRole('button', { name: 'Close icon picker' }),
+    ).toHaveFocus(),
+  )
+})
+
+test('Tab wraps in both directions within the sheet controls', () => {
+  renderWithI18n(<IconPicker onChange={vi.fn()} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
+  const close = screen.getByRole('button', { name: 'Close icon picker' })
+  const lastIcon = screen.getByRole('button', {
+    name: FOOD_ICONS[FOOD_ICONS.length - 1],
+  })
+
+  lastIcon.focus()
+  fireEvent.keyDown(lastIcon, { key: 'Tab' })
+  expect(close).toHaveFocus()
+
+  fireEvent.keyDown(close, { key: 'Tab', shiftKey: true })
+  expect(lastIcon).toHaveFocus()
+})
+
+test('simultaneous picker dialogs have distinct accessible title ids', () => {
+  renderWithI18n(
+    <>
+      <IconPicker onChange={vi.fn()} />
+      <IconPicker onChange={vi.fn()} />
+    </>,
+  )
+
+  for (const trigger of screen.getAllByRole('button', {
+    name: 'Choose icon',
+  })) {
+    fireEvent.click(trigger)
+  }
+
+  const titleIds = screen
+    .getAllByRole('dialog', { name: 'Choose an icon' })
+    .map((dialog) => dialog.getAttribute('aria-labelledby'))
+  expect(new Set(titleIds).size).toBe(2)
+  for (const titleId of titleIds) {
+    expect(titleId).not.toBeNull()
+    expect(document.getElementById(titleId as string)).not.toBeNull()
+  }
+})
+
 test('closing the sheet leaves the icon unchanged and restores trigger focus', async () => {
   const onChange = vi.fn()
   renderWithI18n(<IconPicker value="🍕" onChange={onChange} />)

--- a/src/components/foods/IconPicker.test.tsx
+++ b/src/components/foods/IconPicker.test.tsx
@@ -1,7 +1,17 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
-import { expect, test, vi } from 'vitest'
+import { afterAll, beforeAll, expect, test, vi } from 'vitest'
 import { renderWithI18n } from '../../lib/i18n/testing'
 import { FOOD_ICONS, IconPicker } from './IconPicker'
+
+let scrollTo: ReturnType<typeof vi.spyOn>
+
+beforeAll(() => {
+  scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+})
+
+afterAll(() => {
+  scrollTo.mockRestore()
+})
 
 test('starts collapsed and invites the person to choose an icon', () => {
   renderWithI18n(<IconPicker onChange={vi.fn()} />)
@@ -182,4 +192,17 @@ test('there is nothing to clear until something is chosen', () => {
   fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
 
   expect(screen.queryByRole('button', { name: 'No icon' })).toBeNull()
+})
+
+test('locks page scrolling while the standalone picker sheet is open', async () => {
+  document.body.style.cssText = ''
+  renderWithI18n(<IconPicker onChange={vi.fn()} />)
+
+  fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
+
+  expect(document.body.style.position).toBe('fixed')
+
+  fireEvent.click(screen.getByRole('button', { name: 'Close icon picker' }))
+
+  await waitFor(() => expect(document.body.style.position).toBe(''))
 })

--- a/src/components/foods/IconPicker.tsx
+++ b/src/components/foods/IconPicker.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useMessages } from '../../lib/i18n'
 
 /**
@@ -96,12 +97,24 @@ interface Props {
  */
 export function IconPicker({ value, onChange, disabled }: Props) {
   const { icon } = useMessages().common
+  const [open, setOpen] = useState(false)
 
   return (
     <fieldset className="rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">
       <legend className="px-1 text-sm font-medium">{icon.label}</legend>
       <p className="mb-2 text-xs opacity-60">{icon.hint}</p>
-      <div className="flex flex-wrap gap-1">
+      <button
+        type="button"
+        disabled={disabled}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-label={value === undefined ? icon.choose : icon.change}
+        onClick={() => setOpen(true)}
+        className="flex min-h-11 min-w-11 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] text-xl"
+      >
+        {value ?? '🍽️'}
+      </button>
+      {open && <div className="flex flex-wrap gap-1">
         {FOOD_ICONS.map((candidate) => {
           const chosen = candidate === value
           return (
@@ -132,7 +145,7 @@ export function IconPicker({ value, onChange, disabled }: Props) {
             ✕
           </button>
         )}
-      </div>
+      </div>}
     </fieldset>
   )
 }

--- a/src/components/foods/IconPicker.tsx
+++ b/src/components/foods/IconPicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useMessages } from '../../lib/i18n'
 import { IconPickerSheet } from './IconPickerSheet'
 
@@ -99,12 +99,24 @@ interface Props {
 export function IconPicker({ value, onChange, disabled }: Props) {
   const { icon } = useMessages().common
   const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  const close = () => {
+    setOpen(false)
+    requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+
+  const clear = () => {
+    onChange(undefined)
+    close()
+  }
 
   return (
     <fieldset className="rounded-[var(--app-radius)] border border-[var(--app-border)] p-3">
       <legend className="px-1 text-sm font-medium">{icon.label}</legend>
       <p className="mb-2 text-xs opacity-60">{icon.hint}</p>
       <button
+        ref={triggerRef}
         type="button"
         disabled={disabled}
         aria-expanded={open}
@@ -122,10 +134,10 @@ export function IconPicker({ value, onChange, disabled }: Props) {
         disabled={disabled}
         onChoose={(candidate) => {
           onChange(candidate === value ? undefined : candidate)
-          setOpen(false)
+          close()
         }}
-        onClear={() => onChange(undefined)}
-        onClose={() => setOpen(false)}
+        onClear={clear}
+        onClose={close}
       />
     </fieldset>
   )

--- a/src/components/foods/IconPicker.tsx
+++ b/src/components/foods/IconPicker.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useMessages } from '../../lib/i18n'
+import { IconPickerSheet } from './IconPickerSheet'
 
 /**
  * The emoji a food or a one-off may wear, curated (#94, #75).
@@ -114,38 +115,18 @@ export function IconPicker({ value, onChange, disabled }: Props) {
       >
         {value ?? '🍽️'}
       </button>
-      {open && <div className="flex flex-wrap gap-1">
-        {FOOD_ICONS.map((candidate) => {
-          const chosen = candidate === value
-          return (
-            <button
-              key={candidate}
-              type="button"
-              disabled={disabled}
-              aria-pressed={chosen}
-              onClick={() => onChange(chosen ? undefined : candidate)}
-              className={`flex min-h-11 min-w-11 items-center justify-center rounded-[var(--app-radius)] border text-xl ${
-                chosen
-                  ? 'border-[var(--app-fg)] bg-[var(--app-bg)]'
-                  : 'border-transparent'
-              }`}
-            >
-              {candidate}
-            </button>
-          )
-        })}
-        {value !== undefined && (
-          <button
-            type="button"
-            disabled={disabled}
-            aria-label={icon.none}
-            onClick={() => onChange(undefined)}
-            className="flex min-h-11 min-w-11 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] text-sm opacity-60"
-          >
-            ✕
-          </button>
-        )}
-      </div>}
+      <IconPickerSheet
+        open={open}
+        icons={FOOD_ICONS}
+        value={value}
+        disabled={disabled}
+        onChoose={(candidate) => {
+          onChange(candidate === value ? undefined : candidate)
+          setOpen(false)
+        }}
+        onClear={() => onChange(undefined)}
+        onClose={() => setOpen(false)}
+      />
     </fieldset>
   )
 }

--- a/src/components/foods/IconPickerSheet.tsx
+++ b/src/components/foods/IconPickerSheet.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { useMessages } from '../../lib/i18n'
 
@@ -27,6 +28,17 @@ export function IconPickerSheet({
   onClose,
 }: Props) {
   const { icon } = useMessages().common
+
+  useEffect(() => {
+    if (!open) return
+
+    const dismissOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+
+    window.addEventListener('keydown', dismissOnEscape)
+    return () => window.removeEventListener('keydown', dismissOnEscape)
+  }, [open, onClose])
 
   if (!open) return null
 

--- a/src/components/foods/IconPickerSheet.tsx
+++ b/src/components/foods/IconPickerSheet.tsx
@@ -1,6 +1,26 @@
-import { useEffect } from 'react'
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useId,
+  useRef,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { useMessages } from '../../lib/i18n'
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function focusableElements(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((element) => !element.hidden && element.tabIndex >= 0)
+}
 
 interface Props {
   open: boolean
@@ -28,22 +48,57 @@ export function IconPickerSheet({
   onClose,
 }: Props) {
   const { icon } = useMessages().common
+  const titleId = useId()
+  const sheetRef = useRef<HTMLElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    closeButtonRef.current?.focus()
+  }, [open])
 
   useEffect(() => {
     if (!open) return
 
     const dismissOnEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose()
+      if (event.key !== 'Escape') return
+      event.preventDefault()
+      event.stopImmediatePropagation()
+      onClose()
     }
 
-    window.addEventListener('keydown', dismissOnEscape)
-    return () => window.removeEventListener('keydown', dismissOnEscape)
+    window.addEventListener('keydown', dismissOnEscape, true)
+    return () => window.removeEventListener('keydown', dismissOnEscape, true)
   }, [open, onClose])
+
+  const trapFocus = (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (event.key !== 'Tab') return
+    const sheet = sheetRef.current
+    if (!sheet) return
+    const focusable = focusableElements(sheet)
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (!first || !last) return
+
+    const active = document.activeElement
+    if (event.shiftKey) {
+      if (active !== first && sheet.contains(active)) return
+      event.preventDefault()
+      last.focus()
+      return
+    }
+    if (active !== last && sheet.contains(active)) return
+    event.preventDefault()
+    first.focus()
+  }
 
   if (!open) return null
 
   return createPortal(
-    <div className="fixed inset-0 z-[60]">
+    <div
+      className="fixed inset-0 z-[60]"
+      onPointerDown={(event) => event.stopPropagation()}
+    >
       <button
         type="button"
         tabIndex={-1}
@@ -52,16 +107,19 @@ export function IconPickerSheet({
         className="absolute inset-0 bg-black/30"
       />
       <section
+        ref={sheetRef}
         role="dialog"
         aria-modal="true"
-        aria-labelledby="icon-picker-title"
+        aria-labelledby={titleId}
+        onKeyDown={trapFocus}
         className="absolute inset-x-0 bottom-0 max-h-[88svh] overflow-auto rounded-t-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-4 shadow-2xl"
       >
         <header className="mb-3 flex items-center justify-between gap-3">
-          <h2 id="icon-picker-title" className="text-lg font-semibold">
+          <h2 id={titleId} className="text-lg font-semibold">
             {icon.chooseTitle}
           </h2>
           <button
+            ref={closeButtonRef}
             type="button"
             aria-label={icon.close}
             onClick={onClose}

--- a/src/components/foods/IconPickerSheet.tsx
+++ b/src/components/foods/IconPickerSheet.tsx
@@ -1,0 +1,97 @@
+import { createPortal } from 'react-dom'
+import { useMessages } from '../../lib/i18n'
+
+interface Props {
+  open: boolean
+  icons: readonly string[]
+  value?: string
+  disabled?: boolean
+  onChoose: (icon: string) => void
+  onClear: () => void
+  onClose: () => void
+}
+
+/**
+ * The picker lives above its form rather than expanding it: the surrounding
+ * field stays a compact summary while the full set remains easy to reach.
+ * `icons` comes from the picker so this display component does not import its
+ * public parent and create a circular dependency.
+ */
+export function IconPickerSheet({
+  open,
+  icons,
+  value,
+  disabled,
+  onChoose,
+  onClear,
+  onClose,
+}: Props) {
+  const { icon } = useMessages().common
+
+  if (!open) return null
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60]">
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-hidden="true"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/30"
+      />
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="icon-picker-title"
+        className="absolute inset-x-0 bottom-0 max-h-[88svh] overflow-auto rounded-t-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] p-4 shadow-2xl"
+      >
+        <header className="mb-3 flex items-center justify-between gap-3">
+          <h2 id="icon-picker-title" className="text-lg font-semibold">
+            {icon.chooseTitle}
+          </h2>
+          <button
+            type="button"
+            aria-label={icon.close}
+            onClick={onClose}
+            className="flex min-h-11 min-w-11 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] text-xl"
+          >
+            ×
+          </button>
+        </header>
+        <div className="flex flex-wrap gap-1">
+          {icons.map((candidate) => {
+            const chosen = candidate === value
+            return (
+              <button
+                key={candidate}
+                type="button"
+                disabled={disabled}
+                aria-pressed={chosen}
+                onClick={() => onChoose(candidate)}
+                className={`flex min-h-11 min-w-11 items-center justify-center rounded-[var(--app-radius)] border text-xl ${
+                  chosen
+                    ? 'border-[var(--app-fg)] bg-[var(--app-bg)]'
+                    : 'border-transparent'
+                }`}
+              >
+                {candidate}
+              </button>
+            )
+          })}
+          {value !== undefined && (
+            <button
+              type="button"
+              disabled={disabled}
+              aria-label={icon.none}
+              onClick={onClear}
+              className="flex min-h-11 min-w-11 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] text-sm opacity-60"
+            >
+              ×
+            </button>
+          )}
+        </div>
+      </section>
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/foods/IconPickerSheet.tsx
+++ b/src/components/foods/IconPickerSheet.tsx
@@ -22,6 +22,33 @@ function focusableElements(container: HTMLElement) {
   ).filter((element) => !element.hidden && element.tabIndex >= 0)
 }
 
+function useBodyScrollLock(active: boolean) {
+  useEffect(() => {
+    if (!active) return
+
+    const { body } = document
+    const y = window.scrollY
+    const previous = {
+      position: body.style.position,
+      top: body.style.top,
+      left: body.style.left,
+      right: body.style.right,
+      width: body.style.width,
+      overflow: body.style.overflow,
+    }
+    body.style.position = 'fixed'
+    body.style.top = `${-y}px`
+    body.style.left = '0'
+    body.style.right = '0'
+    body.style.width = '100%'
+    body.style.overflow = 'hidden'
+    return () => {
+      Object.assign(body.style, previous)
+      window.scrollTo(0, y)
+    }
+  }, [active])
+}
+
 interface Props {
   open: boolean
   icons: readonly string[]
@@ -70,6 +97,8 @@ export function IconPickerSheet({
     window.addEventListener('keydown', dismissOnEscape, true)
     return () => window.removeEventListener('keydown', dismissOnEscape, true)
   }, [open, onClose])
+
+  useBodyScrollLock(open)
 
   const trapFocus = (event: ReactKeyboardEvent<HTMLElement>) => {
     if (event.key !== 'Tab') return

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -549,6 +549,52 @@ test('a one-off can be given an icon, and it goes to the diary with it', async (
   })
 })
 
+test('Escape closes only the icon picker and leaves the one-off draft usable', async () => {
+  const onClose = renderSheet()
+  await search('poffertjes at the fair')
+  await waitFor(() =>
+    expect(
+      screen.getByText('Nothing found for “poffertjes at the fair”'),
+    ).toBeDefined(),
+  )
+  fireEvent.click(screen.getByText('Log “poffertjes at the fair” as a one-off'))
+  const calories = screen.getByLabelText('Calories (kcal)')
+  fireEvent.change(calories, { target: { value: '400' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
+
+  fireEvent.keyDown(window, { key: 'Escape' })
+
+  expect(screen.queryByRole('dialog', { name: 'Choose an icon' })).toBeNull()
+  expect(onClose).not.toHaveBeenCalled()
+  expect(calories).toHaveValue('400')
+  fireEvent.change(calories, { target: { value: '450' } })
+  expect(calories).toHaveValue('450')
+})
+
+test('a pointer gesture in the icon picker does not drag the add sheet', async () => {
+  const onClose = renderSheet()
+  await search('poffertjes at the fair')
+  await waitFor(() =>
+    expect(
+      screen.getByText('Nothing found for “poffertjes at the fair”'),
+    ).toBeDefined(),
+  )
+  fireEvent.click(screen.getByText('Log “poffertjes at the fair” as a one-off'))
+  fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
+  const dialog = screen.getByRole('dialog', { name: 'Choose an icon' })
+
+  fireEvent.pointerDown(dialog, {
+    button: 0,
+    pointerId: 1,
+    clientY: 100,
+  })
+  fireEvent.pointerMove(window, { pointerId: 1, clientY: 900 })
+  fireEvent.pointerUp(window, { pointerId: 1, clientY: 900 })
+
+  expect(onClose).not.toHaveBeenCalled()
+  expect(dialog).toBeVisible()
+})
+
 test('a one-off nobody decorated carries no icon at all', async () => {
   renderSheet()
   await search('poffertjes at the fair')

--- a/src/components/nutrition/AddSheet.test.tsx
+++ b/src/components/nutrition/AddSheet.test.tsx
@@ -538,6 +538,7 @@ test('a one-off can be given an icon, and it goes to the diary with it', async (
     ).toBeDefined(),
   )
   fireEvent.click(screen.getByText('Log “poffertjes at the fair” as a one-off'))
+  fireEvent.click(screen.getByRole('button', { name: 'Choose icon' }))
   fireEvent.click(screen.getByRole('button', { name: '🍬' }))
   fireEvent.click(screen.getByText('Add to diary'))
 

--- a/src/lib/i18n/messages/en/common.ts
+++ b/src/lib/i18n/messages/en/common.ts
@@ -40,6 +40,8 @@ export const common = {
   icon: {
     label: 'Icon',
     hint: 'Shown when there is no picture of this.',
+    choose: 'Choose icon',
+    change: 'Change icon',
     none: 'No icon',
   },
 

--- a/src/lib/i18n/messages/en/common.ts
+++ b/src/lib/i18n/messages/en/common.ts
@@ -42,6 +42,8 @@ export const common = {
     hint: 'Shown when there is no picture of this.',
     choose: 'Choose icon',
     change: 'Change icon',
+    chooseTitle: 'Choose an icon',
+    close: 'Close icon picker',
     none: 'No icon',
   },
 

--- a/src/lib/i18n/messages/nl/common.ts
+++ b/src/lib/i18n/messages/nl/common.ts
@@ -29,6 +29,8 @@ export const common = {
     hint: 'Wordt getoond als er geen foto van is.',
     choose: 'Icoon kiezen',
     change: 'Icoon wijzigen',
+    chooseTitle: 'Kies een icoon',
+    close: 'Icoonkiezer sluiten',
     none: 'Geen icoon',
   },
 

--- a/src/lib/i18n/messages/nl/common.ts
+++ b/src/lib/i18n/messages/nl/common.ts
@@ -27,6 +27,8 @@ export const common = {
   icon: {
     label: 'Icoon',
     hint: 'Wordt getoond als er geen foto van is.',
+    choose: 'Icoon kiezen',
+    change: 'Icoon wijzigen',
     none: 'Geen icoon',
   },
 


### PR DESCRIPTION
## Summary

Collapses the food and one-off icon picker to a single 44px control showing the
chosen emoji, or `🍽️` when no icon is selected. Opening it presents the existing
curated icon set in an accessible bottom sheet, keeping the form and its save
action visible on a phone.

The sheet supports explicit clearing, close/backdrop/Escape dismissal, keyboard
focus containment, and focus return to the trigger. It isolates keyboard and
pointer events from the nutrition add sheet, so interaction with the nested
picker cannot close or drag the parent sheet.

## Why

The previous picker kept roughly forty targets permanently inside already-long
mobile forms. The compact trigger preserves the same stored-value behavior while
making icon choice reachable without occupying the form.

## Validation

- `pnpm typecheck`
- `pnpm check`
- `pnpm test` — 98 files, 1,112 tests
