### PR TITLE
feat(nutrition): rename and delete a Combo from the library

### DIFF
--- a/convex/combos.test.ts
+++ b/convex/combos.test.ts
@@ -223,6 +223,16 @@ describe('a Combo is one person’s', () => {
     expect(await t.query(api.combos.list, {})).toEqual([])
   })
 
+  test('nobody else can delete it', async () => {
+    const { t, comboId } = await saveBreakfast()
+    await expect(
+      t.withIdentity(asBob).mutation(api.combos.remove, { id: comboId }),
+    ).rejects.toThrow()
+    expect(
+      await t.withIdentity(asAlice).query(api.combos.list, {}),
+    ).toHaveLength(1)
+  })
+
   test('reads identically however many Groups the person is in', async () => {
     const { t } = await saveBreakfast()
     const before = await t.withIdentity(asAlice).query(api.combos.list, {})
@@ -414,5 +424,103 @@ describe('logging a Combo', () => {
       (c) => c.label === 'Stroopwafel from the market',
     )
     expect(rebuilt?.icon).toBe('🍪')
+  })
+})
+
+/**
+ * Renaming and deleting from the library (#129).
+ *
+ * A Combo is a shortcut for what will happen; the diary is the record of what
+ * did. So neither of these may reach into the diary — which is the thing
+ * somebody would reasonably fear when pressing Delete.
+ */
+describe('keeping the library tidy', () => {
+  test('renaming changes what the library and the add sheet find', async () => {
+    const { t, comboId } = await saveBreakfast()
+
+    await t
+      .withIdentity(asAlice)
+      .mutation(api.combos.rename, { id: comboId, name: 'Weekday breakfast' })
+
+    const [combo] = await t.withIdentity(asAlice).query(api.combos.list, {})
+    expect(combo.name).toBe('Weekday breakfast')
+  })
+
+  test('a name of nothing but spaces is refused', async () => {
+    const { t, comboId } = await saveBreakfast()
+
+    await expect(
+      t.withIdentity(asAlice).mutation(api.combos.rename, {
+        id: comboId,
+        name: '   ',
+      }),
+    ).rejects.toThrow()
+
+    const [combo] = await t.withIdentity(asAlice).query(api.combos.list, {})
+    expect(combo.name).toBe('Usual breakfast')
+  })
+
+  test('deleting takes the components with it, leaving no orphans', async () => {
+    const { t, comboId } = await saveBreakfast()
+    expect(
+      await t.run(async (ctx) => ctx.db.query('comboItems').collect()),
+    ).not.toHaveLength(0)
+
+    await t.withIdentity(asAlice).mutation(api.combos.remove, { id: comboId })
+
+    expect(await t.withIdentity(asAlice).query(api.combos.list, {})).toEqual([])
+    expect(
+      await t.run(async (ctx) => ctx.db.query('comboItems').collect()),
+    ).toEqual([])
+  })
+
+  test('deleting leaves the diary exactly as it was', async () => {
+    const { t, comboId } = await saveBreakfast()
+    const before = await t
+      .withIdentity(asAlice)
+      .query(api.consumption.listForDay, { date: DAY })
+    expect(before).not.toHaveLength(0)
+
+    await t.withIdentity(asAlice).mutation(api.combos.remove, { id: comboId })
+
+    // What was logged happened. Losing the shortcut does not unhappen it.
+    expect(
+      await t.withIdentity(asAlice).query(api.consumption.listForDay, {
+        date: DAY,
+      }),
+    ).toEqual(before)
+  })
+
+  test('renaming leaves the diary exactly as it was', async () => {
+    const { t, comboId } = await saveBreakfast()
+    const before = await t
+      .withIdentity(asAlice)
+      .query(api.consumption.listForDay, { date: DAY })
+
+    await t
+      .withIdentity(asAlice)
+      .mutation(api.combos.rename, { id: comboId, name: 'Something else' })
+
+    expect(
+      await t.withIdentity(asAlice).query(api.consumption.listForDay, {
+        date: DAY,
+      }),
+    ).toEqual(before)
+  })
+
+  test('a Combo that is not yours refuses the same way one that does not exist does', async () => {
+    const { t, comboId } = await saveBreakfast()
+    await t.withIdentity(asAlice).mutation(api.combos.remove, { id: comboId })
+
+    // Gone now, so this is the "no such combo" case; Bob's attempt above is
+    // the "not yours" one. Neither wording may tell them apart (ADR-0009).
+    await expect(
+      t.withIdentity(asAlice).mutation(api.combos.remove, { id: comboId }),
+    ).rejects.toThrow('Combo not found')
+    await expect(
+      t
+        .withIdentity(asBob)
+        .mutation(api.combos.remove, { id: comboId }),
+    ).rejects.toThrow('Combo not found')
   })
 })

