### PR TITLE
feat(nutrition): make Foods and a Combos library reachable from the diary

### DIFF
--- a/convex/foods.test.ts
+++ b/convex/foods.test.ts
@@ -99,6 +99,25 @@ describe('browsing the Catalog without searching', () => {
     ])
   })
 
+  test('takes the first page alphabetically, not an arbitrary hundred', async () => {
+    const { t } = await seed()
+    // Inserted last-first, and past the browse limit, so a page cut before
+    // sorting would keep the z-names and drop the a-names entirely.
+    for (let i = 120; i > 0; i--) {
+      await t.withIdentity(asAlice).mutation(api.foods.create, {
+        name: `Food ${String(i).padStart(3, '0')}`,
+        baseUnit: 'g',
+        nutritionPer100: { calories: 100 },
+      })
+    }
+
+    const rows = await t.withIdentity(asBob).query(api.foods.list, {})
+
+    expect(rows).toHaveLength(100)
+    expect(rows[0].name).toBe('Food 001')
+    expect(rows.at(-1)?.name).toBe('Food 100')
+  })
+
   test('reads the same for two people who share no group', async () => {
     const { t } = await seed()
 

--- a/convex/foods.test.ts
+++ b/convex/foods.test.ts
@@ -75,6 +75,46 @@ describe('the food Catalog', () => {
 })
 
 /**
+ * Arriving at Foods shows the Catalog. `search` cannot answer that — an empty
+ * term means nothing to a full-text index, and it rightly returns nothing — so
+ * browsing is its own query (#100 review).
+ */
+describe('browsing the Catalog without searching', () => {
+  test('lists the foods in alphabetical order', async () => {
+    const { t } = await seed()
+    for (const name of ['Yoghurt', 'Appelstroop']) {
+      await t.withIdentity(asAlice).mutation(api.foods.create, {
+        name,
+        baseUnit: 'g',
+        nutritionPer100: { calories: 100 },
+      })
+    }
+
+    const rows = await t.withIdentity(asBob).query(api.foods.list, {})
+
+    expect(rows.map((f) => f.name)).toEqual([
+      'Appelstroop',
+      'Hagelslag',
+      'Yoghurt',
+    ])
+  })
+
+  test('reads the same for two people who share no group', async () => {
+    const { t } = await seed()
+
+    expect(await t.withIdentity(asAlice).query(api.foods.list, {})).toEqual(
+      await t.withIdentity(asBob).query(api.foods.list, {}),
+    )
+  })
+
+  test('is not readable at all without a session', async () => {
+    const { t } = await seed()
+
+    expect(await t.query(api.foods.list, {})).toEqual([])
+  })
+})
+
+/**
  * A brand is what is written largest on the carton, so it is what people type.
  * A search index has one full-text field, so matching it is a fact about the
  * row rather than about the query — see `lib/foodSearchText.ts`.

--- a/convex/foods.ts
+++ b/convex/foods.ts
@@ -115,15 +115,25 @@ const BROWSE_LIMIT = 100
  * like one you have to guess at (#100 review). This is the other half of the
  * page: the Catalog itself, in alphabetical order.
  *
- * Sorted here rather than by an index because `foods` has none on `name`, and
- * `take` bounds what is read either way. If the Catalog ever outgrows one
- * page, this is where paging goes — not a bigger limit.
+ * Ordered by the `by_name` index rather than sorted after the fact: `take`
+ * has to cut the Catalog somewhere, and cutting it before sorting would make
+ * the first page whatever the table happened to return — not the first page
+ * alphabetically. `foods` is one globally readable table, so it passes a
+ * hundred rows on somebody else's account rather than on the seed's.
+ *
+ * The index orders by raw name, so the page is chosen by that; the sort below
+ * only settles how those same rows read to a person, where case and accents
+ * matter and byte order does not. If the Catalog outgrows one page, this is
+ * where cursor paging goes — not a bigger limit.
  */
 export const list = query({
   args: {},
   handler: async (ctx) => {
     if (!(await getCurrentUser(ctx))) return []
-    const rows = await ctx.db.query('foods').take(BROWSE_LIMIT)
+    const rows = await ctx.db
+      .query('foods')
+      .withIndex('by_name')
+      .take(BROWSE_LIMIT)
     return await Promise.all(
       [...rows]
         .sort((a, b) => a.name.localeCompare(b.name))

--- a/convex/foods.ts
+++ b/convex/foods.ts
@@ -103,6 +103,35 @@ export const search = query({
   },
 })
 
+/** How much of the Catalog a browse shows before somebody narrows it. */
+const BROWSE_LIMIT = 100
+
+/**
+ * The Catalog to browse, rather than to search.
+ *
+ * `search` answers an empty term with nothing, and rightly — a full-text index
+ * has no meaning for `''`. But that left the Foods page blank until somebody
+ * typed, which made a catalog you are meant to be able to look through feel
+ * like one you have to guess at (#100 review). This is the other half of the
+ * page: the Catalog itself, in alphabetical order.
+ *
+ * Sorted here rather than by an index because `foods` has none on `name`, and
+ * `take` bounds what is read either way. If the Catalog ever outgrows one
+ * page, this is where paging goes — not a bigger limit.
+ */
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    if (!(await getCurrentUser(ctx))) return []
+    const rows = await ctx.db.query('foods').take(BROWSE_LIMIT)
+    return await Promise.all(
+      [...rows]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((row) => withImageUrl(ctx, row)),
+    )
+  },
+})
+
 export const get = query({
   args: { id: v.id('foods') },
   handler: async (ctx, args) => {

--- a/convex/lib/slugs.ts
+++ b/convex/lib/slugs.ts
@@ -32,6 +32,10 @@ export const RESERVED_SLUGS: ReadonlySet<string> = new Set([
   // registry entry, no sidebar row — so nothing else claims the segment on its
   // behalf, and `groupPaths.segments.test.ts` holds it here instead.
   'foods',
+  // The Combos library, reserved for the same reason as `foods` above: it has a
+  // Group-level route and is not a Module — a Combo is Personal (ADR-0012), so
+  // there is no registry entry to claim the segment on its behalf.
+  'combos',
   'new',
   'all',
   'home',

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -187,6 +187,11 @@ export default defineSchema({
   })
     .index('by_barcode', ['barcode'])
     .index('by_seedKey', ['seedKey'])
+    // Browsing reads a page of the Catalog in name order. Without this the
+    // page would be whatever the table happened to hand back and only then be
+    // sorted, which is not the first page alphabetically the moment there are
+    // more foods than fit on one (#100 review).
+    .index('by_name', ['name'])
     .searchIndex('search_by_text', { searchField: 'searchText' }),
 
   consumptionEntries: defineTable({

--- a/src/components/foods/FoodsPage.tsx
+++ b/src/components/foods/FoodsPage.tsx
@@ -22,7 +22,17 @@ export function FoodsPage({ nav }: { nav: FoodNav }) {
     const id = setTimeout(() => setDebouncedTerm(term), 250)
     return () => clearTimeout(id)
   }, [term])
-  const results = useQuery(api.foods.search, { term: debouncedTerm })
+  // Two questions, and only ever one of them asked: with nothing typed the
+  // page shows the Catalog, and typing narrows it. `search` cannot answer the
+  // first — an empty term means nothing to a full-text index — so browsing is
+  // its own query rather than a special case bolted onto searching.
+  const browsing = !debouncedTerm.trim()
+  const searched = useQuery(
+    api.foods.search,
+    browsing ? 'skip' : { term: debouncedTerm },
+  )
+  const browsed = useQuery(api.foods.list, browsing ? {} : 'skip')
+  const results = browsing ? browsed : searched
   const navigate = useNavigate()
   const { list } = useMessages().foods
 

--- a/src/components/nutrition/CombosPage.test.tsx
+++ b/src/components/nutrition/CombosPage.test.tsx
@@ -1,0 +1,142 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, expect, test, vi } from 'vitest'
+import type { ComboComponent } from '../../../convex/lib/combos'
+import { renderWithI18n } from '../../lib/i18n/testing'
+import { CombosPage } from './CombosPage'
+import { groupNutritionNav } from './nutritionNav'
+
+/**
+ * The Combos library (#100): somewhere to see what you have saved, rather than
+ * only meeting them inside the add sheet.
+ *
+ * It reads `combos.list`, which resolves the caller and returns their own rows
+ * and nothing else (ADR-0012) — so there is no Group argument here to get
+ * wrong, and none is invented.
+ */
+
+const combos = vi.hoisted(() => ({ value: undefined as unknown }))
+const queried = vi.hoisted(() => ({ value: [] as unknown[] }))
+
+vi.mock('convex/react', () => ({
+  useQuery: (name: string, args: unknown) => {
+    queried.value.push([name, args])
+    return combos.value
+  },
+}))
+
+vi.mock('../../../convex/_generated/api', () => ({
+  api: { combos: { list: 'combos:list' } },
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    params,
+    className,
+  }: {
+    children: React.ReactNode
+    to: string
+    params?: Record<string, string>
+    className?: string
+  }) => {
+    const href = params
+      ? Object.entries(params).reduce(
+          (path, [key, value]) => path.replace(`$${key}`, value),
+          to,
+        )
+      : to
+    return (
+      <a href={href} className={className}>
+        {children}
+      </a>
+    )
+  },
+}))
+
+const bread: ComboComponent = {
+  id: 'bread',
+  label: 'Wholemeal bread',
+  quantity: 70,
+  quantityUnit: 'g',
+  foodId: 'food-bread',
+  food: { baseUnit: 'g', nutritionPer100: { calories: 250 } },
+  available: true,
+}
+
+const granola: ComboComponent = {
+  id: 'granola',
+  label: 'Nora’s granola',
+  quantity: 1,
+  quantityUnit: 'serving',
+  recipeId: 'recipe-granola',
+  available: false,
+}
+
+beforeEach(() => {
+  combos.value = undefined
+  queried.value = []
+})
+
+function render(groupSlug = 'jansen-household') {
+  renderWithI18n(<CombosPage nav={groupNutritionNav(groupSlug)} />)
+}
+
+test('asks only for the signed-in person’s combos', () => {
+  combos.value = []
+  render()
+
+  expect(queried.value).toEqual([['combos:list', {}]])
+})
+
+test('says what a combo is and how one is made when there are none yet', () => {
+  combos.value = []
+  render()
+
+  expect(screen.getByText(/no combos yet/i)).toBeDefined()
+  expect(screen.getByText(/save as combo/i)).toBeDefined()
+  expect(screen.getByRole('link', { name: /diary/i })).toHaveAttribute(
+    'href',
+    '/g/jansen-household/nutrition',
+  )
+})
+
+test('lists what each saved combo holds', () => {
+  combos.value = [
+    { _id: 'combo1', name: 'Usual breakfast', order: 0, components: [bread] },
+    { _id: 'combo2', name: 'Work lunch', order: 1, components: [bread, bread] },
+  ]
+  render()
+
+  expect(screen.getByText('Usual breakfast')).toBeDefined()
+  expect(screen.getByText('Work lunch')).toBeDefined()
+  expect(screen.getByText('1 item')).toBeDefined()
+  expect(screen.getByText('2 items')).toBeDefined()
+  expect(screen.getAllByText('Wholemeal bread').length).toBe(3)
+  expect(screen.queryByText(/no combos yet/i)).toBeNull()
+})
+
+test('a component nobody can reach any more still shows, and says so', () => {
+  combos.value = [
+    {
+      _id: 'combo1',
+      name: 'Usual breakfast',
+      order: 0,
+      components: [bread, granola],
+    },
+  ]
+  render()
+
+  expect(screen.getByText('Nora’s granola')).toBeDefined()
+  expect(screen.getByText('Not available any more')).toBeDefined()
+})
+
+test('keeps the Group that was open in the way back to the diary', () => {
+  combos.value = []
+  render('wine-club')
+
+  expect(screen.getByRole('link', { name: /diary/i })).toHaveAttribute(
+    'href',
+    '/g/wine-club/nutrition',
+  )
+})

--- a/src/components/nutrition/CombosPage.tsx
+++ b/src/components/nutrition/CombosPage.tsx
@@ -1,0 +1,105 @@
+import { Link } from '@tanstack/react-router'
+import { useQuery } from 'convex/react'
+import { api } from '../../../convex/_generated/api'
+import { comboEntries } from '../../../convex/lib/combos'
+import { sumFacts } from '../../../convex/lib/consumption'
+import { fmt, plural, useI18n } from '../../lib/i18n'
+import type { NutritionNav } from './nutritionNav'
+
+/**
+ * The Combos library: what you have saved, in one place (#100).
+ *
+ * A Combo is Personal (ADR-0012), so `combos.list` resolves the caller and
+ * returns their own rows — there is no Group argument to pass, and the page
+ * therefore reads the same from every Group even though its address names one.
+ *
+ * Browsing only. Logging a Combo is something that happens *into a meal*, which
+ * this page has no day and no slot for, and there is deliberately no builder
+ * here: a Combo is made by saving a meal slot you have already filled in, which
+ * is what the empty state explains instead of offering a button that would have
+ * to invent one.
+ */
+export function CombosPage({ nav }: { nav: NutritionNav }) {
+  const { locale, messages } = useI18n()
+  const library = messages.nutrition.combosLibrary
+  const { combos: comboWords, personalNote } = messages.nutrition.diary
+  const combos = useQuery(api.combos.list, {})
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <h1 className="mb-1 text-2xl font-semibold">{library.title}</h1>
+      <p className="mb-4 text-sm text-[var(--app-muted)]">{personalNote}</p>
+
+      <Link
+        {...nav.diary}
+        className="mb-6 inline-flex min-h-11 items-center text-sm underline"
+      >
+        {library.back}
+      </Link>
+
+      {combos === undefined && (
+        <p className="text-sm opacity-60">{messages.common.errors.loading}</p>
+      )}
+
+      {combos?.length === 0 && (
+        <div className="rounded-[var(--app-radius)] border border-[var(--app-border)] p-4">
+          <p className="mb-1 font-medium">{library.empty}</p>
+          <p className="text-sm opacity-70">{library.emptyHow}</p>
+        </div>
+      )}
+
+      <ul className="grid grid-cols-1 gap-3">
+        {combos?.map((combo) => {
+          const totals = sumFacts(
+            comboEntries(combo.components).map((entry) => entry.nutrition),
+          )
+          return (
+            <li
+              key={combo._id}
+              className="rounded-[var(--app-radius)] border border-[var(--app-border)] p-3"
+            >
+              <div className="flex items-baseline justify-between gap-3">
+                <h2 className="min-w-0 truncate font-medium">{combo.name}</h2>
+                {totals.calories !== undefined && (
+                  <span className="shrink-0 text-sm opacity-60">
+                    {fmt(comboWords.kcal, {
+                      calories: Math.round(totals.calories),
+                    })}
+                  </span>
+                )}
+              </div>
+              <p className="mb-2 text-xs opacity-60">
+                {fmt(
+                  plural(locale, combo.components.length, comboWords.itemCount),
+                  { count: combo.components.length },
+                )}
+              </p>
+              <ul className="grid gap-1">
+                {combo.components.map((component) => (
+                  <li
+                    key={component.id}
+                    className={`flex items-baseline justify-between gap-3 text-sm ${
+                      component.available ? '' : 'opacity-50'
+                    }`}
+                  >
+                    <span className="min-w-0 truncate">{component.label}</span>
+                    <span className="shrink-0 text-xs opacity-60">
+                      {component.available
+                        ? fmt(comboWords.amount, {
+                            quantity: component.quantity,
+                            unit: messages.nutrition.units[
+                              component.quantityUnit
+                            ],
+                          })
+                        : comboWords.unavailable}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/nutrition/NutritionPage.test.tsx
+++ b/src/components/nutrition/NutritionPage.test.tsx
@@ -1,0 +1,96 @@
+import { screen } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
+import { NutritionPage } from './NutritionPage'
+import { groupNutritionNav } from './nutritionNav'
+
+/**
+ * The diary is also where the two libraries beside it are reached from (#100).
+ * Foods is the Catalog everybody shares; Combos is the person's own. Neither
+ * had a way in from Nutrition before, so both were addresses you had to know.
+ */
+
+vi.mock('convex/react', () => ({
+  useQuery: () => undefined,
+  useMutation: () => vi.fn(),
+}))
+
+vi.mock('../../../convex/_generated/api', () => ({
+  api: {
+    users: { me: 'users:me' },
+    consumption: {
+      listForDay: 'consumption:listForDay',
+      update: 'consumption:update',
+      remove: 'consumption:remove',
+    },
+    combos: { saveFromMeal: 'combos:saveFromMeal' },
+  },
+}))
+
+// TanStack Router's <Link> reads router state, which a component test has no
+// provider for — the same plain-anchor stand-in the sibling suites use.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    params,
+    search,
+    className,
+  }: {
+    children: React.ReactNode
+    to: string
+    params?: Record<string, string>
+    search?: Record<string, string>
+    className?: string
+  }) => {
+    const path = params
+      ? Object.entries(params).reduce(
+          (acc, [key, value]) => acc.replace(`$${key}`, value),
+          to,
+        )
+      : to
+    const query = search ? `?${new URLSearchParams(search).toString()}` : ''
+    return (
+      <a href={`${path}${query}`} className={className}>
+        {children}
+      </a>
+    )
+  },
+}))
+
+function renderDiary(groupSlug = 'jansen-household') {
+  renderWithI18n(
+    <NutritionPage
+      date="2026-07-18"
+      onDateChange={vi.fn()}
+      nav={groupNutritionNav(groupSlug)}
+    />,
+  )
+}
+
+test('offers the Foods catalog without anybody having to know its address', () => {
+  renderDiary()
+
+  expect(screen.getByRole('link', { name: /foods/i })).toHaveAttribute(
+    'href',
+    '/g/jansen-household/foods',
+  )
+})
+
+test('keeps the Group that was open in the Foods address', () => {
+  renderDiary('wine-club')
+
+  expect(screen.getByRole('link', { name: /foods/i })).toHaveAttribute(
+    'href',
+    '/g/wine-club/foods',
+  )
+})
+
+test('offers the Combos library beside it', () => {
+  renderDiary()
+
+  expect(screen.getByRole('link', { name: /combos/i })).toHaveAttribute(
+    'href',
+    '/g/jansen-household/combos',
+  )
+})

--- a/src/components/nutrition/NutritionPage.tsx
+++ b/src/components/nutrition/NutritionPage.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@tanstack/react-router'
 import { useMutation, useQuery } from 'convex/react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
@@ -81,6 +82,7 @@ export function NutritionPage({
 
   const messages = useMessages()
   const { diary, meals } = messages.nutrition
+  const { libraries } = diary
 
   const totals = sumFacts((entries ?? []).map((e) => e.nutrition))
 
@@ -94,6 +96,28 @@ export function NutritionPage({
           {diary.personalNote}
         </p>
       )}
+
+      {/* The two libraries the diary draws on. Both were addresses you had to
+          know before (#100): the Catalog had no way in from here at all, and a
+          Combo could only be met inside the add sheet. They sit above the day
+          rather than in the shell because neither is a Module — Foods is
+          Catalog and a Combo is Personal — so nothing in the sidebar or the
+          dock claims a row for them, and a phone reaches them the same way a
+          desktop does. */}
+      <nav aria-label={libraries.heading} className="mb-4 flex flex-wrap gap-2">
+        <Link
+          {...nav.foods}
+          className="inline-flex min-h-11 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm no-underline"
+        >
+          {libraries.foods}
+        </Link>
+        <Link
+          {...nav.combos}
+          className="inline-flex min-h-11 items-center rounded-[var(--app-radius)] border border-[var(--app-border)] px-3 text-sm no-underline"
+        >
+          {libraries.combos}
+        </Link>
+      </nav>
 
       <div className="mb-4 flex items-center justify-between gap-2">
         <button

--- a/src/components/nutrition/nutritionNav.test.ts
+++ b/src/components/nutrition/nutritionNav.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from 'vitest'
+import { groupNutritionNav } from './nutritionNav'
+
+/**
+ * Where Nutrition points *out* of itself.
+ *
+ * The Foods Catalog belongs to nobody and a Combo belongs to a person, so
+ * neither destination's content depends on the Group in the URL — but both
+ * addresses do, because a link that dropped the slug would quietly take
+ * whoever followed it out of the Group they were reading (ADR-0002).
+ */
+
+test('the Foods catalog keeps the Group that was open', () => {
+  expect(groupNutritionNav('jansen-household').foods).toEqual({
+    to: '/g/$groupSlug/foods',
+    params: { groupSlug: 'jansen-household' },
+  })
+})
+
+test('the Combos library keeps it too, though a Combo belongs to no Group', () => {
+  expect(groupNutritionNav('me-alice').combos).toEqual({
+    to: '/g/$groupSlug/combos',
+    params: { groupSlug: 'me-alice' },
+  })
+})
+
+test('the diary is what the Combos library comes back to', () => {
+  expect(groupNutritionNav('me-alice').diary).toEqual({
+    to: '/g/$groupSlug/nutrition',
+    params: { groupSlug: 'me-alice' },
+  })
+})

--- a/src/components/nutrition/nutritionNav.ts
+++ b/src/components/nutrition/nutritionNav.ts
@@ -35,6 +35,18 @@ export interface NutritionNav {
    * Catalog.
    */
   addEntry: (date: string, meal: MealName, foodId?: string) => AppLink
+  /**
+   * The two libraries beside the diary (#100).
+   *
+   * Neither one's *content* depends on the Group in the URL — the Catalog
+   * belongs to nobody and a Combo belongs to a person — but both addresses do,
+   * for the same reason every destination here does: a link that dropped the
+   * slug would move whoever followed it into some other Group (ADR-0002).
+   */
+  foods: AppLink
+  combos: AppLink
+  /** The diary itself — what the Combos library is a detour from, and back to. */
+  diary: AppLink
 }
 
 export function groupNutritionNav(groupSlug: string): NutritionNav {
@@ -51,5 +63,8 @@ export function groupNutritionNav(groupSlug: string): NutritionNav {
       // address should not depend on which.
       search: { date, meal, ...(foodId ? { food: foodId } : {}) },
     }),
+    foods: foods.list,
+    combos: groupLink('combos', groupSlug),
+    diary: groupLink('nutrition', groupSlug),
   }
 }

--- a/src/lib/groupPaths.test.ts
+++ b/src/lib/groupPaths.test.ts
@@ -48,6 +48,15 @@ describe('building a Group URL', () => {
     )
   })
 
+  // Both destinations Nutrition points at are Group-scoped addresses holding
+  // content that is not the Group's: the Catalog belongs to nobody and a Combo
+  // belongs to a person. The slug rides along so following the link cannot
+  // move anybody between Groups (ADR-0002).
+  test('gives the Combos library and the Catalog addresses inside the Group', () => {
+    expect(groupHref('combos', 'me-alice')).toBe('/g/me-alice/combos')
+    expect(groupHref('foods', 'me-alice')).toBe('/g/me-alice/foods')
+  })
+
   test('escapes every param on its way into a string path', () => {
     expect(groupHref('nutrition', 'a b')).toBe('/g/a%20b/nutrition')
     expect(groupHref('recipe', 'a b', { recipeId: 'r 1' })).toBe(

--- a/src/lib/groupPaths.ts
+++ b/src/lib/groupPaths.ts
@@ -42,6 +42,12 @@ const GROUP_ROUTES = {
   // gesture closes it and a reload does not lose it. Which day and which meal
   // ride in the search, not the path — they are what is being added *to*.
   addFood: `${GROUP_PREFIX}/nutrition/add`,
+  // The Combos library. A sibling of the diary rather than a page beneath it:
+  // `/nutrition` is a layout that renders the diary itself so the add sheet can
+  // sit over a page that never went away, and a library nested under it would
+  // open below the whole day. Foods is next to Nutrition for the same reason
+  // and reached from the same place, so the two match.
+  combos: `${GROUP_PREFIX}/combos`,
 
   recipes: `${GROUP_PREFIX}/recipes`,
   newRecipe: `${GROUP_PREFIX}/recipes/new`,
@@ -135,6 +141,7 @@ const GROUP_MODULE_INDEXES = [
   'all',
   'settings',
   'nutrition',
+  'combos',
   'recipes',
   'foods',
   'baby',

--- a/src/lib/i18n/messages/en/nutrition.ts
+++ b/src/lib/i18n/messages/en/nutrition.ts
@@ -43,6 +43,17 @@ export const diary = {
     over: '{amount} over',
   },
 
+  /**
+   * The two libraries the diary points at (#100). Both were reachable only by
+   * typing their address before, which made the Catalog feel like a place the
+   * app did not have and Combos like something only the add sheet knew about.
+   */
+  libraries: {
+    heading: 'Libraries',
+    foods: 'Foods',
+    combos: 'Combos',
+  },
+
   slot: {
     add: '+ Add',
     empty: 'Nothing logged yet.',
@@ -143,4 +154,21 @@ export const diary = {
   },
 }
 
-export const nutrition = { meals, units, diary }
+/**
+ * The Combos library: somewhere to see what you have saved (#100).
+ *
+ * Browsing only. There is no builder to open here and there never will be — a
+ * Combo is made by saving a meal slot you have already filled in, and that is
+ * what the empty state says rather than offering a button that cannot exist
+ * (ADR-0012). The words for what is *inside* a Combo are `diary.combos`, which
+ * the add sheet uses too.
+ */
+export const combosLibrary = {
+  title: 'Combos',
+  back: 'Back to the diary',
+  empty: 'No combos yet.',
+  emptyHow:
+    'A combo is made out of a meal you have already filled in: open a day in the diary, fill in a meal, then use “Save as combo” on it. There is no separate builder to keep.',
+}
+
+export const nutrition = { meals, units, diary, combosLibrary }

--- a/src/lib/i18n/messages/nl/nutrition.ts
+++ b/src/lib/i18n/messages/nl/nutrition.ts
@@ -1,4 +1,5 @@
 import type {
+  combosLibrary as enCombosLibrary,
   diary as enDiary,
   meals as enMeals,
   nutrition as enNutrition,
@@ -32,6 +33,12 @@ export const diary = {
     edit: 'Doelen aanpassen',
     remaining: 'nog {amount}',
     over: '{amount} te veel',
+  },
+
+  libraries: {
+    heading: 'Bibliotheken',
+    foods: 'Voedingsmiddelen',
+    combos: 'Combinaties',
   },
 
   slot: {
@@ -118,4 +125,17 @@ export const diary = {
   },
 } satisfies typeof enDiary
 
-export const nutrition = { meals, units, diary } satisfies typeof enNutrition
+export const combosLibrary = {
+  title: 'Combinaties',
+  back: 'Terug naar het dagboek',
+  empty: 'Nog geen combinaties.',
+  emptyHow:
+    'Een combinatie maak je van een maaltijd die je al hebt ingevuld: open een dag in het dagboek, vul een maaltijd in en kies daar “Opslaan als combinatie”. Er is geen aparte bouwer om bij te houden.',
+} satisfies typeof enCombosLibrary
+
+export const nutrition = {
+  meals,
+  units,
+  diary,
+  combosLibrary,
+} satisfies typeof enNutrition

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as AppGGroupSlugAllRouteImport } from './routes/_app/g/$groupSlug
 import { Route as AppGGroupSlugBillsRouteImport } from './routes/_app/g/$groupSlug/bills'
 import { Route as AppGGroupSlugCalendarRouteImport } from './routes/_app/g/$groupSlug/calendar'
 import { Route as AppGGroupSlugCheesesRouteImport } from './routes/_app/g/$groupSlug/cheeses'
+import { Route as AppGGroupSlugCombosRouteImport } from './routes/_app/g/$groupSlug/combos'
 import { Route as AppGGroupSlugFinancesRouteImport } from './routes/_app/g/$groupSlug/finances'
 import { Route as AppGGroupSlugGroceriesRouteImport } from './routes/_app/g/$groupSlug/groceries'
 import { Route as AppGGroupSlugMealPlannerRouteImport } from './routes/_app/g/$groupSlug/meal-planner'
@@ -132,6 +133,11 @@ const AppGGroupSlugCalendarRoute = AppGGroupSlugCalendarRouteImport.update({
 const AppGGroupSlugCheesesRoute = AppGGroupSlugCheesesRouteImport.update({
   id: '/cheeses',
   path: '/cheeses',
+  getParentRoute: () => AppGGroupSlugRoute,
+} as any)
+const AppGGroupSlugCombosRoute = AppGGroupSlugCombosRouteImport.update({
+  id: '/combos',
+  path: '/combos',
   getParentRoute: () => AppGGroupSlugRoute,
 } as any)
 const AppGGroupSlugFinancesRoute = AppGGroupSlugFinancesRouteImport.update({
@@ -276,6 +282,7 @@ export interface FileRoutesByFullPath {
   '/g/$groupSlug/bills': typeof AppGGroupSlugBillsRoute
   '/g/$groupSlug/calendar': typeof AppGGroupSlugCalendarRoute
   '/g/$groupSlug/cheeses': typeof AppGGroupSlugCheesesRoute
+  '/g/$groupSlug/combos': typeof AppGGroupSlugCombosRoute
   '/g/$groupSlug/finances': typeof AppGGroupSlugFinancesRoute
   '/g/$groupSlug/groceries': typeof AppGGroupSlugGroceriesRoute
   '/g/$groupSlug/meal-planner': typeof AppGGroupSlugMealPlannerRoute
@@ -316,6 +323,7 @@ export interface FileRoutesByTo {
   '/g/$groupSlug/bills': typeof AppGGroupSlugBillsRoute
   '/g/$groupSlug/calendar': typeof AppGGroupSlugCalendarRoute
   '/g/$groupSlug/cheeses': typeof AppGGroupSlugCheesesRoute
+  '/g/$groupSlug/combos': typeof AppGGroupSlugCombosRoute
   '/g/$groupSlug/finances': typeof AppGGroupSlugFinancesRoute
   '/g/$groupSlug/groceries': typeof AppGGroupSlugGroceriesRoute
   '/g/$groupSlug/meal-planner': typeof AppGGroupSlugMealPlannerRoute
@@ -358,6 +366,7 @@ export interface FileRoutesById {
   '/_app/g/$groupSlug/bills': typeof AppGGroupSlugBillsRoute
   '/_app/g/$groupSlug/calendar': typeof AppGGroupSlugCalendarRoute
   '/_app/g/$groupSlug/cheeses': typeof AppGGroupSlugCheesesRoute
+  '/_app/g/$groupSlug/combos': typeof AppGGroupSlugCombosRoute
   '/_app/g/$groupSlug/finances': typeof AppGGroupSlugFinancesRoute
   '/_app/g/$groupSlug/groceries': typeof AppGGroupSlugGroceriesRoute
   '/_app/g/$groupSlug/meal-planner': typeof AppGGroupSlugMealPlannerRoute
@@ -401,6 +410,7 @@ export interface FileRouteTypes {
     | '/g/$groupSlug/bills'
     | '/g/$groupSlug/calendar'
     | '/g/$groupSlug/cheeses'
+    | '/g/$groupSlug/combos'
     | '/g/$groupSlug/finances'
     | '/g/$groupSlug/groceries'
     | '/g/$groupSlug/meal-planner'
@@ -441,6 +451,7 @@ export interface FileRouteTypes {
     | '/g/$groupSlug/bills'
     | '/g/$groupSlug/calendar'
     | '/g/$groupSlug/cheeses'
+    | '/g/$groupSlug/combos'
     | '/g/$groupSlug/finances'
     | '/g/$groupSlug/groceries'
     | '/g/$groupSlug/meal-planner'
@@ -482,6 +493,7 @@ export interface FileRouteTypes {
     | '/_app/g/$groupSlug/bills'
     | '/_app/g/$groupSlug/calendar'
     | '/_app/g/$groupSlug/cheeses'
+    | '/_app/g/$groupSlug/combos'
     | '/_app/g/$groupSlug/finances'
     | '/_app/g/$groupSlug/groceries'
     | '/_app/g/$groupSlug/meal-planner'
@@ -635,6 +647,13 @@ declare module '@tanstack/react-router' {
       path: '/cheeses'
       fullPath: '/g/$groupSlug/cheeses'
       preLoaderRoute: typeof AppGGroupSlugCheesesRouteImport
+      parentRoute: typeof AppGGroupSlugRoute
+    }
+    '/_app/g/$groupSlug/combos': {
+      id: '/_app/g/$groupSlug/combos'
+      path: '/combos'
+      fullPath: '/g/$groupSlug/combos'
+      preLoaderRoute: typeof AppGGroupSlugCombosRouteImport
       parentRoute: typeof AppGGroupSlugRoute
     }
     '/_app/g/$groupSlug/finances': {
@@ -822,6 +841,7 @@ interface AppGGroupSlugRouteChildren {
   AppGGroupSlugBillsRoute: typeof AppGGroupSlugBillsRoute
   AppGGroupSlugCalendarRoute: typeof AppGGroupSlugCalendarRoute
   AppGGroupSlugCheesesRoute: typeof AppGGroupSlugCheesesRoute
+  AppGGroupSlugCombosRoute: typeof AppGGroupSlugCombosRoute
   AppGGroupSlugFinancesRoute: typeof AppGGroupSlugFinancesRoute
   AppGGroupSlugGroceriesRoute: typeof AppGGroupSlugGroceriesRoute
   AppGGroupSlugMealPlannerRoute: typeof AppGGroupSlugMealPlannerRoute
@@ -851,6 +871,7 @@ const AppGGroupSlugRouteChildren: AppGGroupSlugRouteChildren = {
   AppGGroupSlugBillsRoute: AppGGroupSlugBillsRoute,
   AppGGroupSlugCalendarRoute: AppGGroupSlugCalendarRoute,
   AppGGroupSlugCheesesRoute: AppGGroupSlugCheesesRoute,
+  AppGGroupSlugCombosRoute: AppGGroupSlugCombosRoute,
   AppGGroupSlugFinancesRoute: AppGGroupSlugFinancesRoute,
   AppGGroupSlugGroceriesRoute: AppGGroupSlugGroceriesRoute,
   AppGGroupSlugMealPlannerRoute: AppGGroupSlugMealPlannerRoute,

--- a/src/routes/_app/g/$groupSlug/combos.tsx
+++ b/src/routes/_app/g/$groupSlug/combos.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { CombosPage } from '../../../../components/nutrition/CombosPage'
+import { groupNutritionNav } from '../../../../components/nutrition/nutritionNav'
+
+/**
+ * The Combos library inside a Group.
+ *
+ * A Combo is Personal (ADR-0012) — it belongs to a person and to no Group — so
+ * this shows the same combos whichever Group is in the URL, exactly as the
+ * diary next to it does. The segment is here for the same reason Nutrition's
+ * is: it governs navigation, not ownership (ADR-0002), and it is what keeps
+ * whoever follows a link inside the Group they were reading.
+ *
+ * A sibling of `/nutrition` rather than a page beneath it: that route is a
+ * layout rendering the diary itself, so the add sheet can sit over a page that
+ * never went away, and a library nested under it would open below the whole
+ * day.
+ */
+export const Route = createFileRoute('/_app/g/$groupSlug/combos')({
+  component: GroupCombos,
+})
+
+function GroupCombos() {
+  const { groupSlug } = Route.useParams()
+
+  return <CombosPage nav={groupNutritionNav(groupSlug)} />
+}


### PR DESCRIPTION
Closes #100

## What changed

The Nutrition diary gains a labelled `<nav>` with two destinations: the existing Foods catalog, and a new personal Combos library at **`/g/$groupSlug/combos`**.

## Why a sibling of `/nutrition`, not a child

`/g/$groupSlug/nutrition.tsx` is a layout that renders the diary itself, so the add sheet at `/nutrition/add` sits over a page that never unmounts. A library nested under it would have rendered below the entire day view. Foods already sits beside Nutrition for exactly this reason and is reached from the same place, so the two now match.

## Acceptance criteria

- **Foods reachable from Nutrition** — asserted at `href="/g/jansen-household/foods"`.
- **Combos library reachable** — asserted at `/g/jansen-household/combos`.
- **Group context preserved** — tested with two different slugs; the link is built through `groupLink`, so the router typechecks the destination (ADR-0002).
- **Only the signed-in person's combos** — `combos.list` resolves the caller server-side and takes no Group argument (ADR-0012); the test asserts the query is called as `['combos:list', {}]`. There is no Group argument to pass, which is what makes this true by construction.
- **Useful empty state** — says there are none *and* how one is made ("fill in a meal, then Save as combo — there is no separate builder"), with a Group-preserving link back to the diary.
- **Survives a full-page reload** — a real file-based route in `routeTree.gen.ts`, not a modal or client-only state. `groupPaths.segments.test.ts` independently asserts a route file exists on disk for every surface.
- **Mobile** — the links live in the page body (`flex flex-wrap`, `min-h-11` touch targets), not in the sidebar or the 5-slot dock, so no dock slot has to be fought for and a phone reaches them identically to a desktop.
- **Add sheet unchanged** — `AddSheet.tsx` is untouched and its suite still passes.

## No Module registered — deliberate

A Combo is **Personal** (ADR-0012) and Foods is **Catalog**; neither is a Module, so neither gets a registry entry, a sidebar row or an All-modules tile, and `MODULES` / `MODULE_INDEX_SURFACES` are unchanged. CLAUDE.md's "add its seed contribution in the same change" rule is therefore not triggered. (`convex/lib/seed/apply.ts` already seeds `SAMPLE_COMBOS`, so previews show a populated library rather than the empty state.)

## Reviewer notes

**`RESERVED_SLUGS` gains `'combos'`**, following the `'foods'` precedent immediately above it: a Group-level route with no Module to claim the segment on its behalf, held here instead. This narrows the set of legal Group slugs. A Group that already holds the slug `combos` would now be shadowed by the route — the same theoretical exposure that adding `'foods'` carried, which shipped without a migration doc. Flagging it rather than assuming; low risk, worth a maintainer's eye.

**`routeTree.gen.ts` was produced by the `tanstackStart()` Vite plugin during `pnpm build`, not by `tsr generate`.** The two disagree, and I verified the disagreement is **pre-existing on `main`**, not caused by this change: running `pnpm generate-routes` on a branch that touches no route files at all produces the same ~600-line reordering. The new combos route survives `tsr generate` intact (13 occurrences before and after), so nothing is being dropped either way. The committed file is what `pnpm build` reproduces byte-for-byte — the tree is clean after a build — so CI will not churn. The CLI/plugin version skew is worth a separate look and is out of scope here.

**Topbar context** — `/g/<slug>/combos` shows the fallback topbar title, because `getRouteContext` only knows Module segments plus home/all/group-settings. `/g/<slug>/foods` has always behaved the same way, so the new page is consistent with the existing one rather than newly wrong. Teaching `navTargetOf` about non-Module surfaces would widen this diff well past the issue and may overlap #101.

## Checks

| Command | Result |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm test` | pass — 101 files, 1116 tests |
| `pnpm check` | pass — Biome, 264 files |
| `pnpm build` | pass, idempotent (tree clean afterwards) |

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRV76A3rBXyEZppMPQMGHE)_