### PR TITLE
docs: decide how the mobile app behaves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,18 @@ Selector note: the UI is translated, so `text` selectors are locale-dependent
 (`Recepten`, not `Recipes`). Prefer `id` selectors; `testID` maps to Android's
 `resource-id`. Apple targets do not work from Windows.
 
+## How the phone behaves
+
+`docs/mobile-interaction.md` is the decided interaction vocabulary for
+`apps/mobile` — press-and-hold, swipe, haptics, sheets, undo-vs-confirm,
+loading, empty states, pull-to-refresh. It is short and prescriptive; the
+research and the rejected alternatives are in
+`docs/research/mobile-interaction-vocabulary.md`.
+
+**A new mobile screen follows it, and a rule that turns out wrong is changed
+there rather than excepted in a component.** The rule underneath all of it:
+don't draw what the platform can draw.
+
 ## Seed data
 
 Two mechanisms with deliberately opposite rules, kept as two plain functions in

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -3,6 +3,13 @@
 Gather mobile is the native, connected-only companion to the Gather household
 app. It shares the same Clerk account and Convex service as the web app.
 
+## How this app behaves
+
+Interaction rules — press-and-hold, swipe, haptics, sheets, undo, loading,
+empty states — live in [`docs/mobile-interaction.md`](../../docs/mobile-interaction.md).
+Read it before adding a screen. The research behind it is in
+[`docs/research/mobile-interaction-vocabulary.md`](../../docs/research/mobile-interaction-vocabulary.md).
+
 ## Run locally
 
 1. Copy `.env.example` to `.env.local` and provide the Clerk and Convex values.