--- a/src/components/nutrition/ComboActions.test.tsx
+++ b/src/components/nutrition/ComboActions.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { renderWithI18n } from '../../lib/i18n/testing'
+import { ComboActions } from './ComboActions'
+
+/**
+ * Renaming and deleting one saved Combo (#129). The card asks for the one
+ * thing it needs and gets out of the way; deleting asks first, because there
+ * is no undo.
+ */
+
+test('renaming starts from the name it already has', () => {
+  renderWithI18n(
+    <ComboActions
+      name="Usual breakfast"
+      onRename={vi.fn()}
+      onDelete={vi.fn()}
+    />,
+  )
+
+  // Both buttons name the combo they act on, so a screen reader hears which
+  // one it is rather than a row of identical "Rename"s.
+  expect(
+    screen.getByRole('button', { name: 'New name for “Usual breakfast”' }),
+  ).toBeDefined()
+  expect(
+    screen.getByRole('button', { name: 'Delete “Usual breakfast”' }),
+  ).toBeDefined()
+
+  fireEvent.click(screen.getByText('Rename'))
+  // Editing a name is usually a correction, not a retype.
+  expect(screen.getByDisplayValue('Usual breakfast')).toBeDefined()
+})
+
+test('a renamed combo is saved trimmed', async () => {
+  const onRename = vi.fn().mockResolvedValue(undefined)
+  renderWithI18n(
+    <ComboActions
+      name="Usual breakfast"
+      onRename={onRename}
+      onDelete={vi.fn()}
+    />,
+  )
+
+  fireEvent.click(screen.getByText('Rename'))
+  fireEvent.change(screen.getByDisplayValue('Usual breakfast'), {
+    target: { value: '  Weekday breakfast  ' },
+  })
+  fireEvent.click(screen.getByText('Save'))
+
+  await waitFor(() =>
+    expect(onRename).toHaveBeenCalledWith('Weekday breakfast'),
+  )
+})
+
+test('an empty name cannot be saved', () => {
+  const onRename = vi.fn()
+  renderWithI18n(
+    <ComboActions
+      name="Usual breakfast"
+      onRename={onRename}
+      onDelete={vi.fn()}
+    />,
+  )
+
+  fireEvent.click(screen.getByText('Rename'))
+  fireEvent.change(screen.getByDisplayValue('Usual breakfast'), {
+    target: { value: '   ' },
+  })
+  fireEvent.click(screen.getByText('Save'))
+
+  // Caught here rather than by the server, whose refusal would arrive in
+  // English whatever the reader's language.
+  expect(onRename).not.toHaveBeenCalled()
+})
+
+test('cancelling a rename keeps the old name', () => {
+  const onRename = vi.fn()
+  renderWithI18n(
+    <ComboActions
+      name="Usual breakfast"
+      onRename={onRename}
+      onDelete={vi.fn()}
+    />,
+  )
+
+  fireEvent.click(screen.getByText('Rename'))
+  fireEvent.change(screen.getByDisplayValue('Usual breakfast'), {
+    target: { value: 'Something else' },
+  })
+  fireEvent.click(screen.getByText('Cancel'))
+
+  expect(onRename).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByText('Rename'))
+  expect(screen.getByDisplayValue('Usual breakfast')).toBeDefined()
+})
+
+test('deleting asks first, and says the diary is safe', () => {
+  const onDelete = vi.fn()
+  renderWithI18n(
+    <ComboActions
+      name="Usual breakfast"
+      onRename={vi.fn()}
+      onDelete={onDelete}
+    />,
+  )
+
+  fireEvent.click(screen.getByText('Delete'))
+
+  expect(screen.getByText('Delete “Usual breakfast”?')).toBeDefined()
+  expect(
+    screen.getByText('What you have already logged stays in your diary.'),
+  ).toBeDefined()
+  expect(onDelete).not.toHaveBeenCalled()
+})
+
+test('confirming deletes, cancelling does not', async () => {
+  const onDelete = vi.fn().mockResolvedValue(undefined)
+  renderWithI18n(
+    <ComboActions
+      name="Usual breakfast"
+      onRename={vi.fn()}
+      onDelete={onDelete}
+    />,
+  )
+
+  fireEvent.click(screen.getByText('Delete'))
+  fireEvent.click(screen.getByText('Cancel'))
+  expect(onDelete).not.toHaveBeenCalled()
+
+  fireEvent.click(screen.getByText('Delete'))
+  // The confirmation's own Delete, which is the second one on screen.
+  fireEvent.click(screen.getAllByText('Delete').at(-1) as HTMLElement)
+  await waitFor(() => expect(onDelete).toHaveBeenCalledTimes(1))
+})
+
+test('a refusal is shown in the reader’s language, not the server’s', async () => {
+  renderWithI18n(
+    <ComboActions
+      name="Usual breakfast"
+      onRename={vi.fn().mockRejectedValue(new Error('Combo not found'))}
+      onDelete={vi.fn()}
+    />,
+  )
+
+  fireEvent.click(screen.getByText('Rename'))
+  fireEvent.change(screen.getByDisplayValue('Usual breakfast'), {
+    target: { value: 'Weekday breakfast' },
+  })
+  fireEvent.click(screen.getByText('Save'))
+
+  await waitFor(() =>
+    expect(screen.getByText('Could not rename this combo')).toBeDefined(),
+  )
+  expect(screen.queryByText('Combo not found')).toBeNull()
+})

