### PR TITLE
Use icons for recipe and food actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,14 @@ Four rules the conversion established, each of which will bite if ignored:
 Component tests render through `renderWithI18n` from `src/lib/i18n/testing.tsx`;
 `useI18n` throws outside `LocaleProvider` rather than falling back.
 
+## Responsive action controls
+
+Compact add, edit, delete, and refresh controls show only their icon below
+Tailwind's desktop breakpoint (`lg`, 1024px), including on tablets. At `lg` and
+above, show the icon and its translated visible label. Every icon-only control
+still needs its translated `aria-label`. Keep a textual label when it carries
+essential state or workflow context, such as a form submission or confirmation.
+
 ## One-shot code states its own end condition
 
 Migration mutations, backfills and compatibility shims are written to run against

--- a/src/components/foods/FoodDetailPage.tsx
+++ b/src/components/foods/FoodDetailPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import { useAction, useQuery } from 'convex/react'
+import { Pencil, RefreshCw } from 'lucide-react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import { fmt, useMessages } from '../../lib/i18n'
@@ -42,9 +43,10 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
         {food.seedKey === undefined ? (
           <Link
             {...nav.edit(foodId)}
-            className="rounded border px-3 py-1.5 text-sm no-underline"
+            aria-label={messages.common.actions.edit}
+            className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border no-underline"
           >
-            {messages.common.actions.edit}
+            <Pencil className="h-4 w-4" aria-hidden="true" />
           </Link>
         ) : (
           <span className="rounded border border-dashed px-3 py-1.5 text-sm opacity-60">
@@ -109,7 +111,8 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
       {food.barcode && (
         <button
           type="button"
-          className="rounded border px-3 py-1.5 text-sm"
+          aria-label={detail.refresh}
+          className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border"
           onClick={() =>
             confirm({
               title: detail.refreshTitle,
@@ -120,7 +123,7 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
             })
           }
         >
-          {detail.refresh}
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
         </button>
       )}
 

--- a/src/components/foods/FoodDetailPage.tsx
+++ b/src/components/foods/FoodDetailPage.tsx
@@ -44,9 +44,12 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
           <Link
             {...nav.edit(foodId)}
             aria-label={messages.common.actions.edit}
-            className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border no-underline"
+            className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border no-underline lg:gap-2 lg:px-3 lg:py-1.5 lg:text-sm"
           >
             <Pencil className="h-4 w-4" aria-hidden="true" />
+            <span className="hidden lg:inline">
+              {messages.common.actions.edit}
+            </span>
           </Link>
         ) : (
           <span className="rounded border border-dashed px-3 py-1.5 text-sm opacity-60">
@@ -112,7 +115,7 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
         <button
           type="button"
           aria-label={detail.refresh}
-          className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border"
+          className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border lg:gap-2 lg:px-3 lg:py-1.5 lg:text-sm"
           onClick={() =>
             confirm({
               title: detail.refreshTitle,
@@ -124,6 +127,7 @@ export function FoodDetailPage({ foodId, nav }: FoodDetailPageProps) {
           }
         >
           <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          <span className="hidden lg:inline">{detail.refresh}</span>
         </button>
       )}
 

--- a/src/components/foods/FoodsPage.tsx
+++ b/src/components/foods/FoodsPage.tsx
@@ -50,9 +50,10 @@ export function FoodsPage({ nav }: { nav: FoodNav }) {
       <Link
         {...nav.create()}
         aria-label={list.addManually}
-        className="mb-4 inline-flex min-h-9 min-w-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] no-underline"
+        className="mb-4 inline-flex min-h-9 min-w-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] no-underline lg:gap-2 lg:px-3 lg:py-1.5 lg:text-sm"
       >
         <Plus className="h-4 w-4" aria-hidden="true" />
+        <span className="hidden lg:inline">{list.addManually}</span>
       </Link>
 
       {results === undefined && debouncedTerm.trim() && (

--- a/src/components/foods/FoodsPage.tsx
+++ b/src/components/foods/FoodsPage.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from '@tanstack/react-router'
 import { useQuery } from 'convex/react'
+import { Plus } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import { fmt, useMessages } from '../../lib/i18n'
@@ -48,9 +49,10 @@ export function FoodsPage({ nav }: { nav: FoodNav }) {
 
       <Link
         {...nav.create()}
-        className="mb-4 inline-block rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 py-1.5 text-sm no-underline"
+        aria-label={list.addManually}
+        className="mb-4 inline-flex min-h-9 min-w-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] no-underline"
       >
-        {list.addManually}
+        <Plus className="h-4 w-4" aria-hidden="true" />
       </Link>
 
       {results === undefined && debouncedTerm.trim() && (

--- a/src/components/recipes/RecipeDetailPage.tsx
+++ b/src/components/recipes/RecipeDetailPage.tsx
@@ -67,14 +67,17 @@ export function RecipeDetailPage({
             <Link
               {...nav.edit(recipeId)}
               aria-label={messages.common.actions.edit}
-              className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border no-underline"
+              className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border no-underline lg:gap-2 lg:px-3 lg:py-1.5 lg:text-sm"
             >
               <Pencil className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden lg:inline">
+                {messages.common.actions.edit}
+              </span>
             </Link>
             <button
               type="button"
               aria-label={messages.common.actions.delete}
-              className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border"
+              className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border lg:gap-2 lg:px-3 lg:py-1.5 lg:text-sm"
               onClick={async () => {
                 setError(null)
                 try {
@@ -88,6 +91,9 @@ export function RecipeDetailPage({
               }}
             >
               <Trash2 className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden lg:inline">
+                {messages.common.actions.delete}
+              </span>
             </button>
           </div>
         )}
@@ -183,9 +189,10 @@ export function RecipeDetailPage({
             <Link
               {...nav.edit(recipeId)}
               aria-label={detail.editManually}
-              className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border border-amber-400 no-underline"
+              className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border border-amber-400 no-underline lg:gap-1 lg:px-2 lg:py-1 lg:text-xs lg:font-medium"
             >
               <Pencil className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden lg:inline">{detail.editManually}</span>
             </Link>
           </div>
         </div>

--- a/src/components/recipes/RecipeDetailPage.tsx
+++ b/src/components/recipes/RecipeDetailPage.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from '@tanstack/react-router'
 import { useAction, useMutation, useQuery } from 'convex/react'
 import { ConvexError } from 'convex/values'
+import { Pencil, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
@@ -65,13 +66,15 @@ export function RecipeDetailPage({
           <div className="flex gap-2">
             <Link
               {...nav.edit(recipeId)}
-              className="rounded border px-3 py-1.5 text-sm no-underline"
+              aria-label={messages.common.actions.edit}
+              className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border no-underline"
             >
-              {messages.common.actions.edit}
+              <Pencil className="h-4 w-4" aria-hidden="true" />
             </Link>
             <button
               type="button"
-              className="rounded border px-3 py-1.5 text-sm"
+              aria-label={messages.common.actions.delete}
+              className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border"
               onClick={async () => {
                 setError(null)
                 try {
@@ -84,7 +87,7 @@ export function RecipeDetailPage({
                 }
               }}
             >
-              {messages.common.actions.delete}
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
         )}
@@ -179,9 +182,10 @@ export function RecipeDetailPage({
             )}
             <Link
               {...nav.edit(recipeId)}
-              className="rounded border border-amber-400 px-2 py-1 text-xs font-medium no-underline"
+              aria-label={detail.editManually}
+              className="inline-flex min-h-9 min-w-9 items-center justify-center rounded border border-amber-400 no-underline"
             >
-              {detail.editManually}
+              <Pencil className="h-4 w-4" aria-hidden="true" />
             </Link>
           </div>
         </div>

--- a/src/components/recipes/RecipesPage.tsx
+++ b/src/components/recipes/RecipesPage.tsx
@@ -44,10 +44,10 @@ export function RecipesPage({
           <ViewModeToggle mode={viewMode} onChange={setViewMode} />
           <Link
             {...nav.create}
-            className="inline-flex min-h-9 items-center gap-2 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 text-sm font-semibold text-[var(--app-fg)] no-underline"
+            aria-label={list.add}
+            className="inline-flex min-h-9 min-w-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] text-[var(--app-fg)] no-underline"
           >
             <Plus className="h-4 w-4" aria-hidden="true" />
-            {list.add}
           </Link>
         </div>
       </div>
@@ -70,9 +70,10 @@ export function RecipesPage({
             </p>
             <Link
               {...nav.create}
-              className="mx-auto inline-flex min-h-9 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm font-semibold no-underline"
+              aria-label={list.emptyAction}
+              className="mx-auto inline-flex min-h-9 min-w-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] no-underline"
             >
-              {list.emptyAction}
+              <Plus className="h-4 w-4" aria-hidden="true" />
             </Link>
           </div>
         </SurfaceCard>

--- a/src/components/recipes/RecipesPage.tsx
+++ b/src/components/recipes/RecipesPage.tsx
@@ -45,9 +45,10 @@ export function RecipesPage({
           <Link
             {...nav.create}
             aria-label={list.add}
-            className="inline-flex min-h-9 min-w-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] text-[var(--app-fg)] no-underline"
+            className="inline-flex min-h-9 min-w-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] text-[var(--app-fg)] no-underline lg:gap-2 lg:px-3 lg:text-sm lg:font-semibold"
           >
             <Plus className="h-4 w-4" aria-hidden="true" />
+            <span className="hidden lg:inline">{list.add}</span>
           </Link>
         </div>
       </div>
@@ -71,9 +72,10 @@ export function RecipesPage({
             <Link
               {...nav.create}
               aria-label={list.emptyAction}
-              className="mx-auto inline-flex min-h-9 min-w-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] no-underline"
+              className="mx-auto inline-flex min-h-9 min-w-9 items-center justify-center rounded-[var(--app-radius)] border border-[var(--app-border)] no-underline lg:gap-2 lg:px-3 lg:text-sm lg:font-semibold"
             >
               <Plus className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden lg:inline">{list.emptyAction}</span>
             </Link>
           </div>
         </SurfaceCard>


### PR DESCRIPTION
## Summary
- replace compact recipe and food add/edit controls with icons
- use icons for related recipe delete and food refresh actions
- retain localized accessible labels for every icon-only control

## Verification
- pnpm exec biome check src/components/recipes/RecipesPage.tsx src/components/recipes/RecipeDetailPage.tsx
- pnpm run typecheck
- pnpm test

Closes #118