### PR TITLE
fix: show fallback icons for food content

### DIFF
--- a/convex/consumption.test.ts
+++ b/convex/consumption.test.ts
@@ -480,6 +480,37 @@ describe('the amounts you have logged for a food', () => {
   })
 })
 
+describe('a food entry’s tile', () => {
+  test('reads the food’s current icon for the diary fallback', async () => {
+    const t = testConvex()
+    await t.withIdentity(asAlice).mutation(api.users.ensureUser, {})
+    const foodId = await t.withIdentity(asAlice).mutation(api.foods.create, {
+      name: 'Oatmeal',
+      baseUnit: 'g',
+      nutritionPer100: { calories: 375 },
+      icon: '🥣',
+    })
+    await t.withIdentity(asAlice).mutation(api.consumption.create, {
+      date: DAY,
+      meal: 'breakfast',
+      foodId,
+      label: 'Oatmeal',
+      quantity: 50,
+      quantityUnit: 'g',
+      nutrition: { calories: 188 },
+    })
+
+    const [entry] = await t
+      .withIdentity(asAlice)
+      .query(api.consumption.listForDay, { date: DAY })
+
+    expect(entry).toMatchObject({
+      sourceIcon: '🥣',
+      thumbnailKind: 'food',
+    })
+  })
+})
+
 /**
  * The emoji on a one-off (#94).
  *

--- a/convex/consumption.ts
+++ b/convex/consumption.ts
@@ -36,15 +36,35 @@ function assertValidNutrition(nutrition: NutritionFacts) {
  * the nutrition are a snapshot, and a snapshot does not change because the
  * thing it was taken from did.
  */