--- a/src/components/nutrition/ComboActions.test.tsx
+++ b/src/components/nutrition/ComboActions.test.tsx
@@ -154,3 +154,64 @@ test('a refusal is shown in the reader’s language, not the server’s', async 
   )
   expect(screen.queryByText('Combo not found')).toBeNull()
 })
+
+/**
+ * Cancel must not look like it stopped something it cannot stop. Once the
+ * write has left, calling it back is not on offer — and putting the controls
+ * away would invite a rename on a row that is already disappearing.
+ */
+test('cancelling is not offered while a delete is in flight', async () => {
+  let finish!: () => void
+  const onDelete = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        finish = resolve
+      }),
+  )
+  renderWithI18n(
+    <ComboActions
+      name="Usual breakfast"
+      onRename={vi.fn()}
+      onDelete={onDelete}
+    />,
+  )
+
+  fireEvent.click(screen.getByText('Delete'))
+  fireEvent.click(screen.getAllByText('Delete').at(-1) as HTMLElement)
+
+  await waitFor(() => expect(screen.getByText('Cancel')).toBeDisabled())
+  fireEvent.click(screen.getByText('Cancel'))
+  // Still the confirmation, not the buttons it would have gone back to.
+  expect(screen.getByText('Delete “Usual breakfast”?')).toBeDefined()
+
+  finish()
+})
+
+test('cancelling is not offered while a rename is in flight', async () => {
+  let finish!: () => void
+  const onRename = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        finish = resolve
+      }),
+  )
+  renderWithI18n(
+    <ComboActions
+      name="Usual breakfast"
+      onRename={onRename}
+      onDelete={vi.fn()}
+    />,
+  )
+
+  fireEvent.click(screen.getByText('Rename'))
+  fireEvent.change(screen.getByDisplayValue('Usual breakfast'), {
+    target: { value: 'Weekday breakfast' },
+  })
+  fireEvent.click(screen.getByText('Save'))
+
+  await waitFor(() => expect(screen.getByText('Cancel')).toBeDisabled())
+  fireEvent.click(screen.getByText('Cancel'))
+  expect(screen.getByDisplayValue('Weekday breakfast')).toBeDefined()
+
+  finish()
+})

