### PR TITLE
docs: tasting Modules domain model and ADR-0024

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,7 +51,7 @@ but they are *about* a Group and are kept per Group (ADR-0005).
 
 **Catalog**:
 Reference data owned by nobody and readable by everybody — the foods that ship
-with Gather. Neither Group-scoped nor Personal. A Catalog entry has no author
+with Gather, and the well-known cheeses (see **Tasting catalog**). Neither Group-scoped nor Personal. A Catalog entry has no author
 and nobody may edit it; it changes only when a new version of Gather ships a
 different one.
 _Avoid_: Global data, Public data
@@ -160,6 +160,55 @@ refused is offered — which is what lets a type added to the catalogue reach
 households that made their choice before it existed.
 _Avoid_: Enabled types, Active types, Visible types
 
+**Tasting**:
+One person's record of having tasted something on a day — a score out of five,
+what they tasted in it, and their notes. Group-scoped and carrying
+**Attribution**, so two Members of a wine club each keep their own Tasting of
+the same bottle rather than overwriting one figure. It is the thing a person
+*makes*: a Tasting subject comes into being because somebody logged a Tasting
+against it, never as a separate first step (ADR-0024). It carries the day it
+happened, which is not the day it was written down.
+_Avoid_: Rating, Review, Note, Entry (the Baby log and the food diary already
+have entries)
+
+**Tasting subject**:
+The thing tasted — a cheese, a wine, a beer. Group-scoped, and the thing the
+household accumulates a relationship with: the photo of the label, the note that
+you buy the aged one, every Tasting anybody has made of it. It holds the facts
+that do not change between tastings (producer, vintage, milk type); what you
+thought on the night belongs to the Tasting.
+
+The shared word appears only where the Kind genuinely is not known. A person
+never reads "subject" or "item" — they read *cheese*, *wine*, *beer*.
+_Avoid_: Item, Product, Bottle (per-Kind words for the shared concept), Entry
+
+**Kind**:
+Which of cheese, wine or beer a Tasting subject is. A Kind is *data*, not code:
+it declares the fields its subjects and their Tastings have, the vocabularies
+those fields draw on, and whether a Tasting catalog ships for it. Adding a
+fourth Kind is an entry in that table plus its messages — not a new Module
+backend. The Kind is fixed by the address a page is at, so the Wines Module can
+never show a cheese.
+_Avoid_: Type, Category, Class
+
+**Tasting catalog**:
+The list of well-known subjects Gather ships for a Kind — the cheeses everybody
+has heard of. Catalog in the established sense: owned by nobody, read-only,
+reconciled by `seedKey`, present in every environment. A Kind may have none, and
+wine and beer deliberately have none: the set of wines is unbounded and every
+vintage differs.
+
+It is a **picker and not a store**. Nothing in a Group ever points at a catalog
+row: choosing one creates that Group's own Tasting subject, prefilled from it,
+which is thereafter ordinary Group content — editable, photographable, and the
+only thing every list and query sees (ADR-0024).
+
+Distinct from a Kind's **vocabularies** — the grape varieties, regions, styles
+and aroma descriptors its fields offer. Those ship too, but they are field
+options rather than subjects, and every Kind has them even when it has no
+catalog.
+_Avoid_: Presets, Templates, Library
+
 **Sample household**:
 A complete, fake Group — members, recipes, tasks, a baby's log, a food diary —
 that exists so a test or preview environment can be looked at. Never present in
@@ -213,6 +262,11 @@ _Avoid_: Signed out, Offline mode
 - A Module is configured by its content and never by a switch. Nothing turns a
   Module on, and what a Module needs configured belongs to one of its records —
   so an empty Module's invitation and its setup are the same screen (ADR-0022).
+- A Catalog entry is a fact or a suggestion, and which one decides whether
+  anything may point at it. A Food is a fact, so a diary entry references the
+  Catalog row and the row stays read-only forever. A **Tasting catalog** entry
+  is a suggestion, so nothing references it: tasting it makes a copy that is
+  yours, and the shipped row is never seen again (ADR-0024).
 - Every client names things the same way and looks however suits it. The words a
   person reads — a Group, a Pin, a Module and what it is for — are one answer
   wherever they are read; the palette, the type and the layout are each client's