--- a/docs/mobile-interaction.md
+++ b/docs/mobile-interaction.md
@@ -1,0 +1,242 @@
+# How gather mobile behaves
+
+The rules the phone app follows: what a press does, what a swipe does, what
+buzzes, what appears while things load. Decided 2026-08-21 from the survey in
+[`docs/research/mobile-interaction-vocabulary.md`](research/mobile-interaction-vocabulary.md),
+which has the research, the alternatives and the versions behind each rule.
+
+This file is the short version, and it is the one to obey. **When you add a
+screen, it follows these rules; when a rule turns out to be wrong, change it
+here rather than making an exception in a component.**
+
+## The one idea underneath all of it
+
+**Don't draw what the platform can draw.** iOS already knows how to render a
+menu, a sheet, a tab bar, an alert — and on iOS 26 it renders them in Liquid
+Glass at no cost. gather's job is to use the system's version, not to build a
+convincing copy of it.
+
+Two consequences worth stating, because they are the ones people forget:
+
+- The tab bar is already Liquid Glass, without gather doing anything. Do not
+  try to style it; on iOS 26 background props on `NativeTabs` have no effect.
+- iOS is the reference and Android is the honest port. Same *behaviour* both
+  places, drawn by each platform in its own idiom — a ripple on Android where
+  iOS fills the row, a snackbar on Android where iOS stays quiet.
+
+---
+
+## Touch
+
+### Press and hold opens a menu. Always.
+
+Hold any row and you get the system context menu — the screen blurs, the row
+lifts, its actions appear. Edit, Delete, Share, whatever that row has.
+
+No screen is exempt and the gesture never means anything else, so it is
+predictable everywhere. Built with `@expo/ui`'s `ContextMenu`, which is a real
+SwiftUI menu on iOS and a Compose menu on Android.
+
+**Rearranging a list is a mode, not a gesture.** A list whose order people
+control — a task list, which already has an `order` column — gets a *Reorder*
+item in that menu, or a button in its header. Entering it grows drag handles on
+every row; Done leaves it. That is how the hold gesture stays free.
+
+A menu is never the only way to reach something. Everything in it is also on the
+row's detail screen.
+
+### Swipe is the shortcut for the one thing you do most
+
+- **Swipe right** does the row's main verb. Completing a task. Nothing at all
+  for a row with no natural verb — a recipe in a list is not "done" — because a
+  made-up action is worse than no action.
+- **Swipe left** reveals a red Delete you have to *tap*. It never fires on a
+  full swipe, because a full swipe is something you do by accident while
+  scrolling, and gather's deletes are permanent.
+- **A full swipe left is reserved for Archive**, and archive does not exist yet
+  (see Open questions). When it does, it goes here. Until then the slot stays
+  empty on purpose — do not fill it with something else.
+
+Built with `ReanimatedSwipeable` from `react-native-gesture-handler`, which is
+already installed.
+
+### Press states and targets
+
+Rows highlight with a background fill on iOS and a ripple on Android. **Not**
+`opacity: 0.6` — that is the React Native default and it is wrong on both
+platforms. Buttons may use opacity or a slight scale.
+
+Anything smaller than about 44×44pt gets `hitSlop`. `QuickActionSheet` already
+does this (`hitSlop={12}`) and is the example to copy.
+
+---
+
+## Feedback
+
+### Haptics
+
+One wrapper, `src/feedback/haptics.ts`, whose functions are named after events —
+`haptics.itemCompleted()`, never `impactAsync(Heavy)` at a call site.
+
+| What happened | What plays |
+| --- | --- |
+| Toggle, segmented control, picker step | `selectionAsync()` |
+| Saved, task completed | `notificationAsync(Success)` |
+| Validation failed, write rejected | `notificationAsync(Error)` |
+| Swipe passes its threshold | `impactAsync(Light)` |
+| Hold-menu opens | `impactAsync(Medium)` |
+| Sheet snapping to a detent | nothing — the platform does it |
+| Pull-to-refresh fires | `impactAsync(Light)` |
+| Ordinary taps, scrolling, navigation | **nothing** |
+
+That last row is the important one. Buzzing on every tap is what makes an app
+feel cheap.
+
+**A haptic is never the only signal.** iOS plays nothing at all in Low Power
+Mode, when the user has turned haptics off, while the camera is open, or during
+dictation. If the only way to know something worked is a buzz, it did not work
+for those people.
+
+### Messages: usually none
+
+The confirmation is the screen changing. A task you added appears in the list —
+nothing needs to say "Task added".
+
+Words appear in exactly two cases:
+
+- **Undo.** "Deleted — Undo" needs somewhere to put the button.
+- **A failure you did not cause** — a background sync failing while you are
+  elsewhere.
+
+Drawn as a snackbar on Android, which has that convention, and something quieter
+on iOS, which does not.
+
+### Undo or confirm — never both
+
+- **Reversible things just happen**, with undo offered: completing, unpinning,
+  un-sharing. Asking first would be nagging.
+- **Permanent things ask first**, with an alert that names what is going: a
+  recipe, a task list, leaving a Group.
+
+Deleting in gather is permanent today — 32 hard `.delete()` calls, and no
+`deletedAt` anywhere in the schema. That is why the second rule exists, and it
+is what would change if archive ever lands.
+
+An action that confirms *and* offers undo has decided it is dangerous and then
+decided it is not. Pick one.
+
+### Completing a task puts it away
+
+A completed task leaves the active list and drops into a collapsed
+**Completed (n)** section at the bottom, which expands on tap. Un-completing
+restores it — `done` is a boolean, so this costs nothing.
+
+Note this is a change: `convex/tasks.ts` currently sorts completed tasks to the
+bottom and leaves them visible.
+
+---
+
+## While you wait
+
+**Loading.** A skeleton of the eventual layout on first paint of a list or
+detail screen — it is what stops the layout jumping. Nothing at all when
+re-querying something already on screen; Convex is live, and the content you can
+see is almost always right. A spinner only inside a control someone just
+pressed. Never a full-screen spinner over content that already exists.
+
+**Optimistic writes.** Use Convex's `withOptimisticUpdate` for small, frequent,
+reversible writes — completing a task, toggling a pin, adding from the launcher.
+Everything else waits for the server. Create new objects inside the update;
+mutating existing ones corrupts the client's state.
+
+**When an optimistic write fails, the rollback must be visible.** A checkbox
+that silently un-checks itself is worse than a slow one.
+
+**Pull to refresh** appears only where it genuinely fetches — task lists backed
+by Notion and Todoist, which sync on demand (ADR-0021). Everywhere else Convex
+is already live, and a refresh gesture that does nothing is a lie. Elsewhere,
+the connection banner is the honest signal.
+
+**Empty states** come in three kinds, one component with a `kind`:
+
+- *Nothing yet* — one button that adds the first thing.
+- *Nothing found* — a way to clear the search or filter, never an add button.
+- *Nothing here for you* — a placeholder Module, a Group you have not joined.
+  An explanation and no action.
+
+---
+
+## Chrome
+
+**Tabs.** The fixed five (ADR-0018), with `minimizeBehavior="onScrollDown"` so
+the bar shrinks as you scroll, and `role="search"` on Search so iOS 26 draws it
+as its own capsule. Badges only when something genuinely needs counting.
+
+**Titles.** Large titles on Module index screens; small inline titles on
+anything you push into.
+
+**Getting out.** The native back button and the swipe-from-edge gesture. **No
+breadcrumbs on the phone** — [ADR-0013](adr/0013-a-nested-page-carries-its-own-trail.md)
+is a web rule and does not cross. What does cross is its second half: back goes
+to the parent, never to history. Every deep-linkable screen must have a working
+parent when opened cold.
+
+**Quick actions.** Kinds are ADR-0018's: `row` grows a field in the launcher,
+`sheet` swaps the launcher's body, `handoff` pushes the Module's own screen. One
+addition: **a `handoff` returns you where you started.** You pressed Add from
+the Baby module; saving a recipe should not leave you standing in Recipes.
+
+**Forms.** First field autofocused. `returnKeyType` chains `next` → `next` →
+`done`. The last field submits. The primary button is disabled until valid, and
+submitting twice does not save twice. `QuickActionSheet` already does all of
+this and is the reference. A validator returns a message key, not a sentence
+(ADR-0011).
+
+---
+
+## Dependencies
+
+Adopted: **`@expo/ui`** — context menus and native sheets, inside the Expo
+release train, works in Expo Go.
+
+Already installed and now actually used: `expo-haptics`,
+`react-native-gesture-handler`, `react-native-reanimated`.
+
+Deliberately not adopted: `@gorhom/bottom-sheet` (nothing here needs a
+JavaScript-drawn sheet), `zeego` (only if `@expo/ui`'s menu turns out to lack
+the blur-and-lift presentation). Deferred until something actually breaks:
+`react-native-keyboard-controller`, and a toast library.
+
+**`expo-glass-effect` only where something needs it.** Glass belongs to chrome
+that floats over scrolling content. Cards, tiles and rows are content. And the
+tab bar is already glass for free. Below iOS 26 and on Android a `GlassView`
+silently becomes a plain `View`, so never build a layout that only reads
+correctly with glass.
+
+---
+
+## Open questions
+
+**How the Add launcher is built.** Two candidates: `@expo/ui`'s `BottomSheet`,
+which opens over the current screen and has no address, or an `expo-router`
+`formSheet`, which is a route with detents and a grabber for free. ADR-0018
+requires that pressing Add never navigates, and whether a `formSheet` presented
+from the tab press counts as navigating is a question about behaviour, not about
+documentation. **Decided on the phone, both built, before either is written
+down.** Watch for [expo/expo#47831](https://github.com/expo/expo/issues/47831),
+where a sheet containing further navigation renders the wrong background on
+iOS 26 — which is the launcher's exact shape.
+
+Either way, the hand-built `Modal` in `QuickActionSheet` retires.
+
+**Archive.** It does not exist: no flag on any table, nothing hidden-but-kept.
+Adding it means a column, a filter on every query that reads those rows, a place
+to see archived things, and a `docs/migrations/` note — a project, not a UI
+change. Tasks are the exception and need nothing: completing already puts a task
+away, reversibly.
+
+**Verify the two Apple sources.** The detent and haptics guidance here came from
+search excerpts, because the HIG could not be fetched when the survey was
+written. Confirm against the real pages before treating them as settled:
+[Sheets](https://developer.apple.com/design/human-interface-guidelines/sheets),
+[Playing haptics](https://developer.apple.com/design/human-interface-guidelines/playing-haptics).

--- a/docs/research/mobile-interaction-vocabulary.md
+++ b/docs/research/mobile-interaction-vocabulary.md
@@ -1,0 +1,568 @@
+# Interaction vocabulary for the gather mobile app
+
+**This is a survey, not a decision.** It exists so that the decisions can be
+argued about one at a time instead of being made accidentally, one component at
+a time, by whoever writes the next screen. Where it recommends, it recommends
+with its reasoning exposed, so the decision can disagree with the reasoning
+rather than with the conclusion.
+
+The output of the decisions is a short prescriptive guidance file — the rules a
+future change obeys — plus, for anything load-bearing, an ADR. Nothing here is
+binding yet.
+
+Compiled 2026-08-20. Package versions were read from the npm registry that day,
+not recalled. Verification status of every source is recorded in §16, and it is
+uneven: Expo's documentation, the Convex documentation and the packages
+installed in `apps/mobile/node_modules` were fetched and read; Apple's Human
+Interface Guidelines could not be fetched from this environment (the HIG is a
+client-rendered site and the data endpoints 404 behind the proxy), so HIG
+content here comes from search excerpts and is marked `HIG (excerpt)` wherever
+it is used. Treat those lines as needing a confirming read before they become
+rules.
+
+---
+
+## 0. Three local facts that make this question gather's, not generic
+
+A generic "how do I do mobile UX" answer gets this wrong three ways.
+
+### The shell is already decided, and it is already native
+
+[ADR-0017](../adr/0017-the-phone-owns-its-look-and-shares-its-words.md) put the
+phone's look in a typed token module and handed navigation chrome to
+`expo-router`'s `Stack` and `NativeTabs`.
+[ADR-0018](../adr/0018-mobile-tabs-are-app-destinations-and-one-of-them-is-a-verb.md)
+fixed the five tabs, made Add a verb that opens a launcher without navigating,
+and gave each Module's quick action a declared `kind` (`row` / `sheet` /
+`handoff`).
+
+So this survey is not free to propose a hand-drawn interaction language. Most of
+what follows either rides on a native component gather already renders, or has
+to argue explicitly for leaving one.
+
+### Everything below the shell is greenfield — including the parts already installed
+
+`apps/mobile` ships `expo-haptics`, `react-native-gesture-handler` (2.32.0) and
+`react-native-reanimated` (4.5.1), and as of today calls **none of them**. A
+`grep` for `Haptics`, `reanimated` and `gesture-handler` across `app/` and
+`src/` returns nothing. There is no swipe action, no long press, no context
+menu, no toast, no skeleton, and no optimistic write anywhere in the app.
+
+That is unusually good news: there is no legacy vocabulary to migrate. The first
+rule written is the rule.
+
+The one interaction that does exist is `QuickActionSheet` — a hand-built
+`Modal` + scrim + `Pressable` grabber with `opacity: 0.6` press states. It is
+the de-facto precedent for "sheet" and for "pressed", and §3 and §5 both have to
+say whether it stays that way.
+
+### The verification story is inverted from the ADRs' assumptions
+
+The README and CLAUDE.md are written for a Windows machine driving an Android
+emulator, and say plainly that Apple targets do not work from there. But **iOS
+is the primary platform** for this app, and the primary device is a real iPhone.
+
+That reshapes the cost of every recommendation below. An iOS-only capability is
+not a thing that has to wait for a Mac; it is a thing verified by installing a
+dev build on the phone (EAS build, `--profile development`) and driving it by
+hand. What it is *not* is a thing `agent-device` can verify on the emulator —
+so an iOS-only rule is a rule an agent cannot check, and that is a real cost
+that belongs in each decision rather than in a footnote.
+
+---
+
+## 1. Posture: iOS is the reference, Android is the honest port
+
+Taken as given from the brief, recorded here because everything downstream leans
+on it:
+
+- **The app should feel like the OS it is running on**, not like a cross-platform
+  compromise and not like gather-on-the-web. On iOS 26 that specifically means
+  Liquid Glass chrome, native sheets with detents, `UIMenu` context menus, and
+  the Taptic vocabulary users already know from Mail and Messages.
+- **Todoist and GitHub are the reference apps.** Both are cross-platform apps
+  that nonetheless read as native on iOS. Neither invents furniture.
+- **Android gets the same behaviour drawn by Material**, not the same pixels.
+  Where Material genuinely disagrees with UIKit — snackbars vs. no snackbars,
+  overflow menus vs. long-press menus, the back gesture — the Android answer is
+  Material's, and the topic says so explicitly rather than pretending the
+  platforms agree.
+
+The important consequence: **gather should almost never draw its own chrome.**
+Every topic below is scored partly on "does this let the platform draw it".
+
+### What Liquid Glass costs and what it gives
+
+Worth stating once, since it colours §2, §3 and §4.
+
+Most of it is free. Recompiling against the iOS 26 SDK gives system controls the
+Liquid Glass treatment automatically, and `NativeTabs` documents that on iOS 26
+the tab bar derives its background from the content beneath it — to the point
+that **background props have no effect there** ([Expo][expo-nt]). gather's tab
+bar is already Liquid Glass, today, without a line of code.
+
+What is *not* free is glass on gather's own surfaces, which needs
+`expo-glass-effect` (57.0.1, bundled with SDK 56+, works in Expo Go). Its
+constraints are sharp and worth knowing before designing anything around it
+([Expo][expo-glass]):
+
+- **iOS 26+ only.** Below that, and on Android, `GlassView` silently falls back
+  to a plain `View` — so any layout that only reads correctly *with* glass is a
+  layout that breaks on Android and on iPhones a year old.
+- **Availability must be checked at runtime.** `isGlassEffectAPIAvailable()`
+  exists because some iOS 26 betas crash without it.
+- **`opacity: 0` disables the effect entirely.** Fading glass means the
+  component's own `glassEffectStyle` animation props, not an opacity animation.
+
+And the design guidance is mostly a list of don'ts: no `blur`, `opacity` or
+`background` on a glass view; no solid fill behind one; no `clipShape`; no
+nested glass containers; and no second glass layer on toolbars and tab bars,
+which already have one. iOS 26 also enforces container corner radii for
+concentricity rather than letting an app override them
+(WWDC25 §284 + community write-ups — see §16).
+
+**Reading:** glass is chrome that floats over scrolling content. gather's cards,
+tiles and rows are content. The honest scope for `expo-glass-effect` in this app
+is small — a floating control or two — and "the tab bar already does it for
+free" may be the whole answer.
+
+---
+
+# Part A — Chrome and navigation
+
+## 2. Tabs, and the three iOS 26 affordances gather is not using
+
+`NativeTabs` already draws the fixed five. Three documented props are unused and
+each is a decision, not a tweak ([Expo][expo-nt]):
+
+| Prop | What it does | Why it matters here |
+| --- | --- | --- |
+| `minimizeBehavior="onScrollDown"` | The iOS 26 bar shrinks to a pill as you scroll down and returns as you scroll up. Android from SDK 55+. | ADR-0018 explicitly bought the real `UITabBarItem` *in order to get* this behaviour, and then did not turn it on. Long lists — Recipes, Tasks, All — are where the app spends its screen. |
+| `role="search"` on the Search trigger | Makes it a real search tab: iOS 26 renders it as a separate glass capsule beside the bar, not a fifth equal item. Needs Xcode 26+. | gather has a Search tab. This is the platform drawing exactly the thing ADR-0018 described. |
+| `NativeTabs.Trigger.Badge` | Native count/dot badges. | The only honest home for "3 tasks due today" if Home ever wants to say so from the bar. |
+
+Two limitations to design around: **the tab bar height cannot be measured**, and
+there is **no dynamic add/remove of tabs** — both of which the fixed five already
+accommodate, which is a point in ADR-0018's favour rather than a problem.
+
+`BottomAccessory` (a real `UITabBarController.bottomAccessory` riding above the
+bar) was considered and rejected in ADR-0018 as iOS-26-only. Under an iOS-first
+posture that rejection is worth **re-examining, not reversing**: the reason it
+lost was that it would need a second control for Android, and that reason has not
+changed.
+
+- **Recommendation:** turn on `minimizeBehavior` and `role="search"`; leave
+  badges until something needs to count; leave `BottomAccessory` closed.
+- **Open:** does `minimizeBehavior` interact badly with the disabled Add slot?
+  Unverified, and cheap to check on device.
+
+## 3. Sheets — three mechanisms, and gather currently uses the fourth
+
+This is the largest fork in the document, because gather has four options and is
+presently using the worst one.
+
+| Mechanism | What it really is | Detents | Cost |
+| --- | --- | --- | --- |
+| **`expo-router` `presentation: 'formSheet'`** | A route, presented by `react-native-screens` as a real `UISheetPresentationController` / Material bottom sheet | `sheetAllowedDetents`, `sheetInitialDetentIndex`, `sheetGrabberVisible`, `sheetCornerRadius`, `sheetLargestUndimmedDetentIndex` | Already installed. Sheet content is a route, so it gets deep links and back-navigation for free |
+| **`@expo/ui` `BottomSheet`** | SwiftUI `sheet` on iOS, Compose `ModalBottomSheet` on Android, `vaul` on web; API-compatible with gorhom | `snapPoints`, or sizes to content | One new dependency (`@expo/ui` 57.0.12), in Expo Go, no custom handle/backdrop/footer |
+| **`@gorhom/bottom-sheet`** | JS-driven on the UI thread via Reanimated worklets | Full control, `BottomSheetFlatList`, keyboard handling | 5.2.14. Most capable, least native. Its own animation curve, not the platform's |
+| **hand-built `Modal` + scrim** | what `QuickActionSheet` does today | none | none, and it shows: no drag-to-dismiss, no detents, no native material |
+
+The HIG's position on the shape itself (excerpt): the system defines `medium`
+(≈half height) and `large` detents; a resizable sheet should **include a
+grabber**, which both signals resizability and cycles detents on tap; the medium
+detent exists for progressive disclosure, and compose-style sheets that need the
+room should be large-only.
+
+Read against gather's launcher, that is a precise description of what
+`QuickActionSheet` is imitating by hand — and of what it gets wrong. A `row`
+action that grows a field in place is exactly a medium detent expanding to
+large.
+
+Two traps if `formSheet` wins, both real and both recent:
+
+- **No native stack headers and no nested stack navigators inside a form sheet.**
+  Headers and actions have to be part of the sheet's own content. gather's
+  launcher has a header with a back affordance — that is content here, not
+  chrome.
+- **[expo/expo#47831](https://github.com/expo/expo/issues/47831)**: a form sheet
+  containing a nested `Stack` renders the navigation theme background instead of
+  the native sheet material on iOS 26. Directly in the blast radius of "Add
+  opens a sheet that can push".
+
+- **Recommendation:** `formSheet` for anything that is a *place* (create,
+  edit, filter, a Module's quick flow); `@expo/ui` `BottomSheet` only if a sheet
+  must open over the current screen without being a route; `@gorhom` only if
+  something needs an interaction the platform sheet cannot express, which
+  nothing in gather currently does. The hand-built modal retires either way.
+- **Open:** whether the Add launcher itself becomes a `formSheet` route. It is
+  the one sheet that ADR-0018 requires *not* to change the route. A sheet
+  presented from `(tabs)/add`'s `tabPress` is not the same thing as navigating
+  to it, and which of those `formSheet` actually is needs checking on device
+  before this is decided.
+
+## 4. Headers, back, and where the trail went
+
+The web app's rule — [ADR-0013](../adr/0013-a-nested-page-carries-its-own-trail.md),
+a nested page renders its own breadcrumbs — has no iOS equivalent and should
+not get one. iOS's answer to "where am I and how do I get out" is the native
+back button with the parent's title, plus the interactive swipe-from-edge
+gesture. Android's is the system back gesture. Both come free with
+`Stack`; a drawn breadcrumb trail on a 390pt-wide screen is web furniture.
+
+What ADR-0013 *does* carry across is its second rule: **back points at the
+parent's address, never at history**. On the phone the navigator already
+guarantees that for pushes; the place it can break is a deep link that lands
+mid-hierarchy with nothing beneath it.
+
+- **Recommendation:** no breadcrumbs on the phone; native `Stack` headers with
+  large titles on Module indexes (`headerLargeTitle`) and inline titles below;
+  every deep-linkable screen must have a working parent when opened cold. Write
+  the ADR-0013 exception down, since a reader of the web rule will otherwise
+  assume it applies.
+- **Open:** large titles or not. GitHub uses them, Todoist largely does not.
+
+---
+
+# Part B — Touch vocabulary
+
+## 5. Press states, hit targets, and the thing every RN app gets subtly wrong
+
+Today every pressable in `apps/mobile` uses `opacity: 0.6` while pressed. That
+is the React Native default idiom, and it is wrong on both platforms: iOS
+highlights a *row* with a background fill rather than fading its content, and
+Android draws a ripple from the touch point.
+
+`react-native-gesture-handler` 2.32 — already installed — ships its own
+`Pressable` with `android_ripple` support and gesture-system integration, which
+matters as soon as a pressable lives inside something that scrolls or swipes.
+
+- **Recommendation:** rows and list items get a background-fill press state on
+  iOS and a ripple on Android, expressed once in a shared `Row`/`Pressable`
+  wrapper rather than per screen. Buttons keep a subtle opacity or scale.
+  Everything below ~44×44pt gets `hitSlop` — `QuickActionSheet` already does
+  this correctly with `hitSlop={12}` and is the precedent.
+- **Open:** whether the wrapper is a component or a hook returning style.
+
+## 6. Long press and context menus
+
+This is where "feels iOS" is won or lost, and it is the topic with the most
+alternatives.
+
+| Option | iOS result | Android result | Dependency |
+| --- | --- | --- | --- |
+| `onLongPress` + custom popover | drawn by gather | drawn by gather | none |
+| **`@expo/ui` SwiftUI `ContextMenu`** | real SwiftUI context menu with the system's preview-and-blur | Compose `DropdownMenu` (separate code path) | `@expo/ui` 57.0.12, in Expo Go |
+| `react-native-context-menu-view` (1.21.0) | real `UIMenu` | Android `ContextMenu` | one small native module |
+| **Zeego** (3.0.6) | wraps `react-native-ios-context-menu` — real `UIMenu` with previews and submenus | `@react-native-menu/menu` | dev client required — gather has one; last published 2025-03-21 |
+
+The dev-client objection that usually rules Zeego out does not apply here: the
+README already treats a development build as the normal way to run this app.
+The objection that does apply is freshness — a package last published seventeen
+months ago, sitting on top of two other native modules, in an app that upgrades
+Expo SDKs.
+
+What the reference apps do, as **observation rather than verified source**:
+GitHub leans heavily on long-press context menus over list rows; Todoist uses
+long press primarily for drag-to-reorder, with a separate row menu. That is a
+genuine fork — long press cannot be both on the same row without one of them
+winning after a delay.
+
+- **Recommendation:** `@expo/ui`'s `ContextMenu` first, on the grounds that it
+  is the only option that adds no native module outside the Expo release train
+  and still produces a real system menu. Reach for Zeego only if the SwiftUI
+  component turns out not to support the preview-and-blur presentation that makes
+  an iOS context menu feel like one.
+- **Open, and important:** what long press *means* in gather. Menu, or reorder?
+  Pick one globally; a per-screen answer is how an app stops being predictable.
+- **Rule that should survive whatever wins:** a long press is never the only way
+  to reach an action. Everything in a context menu is also reachable from the
+  detail screen or a swipe.
+
+## 7. Swipe actions on rows
+
+`ReanimatedSwipeable` is present in the installed `react-native-gesture-handler`
+2.32 (`src/components/ReanimatedSwipeable/`), alongside the legacy Animated-based
+`Swipeable`. New code should use the Reanimated one. Android's own idiom is
+Compose's `SwipeToDismissBox`, which behaves the same way from the user's side.
+
+The vocabulary question is not "can we" but "what does a direction mean", and
+the answer has to be global. Todoist's is roughly: swipe one way completes,
+the other opens scheduling. Mail's is: one way archives, the other flags.
+gather's rows are heterogeneous — a task, a recipe, a food, a pinned Module —
+and a direction that means "complete" on a task must not mean "delete" on a
+recipe.
+
+- **Recommendation:** at most two actions per row, one per direction; the
+  destructive one is never the *short* swipe (a full swipe that deletes
+  something without confirmation is a bug that ships); the leading direction is
+  reserved for the row's primary verb (complete a task, cook a recipe) and the
+  trailing one for a menu-ish secondary. Rows that have no meaningful verb get
+  no swipe at all rather than a made-up one.
+- **Open:** does delete-by-swipe exist in gather, and if so does it go through
+  undo (§13) or through confirmation (§9)? These are alternatives, not a
+  sequence.
+
+## 8. Pull to refresh
+
+Convex is a live-query backend: lists update themselves without asking. That
+makes pull-to-refresh nearly meaningless as a data operation, and *not*
+meaningless as a gesture — people pull to reassure themselves, and its absence
+reads as staleness.
+
+The exception is real: the Tasks module's external providers (Notion, Todoist)
+sync manually per
+[ADR-0021](../adr/0021-task-backend-capabilities-and-manual-sync.md). There,
+pulling actually does something.
+
+- **Recommendation:** `RefreshControl` wherever a list is backed by an external
+  provider that syncs on demand, because there it is honest. Elsewhere, prefer
+  the connection banner (§12) over a gesture that pretends to fetch.
+- **Open:** whether "honest only" or "everywhere, for consistency" is the better
+  answer for a household app whose users will not know which lists are external.
+
+## 9. Destructive actions and confirmation
+
+Three shapes, and the platforms diverge:
+
+- **`Alert`** — a modal with a red destructive button. Correct on iOS for
+  irreversible destruction, and correct on Android too.
+- **Action sheet** — iOS's idiom for "confirm this destruction that you started
+  from a swipe or a menu", where the sheet also names what is being destroyed.
+- **Undo** — Material's answer (snackbar with UNDO), and increasingly iOS's for
+  anything recoverable.
+
+The rule worth extracting: **confirmation and undo are alternatives.** An app
+that confirms *and* then offers undo has decided the action is dangerous and
+then decided it is not.
+
+- **Recommendation:** anything recoverable (complete, archive, remove from a
+  list) uses undo and no dialogue; anything genuinely irreversible (delete a
+  recipe, leave a Group, delete a task list with contents) uses an alert that
+  names the object. Nothing uses both.
+- **Open:** which of gather's destructive actions are actually recoverable —
+  a Convex-level question, not a UI one, and the answer may be "none of them are
+  today", which would make undo a backend change rather than a component.
+
+## 10. The haptic vocabulary
+
+`expo-haptics` is installed and unused. Its API ([Expo][expo-haptics]):
+`impactAsync` (`Light`/`Medium`/`Heavy`/`Rigid`/`Soft`), `notificationAsync`
+(`Success`/`Warning`/`Error`), `selectionAsync()`, and
+`performAndroidHapticsAsync` for the ~20 Android-specific patterns.
+
+Two constraints decide the shape of any rule here. First, the platform one:
+**iOS silently plays nothing** when Low Power Mode is on, when the user has
+turned system haptics off, while the camera is active, or during dictation.
+Second, the guidance one — the HIG's line (excerpt) is that haptics *supplement*
+visual feedback and that system-defined haptics should be used consistently so
+people are not confused. Together they give the only rule that really matters:
+**a haptic is never the only signal that something happened.**
+
+A starting vocabulary, offered as a table because that is the form it needs to
+end up in:
+
+| Event | Call | Why |
+| --- | --- | --- |
+| Toggle, segmented control, picker step | `selectionAsync()` | What the system uses for exactly this |
+| Quick-add saved, task completed | `notificationAsync(Success)` | An outcome, not a collision |
+| Validation failed, mutation rejected | `notificationAsync(Error)` | Pairs with the inline error, never replaces it |
+| Swipe action passing its threshold | `impactAsync(Light)` | The one place a haptic is genuinely load-bearing: it is how you know you have gone far enough without watching |
+| Long press opening a context menu | `impactAsync(Medium)` | Matches the system's own menu haptic |
+| Sheet snapping to a detent | none | The platform sheet already does this |
+| Pull-to-refresh firing | `impactAsync(Light)` | Convention |
+| Navigation, scrolling, ordinary taps | **none** | This is the overuse that makes an app feel cheap |
+
+- **Recommendation:** adopt the table as-is, in one `src/feedback/haptics.ts`
+  wrapper that names events rather than intensities — call sites say
+  `haptics.itemCompleted()`, never `impactAsync(Heavy)`. That wrapper is also
+  where the Android divergence (`performAndroidHapticsAsync`) lives, and where a
+  future "reduce haptics" preference would.
+- **Open:** whether `Heavy` is ever right in this app. Probably not.
+
+---
+
+# Part C — Feedback and state
+
+## 11. Loading
+
+Convex queries return `undefined` while loading, which makes "what do we render"
+a decision every list makes, and currently makes differently.
+
+The choices are the usual three: a spinner, a skeleton of the eventual layout, or
+nothing (render the last known content and let it update). Live queries make the
+third viable more often than in a REST app — a cached list is usually correct.
+
+- **Recommendation:** skeletons for first paint of a list or detail screen,
+  because they are what stop the layout jumping; nothing at all for a re-query
+  where content is already on screen; a spinner only inside a control that the
+  user just pressed. No full-screen spinners over content that already exists.
+- **Open:** whether skeletons are worth their maintenance in a 13-Module app, or
+  whether a quiet placeholder tile is enough.
+
+## 12. Optimistic writes, and the offline story
+
+Convex supports `withOptimisticUpdate` on mutations, with `localStore.getQuery` /
+`setQuery`, automatic rollback when the mutation resolves, and one hard rule:
+**never mutate objects in the update** — new objects only, or the client's
+internal state corrupts ([Convex][convex-opt]).
+
+gather mobile is documented as *connected-only* and already has a
+`ConnectionLostBanner` and an `AvailabilityProvider`. That is the right posture
+and it makes optimism a UX choice rather than an offline strategy.
+
+- **Recommendation:** optimistic updates for the small, high-frequency, safely
+  reversible writes — completing a task, toggling a pin, adding via the
+  launcher. Everything else waits for the server and shows its result. Where a
+  write fails, the rollback must be accompanied by a visible error; a silently
+  reverted checkbox is worse than a slow one.
+- **Open:** does the quick-add launcher stay open optimistically (ADR-0018 says
+  saving a `row` action leaves the launcher open), and what does it do when that
+  optimistic add later fails and the launcher is gone?
+
+## 13. Toasts, snackbars, and the platform disagreement
+
+Android has a first-class answer: the Material snackbar, bottom of the screen,
+optionally with UNDO. iOS has never had one; apps that show toasts on iOS are
+importing an Android idiom, and the iOS-native equivalents are (a) doing nothing
+and letting the list update, (b) an inline banner, or (c) the small system-style
+HUD that `burnt` (0.13.0) renders natively.
+
+Under an iOS-first posture this is the topic where "one behaviour, both
+platforms" is most tempting and most wrong.
+
+- **Recommendation:** default to **no toast** — the list changing is the
+  feedback, plus the haptic from §10. Reserve a transient message for the two
+  cases that genuinely need one: an undoable destruction (§9), and a background
+  failure the user did not cause. Draw it as a snackbar on Android and as
+  something quieter on iOS — an inline banner or `burnt`.
+- **Open:** `sonner-native` (0.27.0, actively published) is the ergonomic
+  cross-platform toast library and would be one API for both. It is also
+  precisely the app-drawn furniture §1 is suspicious of. This is a real
+  trade-off and should be decided rather than defaulted.
+
+## 14. Empty states
+
+The app already has `ModulePlaceholder`, `NoGroup`, `GroupPending` and
+`SocialSoon`, so it has four empty-ish states and no stated rule. Three kinds
+worth distinguishing, because they want different things:
+
+- **Nothing yet** — the collection is empty and the fix is to add something. Gets
+  a single primary action that does exactly that. This is where an empty state
+  earns its keep.
+- **Nothing found** — a search or filter matched nothing. Gets a way to clear the
+  filter, never an "add" button that would create the wrong thing.
+- **Nothing here for you** — a Module that is a placeholder, or a Group you have
+  not joined. Gets an explanation and no action.
+
+- **Recommendation:** one `EmptyState` component with a `kind`, so the three stay
+  visually the same and behaviourally distinct, and so the existing four
+  components collapse into it rather than multiplying.
+
+## 15. Keyboard, forms, and submission
+
+`QuickActionSheet` gets the fundamentals right already — `KeyboardAvoidingView`
+with the iOS `padding` behaviour, `autoFocus` on the first field,
+`returnKeyType` chaining `next` → `done`, and submit-on-last-field. That is the
+pattern; it just needs stating.
+
+The known weak spot is `KeyboardAvoidingView` itself, which behaves differently
+per platform and badly inside sheets. `react-native-keyboard-controller`
+(1.22.4, published 2026-08-17) is the current answer and is a native module.
+
+- **Recommendation:** keep `KeyboardAvoidingView` until a sheet actually
+  misbehaves, then adopt `react-native-keyboard-controller` app-wide rather than
+  per screen. Submission rules: the primary action is disabled until valid
+  (already the launcher's behaviour), submitting is idempotent under double-tap,
+  and the keyboard's return key does what the on-screen button does.
+- **Rule worth carrying from the web:** a validator returns a key, not a
+  sentence ([ADR-0011](../adr/0011-the-ui-is-english-at-the-source-and-translations-are-typed-dictionaries.md)).
+  Nothing about the phone changes that, and every new string here lands in both
+  message trees.
+
+---
+
+## 16. Sources, and what was actually verified
+
+**Fetched and read (primary):**
+
+- [Expo — GlassEffect][expo-glass] · [Expo — Haptics][expo-haptics] ·
+  [Expo — UI (`@expo/ui`)][expo-ui] ·
+  [Expo — `@expo/ui` BottomSheet][expo-ui-sheet] ·
+  [Expo — Native tabs][expo-nt]
+- [Convex — Optimistic updates][convex-opt]
+- `apps/mobile/node_modules/react-native-gesture-handler@2.32.0` — source read
+  directly for `ReanimatedSwipeable`, `Swipeable` (legacy) and `Pressable`
+- npm registry, 2026-08-20, for every version number in this document
+
+**Search excerpts only — not fetched, marked `HIG (excerpt)` in the text:**
+
+- [Apple HIG — Sheets](https://developer.apple.com/design/human-interface-guidelines/sheets)
+  (detents, grabber, progressive disclosure)
+- [Apple HIG — Playing haptics](https://developer.apple.com/design/human-interface-guidelines/playing-haptics)
+  (supplement visual feedback; use system-defined haptics consistently)
+- Liquid Glass don'ts, drawn from [WWDC25 §284](https://developer.apple.com/videos/play/wwdc2025/284/)
+  coverage and community write-ups rather than from the HIG itself
+
+Apple's documentation site could not be fetched from this environment: the HIG
+renders client-side and its data endpoints return 404 through the proxy. **Every
+HIG-derived line above should be confirmed against the real page before it
+becomes a rule**, and the two that most deserve it are the sheet detent guidance
+(§3) and the haptics best practices (§10).
+
+**Observation, not source:** everything said about how Todoist and GitHub behave.
+Those are recollections of using the apps. They are useful for framing a choice
+and are not evidence for one; check them on the phone before citing them in a
+decision.
+
+**Not researched, deliberately out of scope:** motion tokens and screen
+transitions, shared-element animation, the type and spacing scale, accessibility
+beyond touch targets and the haptics/visual pairing rule, and iPad layout.
+
+[expo-glass]: https://docs.expo.dev/versions/latest/sdk/glass-effect/
+[expo-haptics]: https://docs.expo.dev/versions/latest/sdk/haptics/
+[expo-ui]: https://docs.expo.dev/versions/latest/sdk/ui/
+[expo-ui-sheet]: https://docs.expo.dev/versions/latest/sdk/ui/drop-in-replacements/bottomsheet/
+[expo-nt]: https://docs.expo.dev/router/advanced/native-tabs/
+[convex-opt]: https://docs.convex.dev/client/react/optimistic-updates
+
+---
+
+## 17. The dependency shortlist, if every recommendation above were taken
+
+| Package | Version | For | Verdict |
+| --- | --- | --- | --- |
+| `expo-haptics` | installed | §10 | already there, just unused |
+| `react-native-gesture-handler` | 2.32.0, installed | §5, §7 | already there, just unused |
+| `react-native-reanimated` | 4.5.1, installed | §7 | already there, just unused |
+| `@expo/ui` | 57.0.12 | §6 context menus, §3 non-route sheets | **add** — Expo release train, Expo Go, no extra native module |
+| `expo-glass-effect` | 57.0.1 | §1 | **add only when something needs it**; the tab bar is already glass for free |
+| `burnt` *or* `sonner-native` | 0.13.0 / 0.27.0 | §13 | **defer** — decide the toast question first |
+| `react-native-keyboard-controller` | 1.22.4 | §15 | **defer** — adopt when `KeyboardAvoidingView` actually breaks |
+| `zeego` | 3.0.6 | §6 | **no**, unless `@expo/ui`'s context menu lacks the preview presentation |
+| `@gorhom/bottom-sheet` | 5.2.14 | §3 | **no** — nothing in gather needs a JS-drawn sheet |
+
+Net: one dependency added now, one added on demand, three deferred behind a
+decision, two rejected.
+
+---
+
+## 18. The decisions this survey is asking for
+
+In rough order of how much else depends on them:
+
+1. **What does a long press mean** — context menu, or drag-to-reorder? (§6)
+2. **Does the Add launcher become a `formSheet` route**, given ADR-0018 requires
+   it not to change the route? (§3)
+3. **Toast or no toast on iOS**, and does that pull in a library? (§13)
+4. **Undo or confirm** for each destructive action — which in turn asks whether
+   gather's deletes are recoverable at all. (§9, §12)
+5. **The haptic table** — adopt as written, or amend? (§10)
+6. **Swipe directions**: one global meaning per direction, and whether delete is
+   ever one of them. (§7)
+7. **`minimizeBehavior` and `role="search"`** — turn on, or leave? (§2)
+8. **Pull-to-refresh**: honest-only, or everywhere? (§8)
+9. **Large titles** on Module indexes? (§4)
+10. **How much of this becomes an ADR** rather than a guidance file. Candidates:
+    the long-press meaning, the sheet mechanism, and the "never draw chrome the
+    platform can draw" posture itself.


### PR DESCRIPTION
Two documents, in the order they were written.

**`docs/research/mobile-interaction-vocabulary.md`** — the survey. Sheets, long press, swipe, haptics, tabs, press states, loading, optimistic writes, toasts, empty states, keyboard. Written under an iOS-primary posture (Liquid Glass and native chrome as the reference, Android as the honest Material port), against a starting fact worth stating: `apps/mobile` already ships `expo-haptics`, `react-native-gesture-handler` and `react-native-reanimated` and calls **none of them**. No legacy vocabulary to migrate.

**`docs/mobile-interaction.md`** — the decisions, short and prescriptive, linked from CLAUDE.md and the mobile README. The rule underneath all of it: don't draw what the platform can draw.

What was decided:

- **Press and hold always opens a menu**, everywhere, no exceptions. Rearranging a list is a mode you enter deliberately, so the gesture keeps one meaning app-wide and task lists still get their drag handles.
- **Swipe right does the row's verb; swipe left reveals a Delete you must tap.** Never a full-swipe commit — every delete in `convex/` is a hard delete (32 `.delete()` calls, no `deletedAt` in the schema). The full swipe stays reserved, in writing, for an archive that does not exist yet.
- **Undo for reversible things, a confirmation for permanent ones, never both.**
- **Completing a task puts it away** into a collapsed `Completed (n)` section, rather than leaving it sorted to the bottom as `convex/tasks.ts` does today.
- **No toasts** except undo and background failures — iOS has no snackbar convention and the list changing is the confirmation.
- **The haptic table adopted as written**, including the row that says ordinary taps, scrolling and navigation get nothing.
- **Tab bar minimise and the iOS 26 search role turned on** — ADR-0018 bought the native tab bar to get these and never switched them on.
- **Pull-to-refresh only where a provider really syncs** (ADR-0021); large titles on Module indexes only.
- **A `handoff` quick action returns you where you started.** Pressing Add in one Module should not leave you standing in another.

Two things stay open on purpose, and the doc says why: how the Add launcher is built — a question about behaviour that gets answered on a phone, not on paper, given ADR-0018 requires Add never to navigate — and archive, which turned out to be a schema project rather than a gesture.

Also worth a reviewer's attention: §16 of the survey records verification honestly and unevenly. Expo's docs, Convex's docs and the installed packages were fetched and read; Apple's HIG could not be fetched from this environment, so HIG-derived lines are marked as search excerpts and flagged for a confirming read. Claims about how Todoist and GitHub behave are labelled observation, not evidence.

Docs only — no code, no dependency changes.