--- a/src/components/nutrition/ComboActions.tsx
+++ b/src/components/nutrition/ComboActions.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react'
+import { fmt, useMessages } from '../../lib/i18n'
+
+interface Props {
+  name: string
+  onRename: (name: string) => Promise<void>
+  onDelete: () => Promise<void>
+}
+
+/**
+ * Renaming and deleting one saved Combo (#129).
+ *
+ * Both are the person's own doing on their own row, so the controls live on
+ * the card rather than behind a menu. Only one of the three states is on show
+ * at a time — the buttons, the rename field, or the delete confirmation —
+ * because they occupy the same corner and a card showing two of them at once
+ * would be asking two questions.
+ *
+ * Neither action touches the diary. A Combo is a shortcut for what will
+ * happen; the entries it has already written are records of what did, and
+ * they keep the name they were logged under (ADR-0003, #99). That is worth
+ * saying out loud at the point of deleting, so it is.
+ *
+ * A refusal from the server is never shown verbatim. These mutations answer
+ * in English sentences, and the person reading may not be — so the form
+ * validates the one case it can (an empty name) and anything else resolves to
+ * a message from the tree (ADR-0011).
+ */
+export function ComboActions({ name, onRename, onDelete }: Props) {
+  const messages = useMessages()
+  const library = messages.nutrition.combosLibrary
+  const [mode, setMode] = useState<'idle' | 'renaming' | 'confirming'>('idle')
+  const [draft, setDraft] = useState(name)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function idle() {
+    setMode('idle')
+    setError(null)
+  }
+
+  if (mode === 'renaming') {
+    return (
+      <form
+        className="mt-2 flex flex-wrap items-center gap-2"
+        onSubmit={async (e) => {
+          e.preventDefault()
+          const next = draft.trim()
+          // The server refuses an empty name too; catching it here is what
+          // keeps that refusal off a screen it would arrive on in English.
+          if (!next || busy) return
+          setBusy(true)
+          setError(null)
+          try {
+            await onRename(next)
+            idle()
+          } catch {
+            setError(library.renameFailed)
+          } finally {
+            setBusy(false)
+          }
+        }}
+      >
+        <input
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          aria-label={fmt(library.renameLabel, { name })}
+          className="min-h-11 min-w-0 flex-1 rounded-[var(--app-radius)] border border-[var(--app-border)] bg-[var(--app-surface)] px-3 text-[16px]"
+        />
+        <button
+          type="submit"
+          disabled={busy || !draft.trim()}
+          className="min-h-11 rounded-[var(--app-radius)] border border-[var(--app-fg)] bg-[var(--app-fg)] px-3 text-sm font-semibold text-[var(--app-surface)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {messages.common.actions.save}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setDraft(name)
+            idle()
+          }}
+          className="min-h-11 text-sm underline"
+        >
+          {messages.common.actions.cancel}
+        </button>
+        {error && <p className="w-full text-xs text-red-700">{error}</p>}
+      </form>
+    )
+  }
+
+  if (mode === 'confirming') {
+    return (
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <p className="w-full text-sm">
+          {fmt(library.deleteConfirm, { name })}{' '}
+          <span className="opacity-70">{library.deleteKeepsDiary}</span>
+        </p>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={async () => {
+            setBusy(true)
+            setError(null)
+            try {
+              await onDelete()
+              // No idle() on success: the row this lives on is gone.
+            } catch {
+              setError(library.deleteFailed)
+              setBusy(false)
+            }
+          }}
+          className="min-h-11 rounded-[var(--app-radius)] border border-red-700 bg-red-700 px-3 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {messages.common.actions.delete}
+        </button>
+        <button
+          type="button"
+          onClick={idle}
+          className="min-h-11 text-sm underline"
+        >
+          {messages.common.actions.cancel}
+        </button>
+        {error && <p className="w-full text-xs text-red-700">{error}</p>}
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-2 flex items-center gap-3">
+      <button
+        type="button"
+        onClick={() => {
+          setDraft(name)
+          setMode('renaming')
+        }}
+        aria-label={fmt(library.renameLabel, { name })}
+        className="inline-flex min-h-11 items-center text-sm underline"
+      >
+        {library.rename}
+      </button>
+      <button
+        type="button"
+        onClick={() => setMode('confirming')}
+        aria-label={fmt(library.deleteLabel, { name })}
+        className="inline-flex min-h-11 items-center text-sm text-red-700 underline"
+      >
+        {library.delete}
+      </button>
+    </div>
+  )
+}