--- a/docs/adr/0024-a-tasting-catalog-is-a-picker-and-tasting-it-makes-it-yours.md
+++ b/docs/adr/0024-a-tasting-catalog-is-a-picker-and-tasting-it-makes-it-yours.md
@@ -1,0 +1,86 @@
+# A Tasting catalog is a picker, and tasting it makes it yours
+
+Status: decided (2026-08-22), not yet implemented
+
+The tasting Modules — Cheeses, Wines, Beers — need somewhere for "Gouda" to come
+from. Gather already has an answer to that question, and it is the wrong one
+here.
+
+**Foods** ships a Catalog: read-only rows reconciled by `seedKey`, which the
+seed always wins over, and which every diary entry in every Group references
+directly ([ADR-0004](0004-catalog-entries-are-read-only-and-the-seed-always-wins.md)).
+Copying that shape for cheeses is the obvious move, and it fails on two things a
+Food never had to survive.
+
+**We chose the other shape. The Tasting catalog is a picker: choosing an entry
+creates that Group's own Tasting subject, prefilled from it, and nothing ever
+points at the shipped row again.** The catalog row's key is kept on the copy as
+**Provenance** — checked on read, safe to dangle — and nothing else.
+
+## Why a Food's shape does not fit
+
+**A Tasting subject accumulates a relationship; a Food does not.** A Food is a
+fact: a gram of Gouda has that much fat whatever anybody thinks, so a read-only
+row shared by everyone is exactly right. A Tasting subject is the thing your
+household has opinions about — the photo of the label, the note that you buy the
+48-month one, the six Tastings hanging off it. A read-only row can hold none of
+that. Under a reference model, the subjects people use *most* — the well-known
+ones — would be precisely the ones able to hold the least.
+
+**The seed deletes retired fixtures.** That is ADR-0004's contract and not an
+edge case. If `gouda` is later split into `gouda-young` and `gouda-aged`, every
+Tasting referencing the old row points at nothing. Provenance is allowed to
+dangle — the glossary says so — but the *subject of a Tasting is not
+provenance*. It is what you tasted, and a tasting history that has forgotten
+what it was of is broken in a way a dangling recipe link is not.
+
+**Corrections would rewrite history.** The upside of referencing is that a fix
+we ship reaches every Group. Applied here that means a deploy silently changing
+what somebody's 2026 tasting notes were about. That is a cost, not a feature.
+
+## What this buys
+
+One table, one ownership rule. Every list, search, sort, average and photo in
+the Module sees `tastingSubjects` rows belonging to the Group, full stop. The
+two-shaped problem — shipped things and your things — exists in exactly one
+place, the add flow, and nowhere else in the Module.
+
+It also costs nothing at rest: no row exists until a Group has actually tasted
+something, so a Group that never opens Cheeses stores nothing, which is the
+whole benefit a pure-reference model was offering.
+
+Materialising is idempotent, enforced on `(groupId, kind, catalogKey)`. Tasting
+Gouda a second time finds your Gouda; it never makes a second one. Hand-typed
+names get no such constraint — two different Barolos from two producers are two
+subjects with one short name — so the create flow warns rather than refuses.
+
+## What we are paying
+
+**A correction to a shipped entry never reaches a Group that already copied
+it.** A wrong milk type on Gouda is wrong in every household that tasted it
+before the fix. Accepted deliberately: the alternative is a deploy editing
+records people wrote.
+
+**Two catalogs now exist with opposite rules**, and a reader who knows Foods
+will guess wrong about cheeses. That is what the standing rule in `CONTEXT.md`
+is for: a Catalog entry is either a *fact* (referenced, read-only forever) or a
+*suggestion* (copied, then irrelevant), and which one it is has to be said out
+loud per catalog.
+
+## Where the catalog lives
+
+**In Convex, seeded, uncached** — not bundled into the client, which was the
+alternative considered. At the sizes involved (~40 cheeses; `catalogFoods.ts` is
+33 entries in 14KB) a bundle would be free and would need no seed apparatus at
+all. Convex was chosen anyway, to keep two doors open: a client-side cache can
+be added later without moving the data, and entries could one day be contributed
+by households rather than authored by us — which a bundle makes impossible.
+
+The price is the seed machinery ADR-0004 governs, and a
+`convex run seed:seedTastingCatalog` line beside the existing one in
+`deploy:dev` and `deploy:prod`.
+
+**Kind vocabularies are not part of this.** Grape varieties, regions, styles and
+aroma descriptors ship in `packages/core` alongside the Kind specs, because they
+are field options rather than subjects — every Kind has them, including the two
+with no catalog at all.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@
 | 0021 | Task backends expose capabilities and reconcile manually | accepted | tasks | `convex/taskLists.ts`, `convex/integrations.ts` |
 | 0022 | A Module is configured by its content, not by a switch | decided | mobile modules | `apps/mobile/src/modules/baby/` |
 | 0023 | Modules live inside the tab stacks | decided | mobile navigation | `apps/mobile/app/(app)/(tabs)/`, `apps/mobile/src/modules/` |
+| 0024 | A Tasting catalog is a picker, and tasting it makes it yours | decided | tasting | `convex/tastings.ts`, `packages/core/src/tastingKinds.ts` |


### PR DESCRIPTION
Docs-only. Records the design settled for the tasting Modules (Cheeses, Wines, Beers) before any code is written.

## CONTEXT.md

Four new glossary terms — **Tasting**, **Tasting subject**, **Kind**, **Tasting catalog** — plus:

- the **Catalog** entry widened to cover both catalogs;
- a standing rule stating that a Catalog entry is either a *fact* (referenced, read-only forever, as a Food is) or a *suggestion* (copied on first use, then irrelevant, as a shipped cheese is).

## ADR-0024 — A Tasting catalog is a picker, and tasting it makes it yours

The one decision here that is hard to reverse and surprising without context: the tasting catalog deliberately departs from how Foods treats Catalog. Choosing a shipped cheese creates the Group's own subject, prefilled, keeping the catalog key only as Provenance; nothing ever references the shipped row.

Reasons recorded: a Tasting subject accumulates a relationship (photo, notes, tastings) that a read-only row cannot hold; ADR-0004's seed deletes retired fixtures, which would orphan the *subject of a tasting* rather than mere provenance; and propagating corrections would mean a deploy rewriting what somebody's notes were about. Costs are stated too — corrections never reach Groups that already copied, and two catalogs now exist with opposite rules.

Also records that the catalog lives in Convex rather than bundled, chosen to keep a later cache and possible household-contributed entries open, and that Kind vocabularies (grapes, regions, styles, aroma tags) ship in `packages/core` instead.

## Decisions captured here that the ADR does not repeat

Item + Tasting; one Module per kind over one shared backend; a single table pair with a `kind` discriminator and typed field specs (`text`/`number`/`scale`/`select`/`tags`) in `packages/core`; Group-scoped with Attribution on the Tasting; one 1–5 scale across kinds; `recipePhoto` reused on the subject; no Share/Move; the Tasting testifies to the activity stream; averages computed on read; web first, mobile later.

No code changes, so nothing to verify beyond the docs themselves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bo34RgYhcxaHzeLqENvpnE)_