-async function visibleRecipeId(
+async function entryThumbnail(
   ctx: QueryCtx,
-  recipeId: Id<'recipes'> | undefined,
+  entry: Doc<'consumptionEntries'>,
   viewerGroupIds: Id<'groups'>[],
-): Promise<Id<'recipes'> | undefined> {
-  if (!recipeId) return undefined
-  const recipe = await ctx.db.get(recipeId)
-  if (!recipe || !isVisibleToGroups(recipe, viewerGroupIds)) return undefined
-  return recipeId
+): Promise<{
+  recipeId: Id<'recipes'> | undefined
+  imageUrl?: string | null
+  sourceIcon?: string
+  thumbnailKind: 'food' | 'recipe'
+}> {
+  if (entry.foodId) {
+    const food = await ctx.db.get(entry.foodId)
+    return {
+      recipeId: undefined,
+      imageUrl: food?.imageId ? await ctx.storage.getUrl(food.imageId) : null,
+      sourceIcon: food?.icon,
+      thumbnailKind: 'food',
+    }
+  }
+  if (!entry.recipeId) return { recipeId: undefined, thumbnailKind: 'food' }
+  const recipe = await ctx.db.get(entry.recipeId)
+  if (!recipe || !isVisibleToGroups(recipe, viewerGroupIds)) {
+    return { recipeId: undefined, thumbnailKind: 'recipe' }
+  }
+  return {
+    recipeId: entry.recipeId,
+    imageUrl: recipe.imageId ? await ctx.storage.getUrl(recipe.imageId) : null,
+    thumbnailKind: 'recipe',
+  }
 }
 
 export const listForDay = query({
@@ -62,7 +82,7 @@ export const listForDay = query({
     return await Promise.all(
       entries.map(async (entry) => ({
         ...entry,
-        recipeId: await visibleRecipeId(ctx, entry.recipeId, viewerGroupIds),
+        ...(await entryThumbnail(ctx, entry, viewerGroupIds)),
       })),
     )
   },

--- a/convex/lib/seed/sampleHousehold.ts
+++ b/convex/lib/seed/sampleHousehold.ts
@@ -904,6 +904,7 @@ export const SAMPLE_USER_FOODS = [
   {
     name: 'Nora’s granola',
     brand: 'Homemade',
+    icon: '🥣',
     baseUnit: 'g' as const,
     nutritionPer100: {
       calories: 471,
@@ -938,6 +939,7 @@ export const SAMPLE_USER_FOODS = [
     // sample was reset. A code no real packet carries cannot collide.
     name: 'Roomboter ontbijtkoek',
     brand: 'Peijnenburg',
+    icon: '🍞',
     barcode: '2000000000017',
     baseUnit: 'g' as const,
     nutritionPer100: {
@@ -960,6 +962,7 @@ export const SAMPLE_USER_FOODS = [
     // they leave behind.
     name: 'Bakery seeded spelt loaf',
     brand: 'Buurtbakker',
+    icon: '🥖',
     baseUnit: 'g' as const,
     nutritionPer100: {
       calories: 259,

--- a/convex/seed.test.ts
+++ b/convex/seed.test.ts
@@ -142,6 +142,9 @@ describe('the Sample household', () => {
     expect(new Set(userFoods.map((f) => f.nutritionSource))).toEqual(
       new Set(['imported', 'ai', 'manual']),
     )
+    // A review of a seeded preview must demonstrate the icon fallback without
+    // having to type a search first (#114).
+    expect(userFoods.every((f) => f.icon !== undefined)).toBe(true)
     // Catalog foods claim nothing: their figures are authored (ADR 0004).
     const catalog = await t.run(async (ctx) =>
       (await ctx.db.query('foods').collect()).filter(

--- a/src/components/foods/FoodDetailPage.tsx
+++ b/src/components/foods/FoodDetailPage.tsx
@@ -4,6 +4,7 @@ import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import { fmt, useMessages } from '../../lib/i18n'
 import { useConfirmAction } from '../app/ConfirmAction'
+import { FoodThumbnail } from '../nutrition/FoodThumbnail'
 import { NutritionPanel } from '../recipes/NutritionPanel'
 import type { FoodNav } from './foodNav'
 
@@ -30,9 +31,12 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
   return (
     <article className="mx-auto max-w-2xl">
       <div className="mb-4 flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">{food.name}</h1>
-          {food.brand && <p className="text-sm opacity-60">{food.brand}</p>}
+        <div className="flex items-center gap-3">
+          <FoodThumbnail src={food.imageUrl} icon={food.icon} />
+          <div>
+            <h1 className="text-2xl font-semibold">{food.name}</h1>
+            {food.brand && <p className="text-sm opacity-60">{food.brand}</p>}
+          </div>
         </div>
         {/*
           Catalog entries are owned by nobody and read-only (ADR 0004) — the

--- a/src/components/foods/FoodsPage.tsx
+++ b/src/components/foods/FoodsPage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from 'convex/react'
 import { useEffect, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import { fmt, useMessages } from '../../lib/i18n'
+import { FoodThumbnail } from '../nutrition/FoodThumbnail'
 import { BarcodeScanner } from './BarcodeScanner'
 import type { FoodNav } from './foodNav'
 
@@ -59,11 +60,17 @@ export function FoodsPage({ nav }: { nav: FoodNav }) {
       <ul className="divide-y divide-[var(--app-border)]">
         {results?.map((food) => (
           <li key={food._id}>
-            <Link {...nav.detail(food._id)} className="block py-2 no-underline">
-              <span className="font-medium">{food.name}</span>
-              {food.brand && (
-                <span className="ml-2 text-sm opacity-60">{food.brand}</span>
-              )}
+            <Link
+              {...nav.detail(food._id)}
+              className="flex items-center gap-3 py-2 no-underline"
+            >
+              <FoodThumbnail src={food.imageUrl} icon={food.icon} />
+              <span>
+                <span className="font-medium">{food.name}</span>
+                {food.brand && (
+                  <span className="ml-2 text-sm opacity-60">{food.brand}</span>
+                )}
+              </span>
             </Link>
           </li>
         ))}

--- a/src/components/nutrition/AddSheet.tsx
+++ b/src/components/nutrition/AddSheet.tsx
@@ -560,6 +560,7 @@ export function AddSheet({ date, meal, justAddedFoodId, nav, onClose }: Props) {
               recipe={{
                 _id: recipe._id,
                 title: recipe.title,
+                imageUrl: recipe.imageUrl,
                 // Filtered to recipes that have it, which the type cannot see.
                 nutrition: recipe.nutrition as NutritionFacts,
               }}
@@ -783,9 +784,7 @@ function FoodCard({
 
   return (
     <ResultCard
-      thumbnail={
-        <FoodThumbnail src={food.imageUrl} icon={food.icon} alt={food.name} />
-      }
+      thumbnail={<FoodThumbnail src={food.imageUrl} icon={food.icon} />}
       title={food.name}
       subtitle={food.brand}
       meta={
@@ -887,7 +886,12 @@ function RecipeCard({
   onToggle,
   onLog,
 }: {
-  recipe: { _id: Id<'recipes'>; title: string; nutrition: NutritionFacts }
+  recipe: {
+    _id: Id<'recipes'>
+    title: string
+    imageUrl: string | null
+    nutrition: NutritionFacts
+  }
   expanded: boolean
   onToggle: () => void
   onLog: LogFn
@@ -904,6 +908,7 @@ function RecipeCard({
 
   return (
     <ResultCard
+      thumbnail={<FoodThumbnail src={recipe.imageUrl} kind="recipe" />}
       title={recipe.title}
       meta={
         recipe.nutrition.calories !== undefined
@@ -982,7 +987,7 @@ function OffCard({
           onClick={onImport}
           className="flex min-h-11 min-w-0 flex-1 items-center gap-3 text-left disabled:opacity-60"
         >
-          <FoodThumbnail src={result.imageUrl} alt={result.name} />
+          <FoodThumbnail src={result.imageUrl} />
           <span className="min-w-0 flex-1">
             <span className="block truncate text-sm font-medium">
               {result.name}

--- a/src/components/nutrition/ComboCard.test.tsx
+++ b/src/components/nutrition/ComboCard.test.tsx
@@ -49,6 +49,7 @@ function render(onLog = vi.fn()) {
 test('shows what is in it before anything is committed', () => {
   const onLog = render()
   expect(screen.getByText('Usual breakfast')).toBeDefined()
+  expect(screen.getByText('🍱')).toBeDefined()
   expect(screen.getByText('2 items')).toBeDefined()
   expect(screen.getByText('Wholemeal bread')).toBeDefined()
   expect(screen.getByText('Flat white')).toBeDefined()

--- a/src/components/nutrition/ComboCard.tsx
+++ b/src/components/nutrition/ComboCard.tsx
@@ -3,6 +3,7 @@ import type { ComboComponent, ComboCounts } from '../../../convex/lib/combos'
 import { comboEntries, countOf, isModified } from '../../../convex/lib/combos'
 import { sumFacts } from '../../../convex/lib/consumption'
 import { fmt, plural, useI18n } from '../../lib/i18n'
+import { FoodThumbnail } from './FoodThumbnail'
 import { NutritionBreakdown } from './NutritionBreakdown'
 import { ResultCard } from './ResultCard'
 
@@ -55,6 +56,7 @@ export function ComboCard({
 
   return (
     <ResultCard
+      thumbnail={<FoodThumbnail kind="combo" />}
       title={combo.name}
       subtitle={fmt(plural(locale, combo.components.length, combos.itemCount), {
         count: combo.components.length,

--- a/src/components/nutrition/ConsumptionEntryRow.test.tsx
+++ b/src/components/nutrition/ConsumptionEntryRow.test.tsx
@@ -175,8 +175,26 @@ test('a one-off shows the icon it was logged with', () => {
   expect(screen.getByText('Poffertjes at the fair')).toBeDefined()
 })
 
-test('an entry with no icon renders exactly as it always did', () => {
-  const { container } = renderWithI18n(
+test('a food entry uses the food icon when it has no photograph', () => {
+  renderWithI18n(
+    <ConsumptionEntryRow
+      nav={nav}
+      entry={{
+        ...entry,
+        foodId: 'food1',
+        sourceIcon: '🥣',
+        thumbnailKind: 'food',
+      }}
+      onUpdate={vi.fn()}
+      onDelete={vi.fn()}
+    />,
+  )
+
+  expect(screen.getByText('🥣')).toBeDefined()
+})
+
+test('a one-off with no icon falls back to the food glyph', () => {
+  renderWithI18n(
     <ConsumptionEntryRow
       nav={nav}
       entry={entry}
@@ -184,7 +202,7 @@ test('an entry with no icon renders exactly as it always did', () => {
       onDelete={vi.fn()}
     />,
   )
-  expect(container.querySelector('[aria-hidden="true"]')).toBeNull()
+  expect(screen.getByText('🍽')).toBeDefined()
 })
 
 test('an invalid quantity does not call onUpdate', () => {

--- a/src/components/nutrition/ConsumptionEntryRow.tsx
+++ b/src/components/nutrition/ConsumptionEntryRow.tsx
@@ -4,6 +4,7 @@ import type { MealName } from '../../../convex/lib/consumption'
 import { MEAL_NAMES } from '../../../convex/lib/consumption'
 import type { NutritionFacts } from '../../../convex/lib/nutrition'
 import { useMessages } from '../../lib/i18n'
+import { FoodThumbnail, type ThumbnailKind } from './FoodThumbnail'
 import type { NutritionNav } from './nutritionNav'
 
 export interface ConsumptionEntryData {
@@ -22,6 +23,12 @@ export interface ConsumptionEntryData {
    * and does not keep a copy of the answer here.
    */
   icon?: string
+  /** The current source picture, if a food or visible recipe still has one. */
+  imageUrl?: string | null
+  /** A food's current chosen icon; a one-off continues to use `icon`. */
+  sourceIcon?: string
+  /** The source type survives when its provenance link is no longer visible. */
+  thumbnailKind?: ThumbnailKind
 }
 
 interface Props {
@@ -48,37 +55,40 @@ export function ConsumptionEntryRow({ entry, nav, onUpdate, onDelete }: Props) {
   return (
     <li className="py-2 text-sm">
       <div className="flex items-center justify-between gap-2">
-        <div>
-          {/* Decoration, and marked as such: the label beside it already says
-              what this is, so a screen reader repeating the emoji's name would
-              only be reading the row twice. */}
-          {entry.icon && (
-            <span aria-hidden="true" className="mr-1.5">
-              {entry.icon}
-            </span>
-          )}
-          <span className="font-medium">{entry.label}</span>
-          <span className="ml-2 opacity-60">
-            {entry.quantity} {units[entry.quantityUnit]}
-            {entry.nutrition.calories !== undefined &&
-              ` · ${entry.nutrition.calories} kcal`}
+        <div className="flex min-w-0 items-center gap-2">
+          {/* Decoration: the label already names this row, so the tile must not
+              make a screen reader announce the same thing twice. */}
+          <span aria-hidden="true">
+            <FoodThumbnail
+              src={entry.imageUrl}
+              icon={entry.sourceIcon ?? entry.icon}
+              kind={entry.thumbnailKind ?? 'food'}
+            />
           </span>
-          {entry.recipeId && (
-            <Link
-              {...nav.recipe(entry.recipeId)}
-              className="ml-2 text-xs underline"
-            >
-              {diary.entry.viewRecipe}
-            </Link>
-          )}
-          {entry.foodId && (
-            <Link
-              {...nav.food(entry.foodId)}
-              className="ml-2 text-xs underline"
-            >
-              {diary.entry.viewFood}
-            </Link>
-          )}
+          <div className="min-w-0">
+            <span className="font-medium">{entry.label}</span>
+            <span className="ml-2 opacity-60">
+              {entry.quantity} {units[entry.quantityUnit]}
+              {entry.nutrition.calories !== undefined &&
+                ` · ${entry.nutrition.calories} kcal`}
+            </span>
+            {entry.recipeId && (
+              <Link
+                {...nav.recipe(entry.recipeId)}
+                className="ml-2 text-xs underline"
+              >
+                {diary.entry.viewRecipe}
+              </Link>
+            )}
+            {entry.foodId && (
+              <Link
+                {...nav.food(entry.foodId)}
+                className="ml-2 text-xs underline"
+              >
+                {diary.entry.viewFood}
+              </Link>
+            )}
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <button

--- a/src/components/nutrition/FoodThumbnail.test.tsx
+++ b/src/components/nutrition/FoodThumbnail.test.tsx
@@ -15,40 +15,49 @@ import { FoodThumbnail } from './FoodThumbnail'
 
 const GLYPH = '🍽'
 
+test.each([
+  ['food', '🍽'],
+  ['recipe', '🍲'],
+  ['combo', '🍱'],
+] as const)('%s uses its own generic glyph', (kind, glyph) => {
+  render(<FoodThumbnail kind={kind} />)
+
+  expect(screen.getByText(glyph)).toBeDefined()
+})
+
 test('a photograph wins over an icon', () => {
-  render(
-    <FoodThumbnail
-      src="https://example.test/nutella.jpg"
-      icon="🍫"
-      alt="Nutella"
-    />,
+  const { container } = render(
+    <FoodThumbnail src="https://example.test/nutella.jpg" icon="🍫" />,
   )
 
-  expect(screen.getByAltText('Nutella')).toBeDefined()
+  expect(container.querySelector('img')).toHaveAttribute(
+    'src',
+    'https://example.test/nutella.jpg',
+  )
   expect(screen.queryByText('🍫')).toBeNull()
   expect(screen.queryByText(GLYPH)).toBeNull()
 })
 
 test('a photograph and nothing else is the photograph', () => {
-  render(<FoodThumbnail src="https://example.test/nutella.jpg" alt="Nutella" />)
+  const { container } = render(
+    <FoodThumbnail src="https://example.test/nutella.jpg" />,
+  )
 
-  expect(screen.getByAltText('Nutella')).toBeDefined()
+  expect(container.querySelector('img')).toBeDefined()
   expect(screen.queryByText(GLYPH)).toBeNull()
 })
 
 test('an icon stands in when there is no photograph', () => {
-  render(<FoodThumbnail icon="🍫" alt="Nutella" />)
+  render(<FoodThumbnail icon="🍫" />)
 
   expect(screen.getByText('🍫')).toBeDefined()
-  expect(screen.queryByAltText('Nutella')).toBeNull()
   expect(screen.queryByText(GLYPH)).toBeNull()
 })
 
 test('neither leaves the generic glyph exactly where it was', () => {
-  render(<FoodThumbnail alt="Nutella" />)
+  render(<FoodThumbnail />)
 
   expect(screen.getByText(GLYPH)).toBeDefined()
-  expect(screen.queryByAltText('Nutella')).toBeNull()
 })
 
 /**
@@ -56,7 +65,7 @@ test('neither leaves the generic glyph exactly where it was', () => {
  * `undefined` — the icon has to answer for that the same way.
  */
 test('a food whose picture query came back empty still shows its icon', () => {
-  render(<FoodThumbnail src={null} icon="🥛" alt="Milk" />)
+  render(<FoodThumbnail src={null} icon="🥛" />)
 
   expect(screen.getByText('🥛')).toBeDefined()
 })

--- a/src/components/nutrition/FoodThumbnail.tsx
+++ b/src/components/nutrition/FoodThumbnail.tsx
@@ -1,9 +1,12 @@
 /**
- * The picture on a row of the add sheet.
+ * The picture on a food, recipe, or Combo tile.
  *
  * Always occupies the same square, picture or no picture: a row that collapses
  * to the left when a food has no image makes a list of results harder to read
- * than one with no images at all.
+ * than one with no images at all. The same tile is used outside the add sheet
+ * too, so every surface has the same fallback chain. Every caller puts the
+ * tile beside the content's name, making it decoration rather than a second
+ * label for assistive technology.
  *
  * Three tiers, in this order — **photograph, then chosen icon, then the generic
  * glyph** (#94, superseding the photo-or-glyph fallback #69 shipped as
@@ -18,22 +21,40 @@
  * a live Open Food Facts result has nothing stored, so it renders theirs
  * directly and the row stops existing when the search does (#69).
  */
+export type ThumbnailKind = 'food' | 'recipe' | 'combo'
+
+const GENERIC_GLYPHS: Record<ThumbnailKind, string> = {
+  food: '🍽',
+  recipe: '🍲',
+  combo: '🍱',
+}
+
 export function FoodThumbnail({
   src,
   icon,
-  alt,
+  kind = 'food',
+  className = 'h-11 w-11 shrink-0',
+  glyphClassName = 'text-sm',
 }: {
   src?: string | null
   /** The emoji this food carries, if somebody picked one. */
   icon?: string
-  alt: string
+  /** Recipes and Combos have no chosen icon, only their type glyph. */
+  kind?: ThumbnailKind
+  /** The tile's outer layout and dimensions. */
+  className?: string
+  /** Lets a large tile give its generic glyph proportionate space. */
+  glyphClassName?: string
 }) {
   return (
-    <span className="flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-bg)]">
+    <span
+      aria-hidden="true"
+      className={`flex items-center justify-center overflow-hidden rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-bg)] ${className}`}
+    >
       {src ? (
         <img
           src={src}
-          alt={alt}
+          alt=""
           loading="lazy"
           className="h-full w-full object-cover"
         />
@@ -45,8 +66,8 @@ export function FoodThumbnail({
           {icon}
         </span>
       ) : (
-        <span aria-hidden="true" className="text-sm opacity-40">
-          🍽
+        <span aria-hidden="true" className={`${glyphClassName} opacity-40`}>
+          {GENERIC_GLYPHS[kind]}
         </span>
       )}
     </span>

--- a/src/components/recipes/RecipeCard.test.tsx
+++ b/src/components/recipes/RecipeCard.test.tsx
@@ -10,26 +10,30 @@ const recipe = {
 }
 
 test('grid mode shows title, stars, tags, and photo', () => {
-  render(<RecipeCard recipe={recipe} mode="grid" />)
+  const { container } = render(<RecipeCard recipe={recipe} mode="grid" />)
   expect(screen.getByText('Sunday Roast')).toBeInTheDocument()
   expect(screen.getByText('★★★★')).toBeInTheDocument()
   expect(screen.getByText('dinner, comfort food')).toBeInTheDocument()
-  expect(screen.getByRole('img', { name: 'Sunday Roast' })).toBeInTheDocument()
+  expect(container.querySelector('img')).toHaveAttribute(
+    'src',
+    'https://example.com/photo.jpg',
+  )
 })
 
-test('recipes without a photo render a placeholder, not a broken image', () => {
+test('recipes without a photo render the recipe glyph, not a broken image', () => {
   render(<RecipeCard recipe={{ ...recipe, imageUrl: null }} mode="grid" />)
   expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  expect(screen.getByText('🍲')).toBeInTheDocument()
 })
 
 test('compact mode renders the same content in a row layout', () => {
-  render(<RecipeCard recipe={recipe} mode="compact" />)
+  const { container } = render(<RecipeCard recipe={recipe} mode="compact" />)
   expect(screen.getByText('Sunday Roast')).toBeInTheDocument()
-  expect(screen.getByRole('img', { name: 'Sunday Roast' })).toBeInTheDocument()
+  expect(container.querySelector('img')).toBeInTheDocument()
 })
 
 test('banner mode renders title and stars overlaid on the photo', () => {
-  render(<RecipeCard recipe={recipe} mode="banner" />)
+  const { container } = render(<RecipeCard recipe={recipe} mode="banner" />)
   expect(screen.getByText('Sunday Roast')).toBeInTheDocument()
-  expect(screen.getByRole('img', { name: 'Sunday Roast' })).toBeInTheDocument()
+  expect(container.querySelector('img')).toBeInTheDocument()
 })

--- a/src/components/recipes/RecipeCard.tsx
+++ b/src/components/recipes/RecipeCard.tsx
@@ -1,3 +1,5 @@
+import { FoodThumbnail } from '../nutrition/FoodThumbnail'
+
 export type RecipeViewMode = 'grid' | 'banner' | 'compact'
 
 export interface RecipeCardData {
@@ -19,18 +21,18 @@ function Stars({ rating }: { rating?: number }) {
 
 function Photo({
   imageUrl,
-  title,
   className,
 }: {
   imageUrl: string | null
-  title: string
   className: string
 }) {
-  if (!imageUrl) {
-    return <div className={`${className} bg-black/5 dark:bg-white/10`} />
-  }
   return (
-    <img src={imageUrl} alt={title} className={`${className} object-cover`} />
+    <FoodThumbnail
+      src={imageUrl}
+      kind="recipe"
+      className={className}
+      glyphClassName="text-4xl"
+    />
   )
 }
 
@@ -40,7 +42,6 @@ export function RecipeCard({ recipe, mode }: RecipeCardProps) {
       <div className="relative h-56 overflow-hidden rounded-xl">
         <Photo
           imageUrl={recipe.imageUrl}
-          title={recipe.title}
           className="absolute inset-0 h-full w-full"
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent" />
@@ -57,7 +58,6 @@ export function RecipeCard({ recipe, mode }: RecipeCardProps) {
       <div className="flex items-center gap-3 rounded-xl border p-2">
         <Photo
           imageUrl={recipe.imageUrl}
-          title={recipe.title}
           className="h-16 w-16 flex-shrink-0 rounded-lg"
         />
         <div>
@@ -75,7 +75,6 @@ export function RecipeCard({ recipe, mode }: RecipeCardProps) {
     <div className="rounded-xl border p-4">
       <Photo
         imageUrl={recipe.imageUrl}
-        title={recipe.title}
         className="mb-3 h-32 w-full rounded-lg"
       />
       <p className="font-medium">{recipe.title}</p>

--- a/src/components/recipes/RecipeDetailPage.tsx
+++ b/src/components/recipes/RecipeDetailPage.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import { fmt, useMessages } from '../../lib/i18n'
+import { FoodThumbnail } from '../nutrition/FoodThumbnail'
 import { NutritionPanel } from './NutritionPanel'
 import { RecipeSharingPanel } from './RecipeSharingPanel'
 import type { RecipeNav } from './recipeNav'
@@ -96,13 +97,12 @@ export function RecipeDetailPage({
         </p>
       )}
 
-      {recipe.imageUrl && (
-        <img
-          src={recipe.imageUrl}
-          alt={recipe.title}
-          className="mb-4 w-full rounded-xl object-cover"
-        />
-      )}
+      <FoodThumbnail
+        src={recipe.imageUrl}
+        kind="recipe"
+        className="mb-4 h-64 w-full"
+        glyphClassName="text-6xl"
+      />
       {recipe.description && (
         <p className="mb-4 opacity-80">{recipe.description}</p>
       )}


### PR DESCRIPTION
## Summary

- Use one decorative thumbnail fallback across foods, recipes, and Combos: photo, chosen food icon, then a type glyph.
- Show it in food list/detail views, recipe list/detail/add sheet, Combo cards, and diary rows.
- Resolve a food diary entry's current icon without exposing recipe provenance that is no longer visible.
- Add icons to Sample household user-food fixtures.

## Root cause

The existing fallback tile was only rendered in two add-sheet food cards. Other listed content had no shared thumbnail, and diary entries only displayed icons stored directly on one-offs.

## Validation

- `pnpm run test` (98 files, 1,120 tests)
- `pnpm run typecheck`
- `pnpm run check`
- `pnpm run build`