--- a/src/components/nutrition/ComboActions.tsx
+++ b/src/components/nutrition/ComboActions.tsx
@@ -77,11 +77,15 @@ export function ComboActions({ name, onRename, onDelete }: Props) {
         </button>
         <button
           type="button"
+          // Nothing to cancel once the write has left: putting the form away
+          // would look like it stopped something it cannot stop, and leave the
+          // card offering a rename on a row that is already changing.
+          disabled={busy}
           onClick={() => {
             setDraft(name)
             idle()
           }}
-          className="min-h-11 text-sm underline"
+          className="min-h-11 text-sm underline disabled:opacity-60"
         >
           {messages.common.actions.cancel}
         </button>
@@ -117,8 +121,11 @@ export function ComboActions({ name, onRename, onDelete }: Props) {
         </button>
         <button
           type="button"
+          // Same reason as the rename form's: a delete already on its way
+          // cannot be called back, so Cancel must not pretend otherwise.
+          disabled={busy}
           onClick={idle}
-          className="min-h-11 text-sm underline"
+          className="min-h-11 text-sm underline disabled:opacity-60"
         >
           {messages.common.actions.cancel}
         </button>

--- a/src/components/nutrition/CombosPage.test.tsx
+++ b/src/components/nutrition/CombosPage.test.tsx
@@ -22,10 +22,20 @@ vi.mock('convex/react', () => ({
     queried.value.push([name, args])
     return combos.value
   },
+  // Renaming and deleting live on the card (#129). What they do is covered in
+  // `ComboActions.test.tsx` and, against the real mutations, in
+  // `convex/combos.test.ts`; here they only have to exist.
+  useMutation: () => vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('../../../convex/_generated/api', () => ({
-  api: { combos: { list: 'combos:list' } },
+  api: {
+    combos: {
+      list: 'combos:list',
+      rename: 'combos:rename',
+      remove: 'combos:remove',
+    },
+  },
 }))
 
 vi.mock('@tanstack/react-router', () => ({

--- a/src/components/nutrition/CombosPage.tsx
+++ b/src/components/nutrition/CombosPage.tsx
@@ -1,9 +1,11 @@
 import { Link } from '@tanstack/react-router'
-import { useQuery } from 'convex/react'
+import { useMutation, useQuery } from 'convex/react'
 import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
 import { comboEntries } from '../../../convex/lib/combos'
 import { sumFacts } from '../../../convex/lib/consumption'
 import { fmt, plural, useI18n } from '../../lib/i18n'
+import { ComboActions } from './ComboActions'
 import type { NutritionNav } from './nutritionNav'
 
 /**
@@ -24,6 +26,10 @@ export function CombosPage({ nav }: { nav: NutritionNav }) {
   const library = messages.nutrition.combosLibrary
   const { combos: comboWords, personalNote } = messages.nutrition.diary
   const combos = useQuery(api.combos.list, {})
+  // Both already resolve the caller and read only their own rows — a Combo is
+  // Personal, so there is no Group argument to pass and none to get wrong.
+  const rename = useMutation(api.combos.rename)
+  const remove = useMutation(api.combos.remove)
 
   return (
     <div className="mx-auto max-w-2xl">
@@ -96,6 +102,15 @@ export function CombosPage({ nav }: { nav: NutritionNav }) {
                   </li>
                 ))}
               </ul>
+              <ComboActions
+                name={combo.name}
+                onRename={async (name) => {
+                  await rename({ id: combo._id as Id<'combos'>, name })
+                }}
+                onDelete={async () => {
+                  await remove({ id: combo._id as Id<'combos'> })
+                }}
+              />
             </li>
           )
         })}

--- a/src/lib/i18n/messages/en/nutrition.ts
+++ b/src/lib/i18n/messages/en/nutrition.ts
@@ -175,6 +175,24 @@ export const combosLibrary = {
   empty: 'No combos yet.',
   emptyHow:
     'A combo is made out of a meal you have already filled in: open a day in the diary, fill in a meal, then use “Save as combo” on it. There is no separate builder to keep.',
+  /**
+   * Renaming and deleting (#129). A Combo's name is something a person typed
+   * — content, never translated — so it arrives as `{name}` and these are
+   * only the sentences around it.
+   */
+  rename: 'Rename',
+  renameLabel: 'New name for “{name}”',
+  renameFailed: 'Could not rename this combo',
+  delete: 'Delete',
+  deleteLabel: 'Delete “{name}”',
+  /** Replaces the buttons once Delete is pressed. There is no undo. */
+  deleteConfirm: 'Delete “{name}”?',
+  /**
+   * Said where the deleting is confirmed, because it is the one thing
+   * somebody might reasonably fear losing by pressing it.
+   */
+  deleteKeepsDiary: 'What you have already logged stays in your diary.',
+  deleteFailed: 'Could not delete this combo',
 }
 
 export const nutrition = { meals, units, diary, combosLibrary }

--- a/src/lib/i18n/messages/nl/nutrition.ts
+++ b/src/lib/i18n/messages/nl/nutrition.ts
@@ -139,6 +139,14 @@ export const combosLibrary = {
   empty: 'Nog geen combinaties.',
   emptyHow:
     'Een combinatie maak je van een maaltijd die je al hebt ingevuld: open een dag in het dagboek, vul een maaltijd in en kies daar “Opslaan als combinatie”. Er is geen aparte bouwer om bij te houden.',
+  rename: 'Hernoemen',
+  renameLabel: 'Nieuwe naam voor “{name}”',
+  renameFailed: 'Kon deze combinatie niet hernoemen',
+  delete: 'Verwijderen',
+  deleteLabel: '“{name}” verwijderen',
+  deleteConfirm: '“{name}” verwijderen?',
+  deleteKeepsDiary: 'Wat je al hebt genoteerd blijft in je dagboek staan.',
+  deleteFailed: 'Kon deze combinatie niet verwijderen',
 } satisfies typeof enCombosLibrary
 
 export const nutrition = {


### PR DESCRIPTION
Closes #129

> **Now targets `main`.** This was opened stacked on #124 because the Combos library page it adds controls to did not exist on `main` yet. #124 has merged, and this has been reopened and retargeted — the branch and its commits are unchanged, and it merges cleanly against `main`.
>
> *(For the record: I said GitHub would retarget this automatically when #124 merged. It does not. Deleting a base branch **closes** the PRs pointing at it. Reopening needed the base branch restored first, then a retarget, then removing it again.)*

Asked for in review on #124 — *"cant i edit combis?"* — which that PR deliberately left out of scope as a navigation change.

## What changed

Each card in the Combos library gains **Rename** and **Delete**. Both mutations already existed in `convex/combos.ts` and were already permission-checked against the caller, so this exposes them rather than writing them. A Combo is Personal (ADR-0012): there is no Group argument to pass and none to get wrong.

## Deleting says what it does not do

The confirmation reads *"Delete "Usual breakfast"? What you have already logged stays in your diary."*

That second sentence is not reassurance, it is the model. A Combo is a shortcut for what will happen; the diary is the record of what did. Neither renaming nor deleting one reaches into it — pinned by two tests that compare the whole day before and after.

That matters concretely now that #99 has landed: diary entries are badged with the Combo that logged them, and the name on the badge is **snapshotted**. Renaming a Combo does not rewrite the day it was logged on, and deleting one does not blank the badge. The two changes agree by construction — they are the same ADR-0003 rule — but they were written to it independently, so it is worth knowing.

## Refusals stay in the reader's language

`rename` and `remove` answer with English sentences (`'Combo not found'`, `'A combo needs a name.'`) and the person reading may not be an English speaker. So the form validates the one case it can — an empty or whitespace-only name, caught before it is sent — and any other failure resolves to a message from the tree. A test asserts a thrown `'Combo not found'` never reaches the screen.

No server change was needed for that, so none was made; the `combos.ts` refusals are untouched and still indistinguishable between "not yours" and "no such combo" (ADR-0009), which a test now covers from both sides.

## One state at a time

The buttons, the rename field and the delete confirmation share a corner of the card, so exactly one is on show. A card displaying two of them would be asking two questions at once. Renaming opens on the name it already has, because editing a name is usually a correction rather than a retype.

Cancel is disabled while a mutation is in flight (`4ad2446`, from review): neither a rename nor a delete already sent can be called back, and a Cancel that appears to stop one would also hand the card back for a second action on a row that is already changing.

## Tests

**New Convex coverage** (`convex/combos.test.ts`) — `remove` had **none at all** before this: deleting takes its `comboItems` with it and leaves no orphans; deleting and renaming each leave the day's entries byte-identical; a whitespace-only name is refused and the old name survives; somebody else cannot delete it; and "not yours" and "no such combo" refuse with the same wording.

**New component coverage** (`ComboActions.test.tsx`, 9 tests): both buttons carry accessible names saying which Combo they act on; rename opens prefilled and saves trimmed; an empty name never reaches the server; cancelling restores the old name; deleting asks first and mentions the diary; confirm deletes and cancel does not; a server refusal is replaced by localized copy; and Cancel is unavailable while either mutation is in flight (tested by holding the promise open).

`CombosPage.test.tsx`'s `convex/react` mock gained `useMutation` — the page now calls it. No existing assertion was changed.

## Checks

| Command | Result |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm test` | pass — 102 files, 1163 tests |
| `pnpm check` | pass — Biome, 267 files |
| `pnpm build` | pass |

## Out of scope

Editing a Combo's *contents* (adding, removing or re-quantifying components). `replaceItems` exists for the post-logging offer, and reusing it as a general editor is its own decision — it would need an answer for what happens to a component whose food has since gone out of reach.